### PR TITLE
linux(state+main): move eager probe refresh orchestration out of state (#3)

### DIFF
--- a/apps/linux/src/main.c
+++ b/apps/linux/src/main.c
@@ -21,8 +21,15 @@ extern void systemd_refresh(void);
 extern void health_init(void);
 extern void health_probe_gateway(void);
 extern void health_run_deep_probe(void);
+extern void health_probe_gateway_eager(void);
+extern void health_run_deep_probe_eager(void);
 extern void state_init(void);
 extern void notify_init(void);
+
+void state_on_probe_refresh_requested(void) {
+    health_probe_gateway_eager();
+    health_run_deep_probe_eager();
+}
 
 static gboolean on_status_poll(gpointer user_data) {
     (void)user_data;

--- a/apps/linux/src/state.c
+++ b/apps/linux/src/state.c
@@ -14,9 +14,6 @@
 #include <glib.h>
 #include "state.h"
 
-extern void health_probe_gateway_eager(void);
-extern void health_run_deep_probe_eager(void);
-
 static AppState current_state = STATE_NOT_INSTALLED;
 static SystemdState current_sys_state = {0};
 static HealthState current_health_state = {0};
@@ -94,15 +91,9 @@ static void trigger_updates(AppState new_state) {
     tray_update_from_state(current_state);
 }
 
-static gboolean idle_trigger_health_probe(gpointer user_data) {
+static gboolean idle_request_probe_refresh(gpointer user_data) {
     (void)user_data;
-    health_probe_gateway_eager();
-    return G_SOURCE_REMOVE;
-}
-
-static gboolean idle_trigger_deep_probe(gpointer user_data) {
-    (void)user_data;
-    health_run_deep_probe_eager();
+    state_on_probe_refresh_requested();
     return G_SOURCE_REMOVE;
 }
 
@@ -161,8 +152,7 @@ void state_update_systemd(const SystemdState *sys_state) {
         // activation, or unit retargeting) to avoid leaving the UI in a stale or generic 
         // "Running" state until the next periodic timer fires.
         // Defer probes asynchronously to keep state mutation fast and decoupled
-        g_idle_add(idle_trigger_health_probe, NULL);
-        g_idle_add(idle_trigger_deep_probe, NULL);
+        g_idle_add(idle_request_probe_refresh, NULL);
     }
     
     trigger_updates(new_state);

--- a/apps/linux/src/state.h
+++ b/apps/linux/src/state.h
@@ -91,3 +91,4 @@ const gchar* systemd_get_canonical_unit_name(void);
 // Callbacks (implemented elsewhere)
 void notify_on_transition(AppState old_state, AppState new_state);
 void tray_update_from_state(AppState state);
+void state_on_probe_refresh_requested(void);


### PR DESCRIPTION
Remove direct eager health/deep-probe calls from the state layer and replace them with a neutral `state_on_probe_refresh_requested()` callback.

`state.c` now detects freshness-boundary transitions and defers a single refresh request through GLib idle scheduling, while `main.c` owns the actual execution of eager health and deep probes. This preserves the existing hydration/activation/unit-retarget probe behavior while restoring a cleaner dependency direction between passive state management and active probe orchestration.

Closes #3 