### PR TITLE
linux(tests): add local Meson coverage for state, systemd helpers, and probe parsing (#5)

### DIFF
--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -55,6 +55,11 @@ meson setup build
 meson compile -C build
 ```
 
+## Testing
+```bash
+meson test -C build
+```
+
 ## Running (Development)
 ```bash
 ./build/openclaw-linux

--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -19,6 +19,7 @@ gtk3_dep = dependency('gtk+-3.0')
 json_glib_dep = dependency('json-glib-1.0')
 gio_dep = dependency('gio-2.0')
 gio_unix_dep = dependency('gio-unix-2.0')
+glib_dep = dependency('glib-2.0')
 
 # Define LIBEXEC_PATH for the C compiler so tray.c knows where the installed helper lives
 libexec_path = get_option('prefix') / get_option('libexecdir') / meson.project_name()
@@ -54,3 +55,19 @@ executable('openclaw-tray-helper',
 
 install_data('ai.openclaw.Companion.desktop',
   install_dir : get_option('datadir') / 'applications')
+
+# Local Tests
+test_state_exe = executable('test_state',
+  ['tests/test_state.c', 'src/state.c'],
+  dependencies : [glib_dep, gio_dep])
+test('state', test_state_exe)
+
+test_systemd_exe = executable('test_systemd_helpers',
+  ['tests/test_systemd_helpers.c', 'src/systemd.c'],
+  dependencies : [glib_dep, gio_dep, gio_unix_dep])
+test('systemd_helpers', test_systemd_exe)
+
+test_health_exe = executable('test_health_parse',
+  ['tests/test_health_parse.c', 'src/health.c'],
+  dependencies : [glib_dep, gio_dep, json_glib_dep])
+test('health_parse', test_health_exe)

--- a/apps/linux/src/health.c
+++ b/apps/linux/src/health.c
@@ -30,6 +30,42 @@ void health_init(void) {
     pending_deep_probe = FALSE;
 }
 
+void health_parse_probe_stdout(const gchar *stdout_buf, ProbeState *ps) {
+    if (!ps) return;
+    if (stdout_buf) {
+        gchar **lines = g_strsplit(stdout_buf, "\n", -1);
+        for (gint i = 0; lines[i] != NULL; i++) {
+            gchar *line = lines[i];
+            if (strstr(line, "Connect:")) {
+                if (strstr(line, "Connect: ok")) {
+                    ps->connect_ok = TRUE;
+                    ps->reachable = TRUE;
+                }
+            }
+            if (strstr(line, "RPC: ok")) {
+                ps->rpc_ok = TRUE;
+            }
+            if (strstr(line, "timeout") || strstr(line, "timed out")) {
+                ps->timed_out = TRUE;
+            }
+        }
+        g_strfreev(lines);
+        
+        // Synthesize summary strings based on the combination of connectivity booleans
+        if (ps->reachable && ps->rpc_ok) {
+            ps->summary = g_strdup("Fully reachable");
+        } else if (ps->connect_ok && ps->timed_out) {
+            ps->summary = g_strdup("Connect OK, but RPC timed out");
+        } else if (!ps->reachable) {
+            ps->summary = g_strdup("Not reachable");
+        } else {
+            ps->summary = g_strdup("Unknown or mixed probe result");
+        }
+    } else {
+        ps->summary = g_strdup("No output from probe");
+    }
+}
+
 static gchar** resolve_openclaw_argv(const gchar *subcommand) {
     // Deterministic 4-tier executable resolution strategy:
     // Priority 1: Use systemd's ExecStart parsing if available (most reliable, matches what daemon runs)
@@ -422,40 +458,7 @@ static void on_deep_probe_finished(GObject *source_object, GAsyncResult *res, gp
         goto check_pending;
     }
     
-    if (stdout_buf) {
-        // Plaintext parsing is intentionally conservative/simple because
-        // probe output is human-oriented, so parsing is heuristic but bounded.
-        gchar **lines = g_strsplit(stdout_buf, "\n", -1);
-        for (gint i = 0; lines[i] != NULL; i++) {
-            gchar *line = lines[i];
-            if (strstr(line, "Connect:")) {
-                if (strstr(line, "Connect: ok")) {
-                    ps.connect_ok = TRUE;
-                    ps.reachable = TRUE;
-                }
-                if (strstr(line, "RPC: ok")) {
-                    ps.rpc_ok = TRUE;
-                }
-            }
-            if (strstr(line, "timeout") || strstr(line, "timed out")) {
-                ps.timed_out = TRUE;
-            }
-        }
-        g_strfreev(lines);
-        
-        // Synthesize summary strings based on the combination of connectivity booleans
-        if (ps.reachable && ps.rpc_ok) {
-            ps.summary = g_strdup("Fully reachable");
-        } else if (ps.connect_ok && ps.timed_out) {
-            ps.summary = g_strdup("Connect OK, but RPC timed out");
-        } else if (!ps.reachable) {
-            ps.summary = g_strdup("Not reachable");
-        } else {
-            ps.summary = g_strdup("Unknown or mixed probe result");
-        }
-    } else {
-        ps.summary = g_strdup("No output from probe");
-    }
+    health_parse_probe_stdout(stdout_buf, &ps);
     
     state_update_probe(&ps);
     

--- a/apps/linux/src/systemd.c
+++ b/apps/linux/src/systemd.c
@@ -31,7 +31,7 @@ static guint properties_changed_signal_id = 0;
 static void fetch_unit_properties(void);
 extern void systemd_refresh(void);
 
-static gboolean is_gateway_unit(const gchar *filename, const gchar *contents) {
+gboolean systemd_is_gateway_unit(const gchar *filename, const gchar *contents) {
     if (!contents) return FALSE;
     
     // Must be a gateway (explicit kind marker or legacy/default filename pattern)
@@ -61,7 +61,7 @@ static gboolean check_system_scope_units(void) {
                 g_autofree gchar *filepath = g_build_filename(paths[i], filename, NULL);
                 gchar *contents = NULL;
                 if (g_file_get_contents(filepath, &contents, NULL, NULL)) {
-                    if (is_gateway_unit(filename, contents)) {
+                    if (systemd_is_gateway_unit(filename, contents)) {
                         g_free(contents);
                         g_dir_close(dir);
                         return TRUE;
@@ -125,6 +125,35 @@ static void get_unit_preference_score(const gchar *unit_name, gboolean *is_activ
     }
 }
 
+gchar* systemd_normalize_unit_override(const gchar *raw_unit) {
+    if (!raw_unit) return NULL;
+    gchar *trimmed = g_strstrip(g_strdup(raw_unit));
+    if (strlen(trimmed) > 0) {
+        if (g_str_has_suffix(trimmed, ".service")) {
+            return trimmed;
+        } else {
+            gchar *res = g_strdup_printf("%s.service", trimmed);
+            g_free(trimmed);
+            return res;
+        }
+    }
+    g_free(trimmed);
+    return NULL;
+}
+
+gchar* systemd_normalize_profile(const gchar *raw_profile) {
+    if (!raw_profile) return NULL;
+    gchar *trimmed = g_strstrip(g_strdup(raw_profile));
+    gchar *res = NULL;
+    if (strlen(trimmed) == 0 || g_strcmp0(trimmed, "default") == 0) {
+        res = g_strdup("openclaw-gateway.service");
+    } else {
+        res = g_strdup_printf("openclaw-gateway-%s.service", trimmed);
+    }
+    g_free(trimmed);
+    return res;
+}
+
 static const gchar* discover_canonical_unit_name(void) {
     if (cached_unit_name) return cached_unit_name;
 
@@ -151,7 +180,7 @@ static const gchar* discover_canonical_unit_name(void) {
         g_autofree gchar *filepath = g_build_filename(systemd_user_dir, filename, NULL);
         gchar *contents = NULL;
         if (g_file_get_contents(filepath, &contents, NULL, NULL)) {
-            if (is_gateway_unit(filename, contents)) {
+            if (systemd_is_gateway_unit(filename, contents)) {
                 g_ptr_array_add(marked_units, g_strdup(filename));
             }
             g_free(contents);
@@ -174,28 +203,10 @@ static const gchar* discover_canonical_unit_name(void) {
         const gchar *raw_unit = g_getenv("OPENCLAW_SYSTEMD_UNIT");
         const gchar *raw_profile = g_getenv("OPENCLAW_PROFILE");
         
-        if (raw_unit) {
-            gchar *trimmed = g_strstrip(g_strdup(raw_unit));
-            if (strlen(trimmed) > 0) {
-                if (g_str_has_suffix(trimmed, ".service")) {
-                    env_override = trimmed;
-                } else {
-                    env_override = g_strdup_printf("%s.service", trimmed);
-                    g_free(trimmed);
-                }
-            } else {
-                g_free(trimmed);
-            }
-        }
+        env_override = systemd_normalize_unit_override(raw_unit);
         
         if (!env_override && raw_profile) {
-            gchar *trimmed = g_strstrip(g_strdup(raw_profile));
-            if (strlen(trimmed) == 0 || g_strcmp0(trimmed, "default") == 0) {
-                env_override = g_strdup("openclaw-gateway.service");
-            } else {
-                env_override = g_strdup_printf("openclaw-gateway-%s.service", trimmed);
-            }
-            g_free(trimmed);
+            env_override = systemd_normalize_profile(raw_profile);
         }
         
         if (env_override) {

--- a/apps/linux/tests/test_health_parse.c
+++ b/apps/linux/tests/test_health_parse.c
@@ -1,0 +1,112 @@
+#include <glib.h>
+#include "../src/state.h"
+
+extern void health_parse_probe_stdout(const gchar *stdout_buf, ProbeState *ps);
+
+static void test_single_target_success(void) {
+    ProbeState ps = {0};
+    health_parse_probe_stdout("Connect: ok\nRPC: ok\n", &ps);
+    g_assert_true(ps.reachable);
+    g_assert_true(ps.connect_ok);
+    g_assert_true(ps.rpc_ok);
+    g_assert_cmpstr(ps.summary, ==, "Fully reachable");
+    g_free(ps.summary);
+}
+
+static void test_single_target_connect_success_no_rpc(void) {
+    ProbeState ps = {0};
+    health_parse_probe_stdout("Connect: ok\nRPC: failed\n", &ps);
+    g_assert_true(ps.reachable);
+    g_assert_true(ps.connect_ok);
+    g_assert_false(ps.rpc_ok);
+    g_assert_cmpstr(ps.summary, !=, "Fully reachable");
+    g_free(ps.summary);
+}
+
+static void test_single_target_failure(void) {
+    ProbeState ps = {0};
+    health_parse_probe_stdout("Connect: failed\n", &ps);
+    g_assert_false(ps.reachable);
+    g_assert_false(ps.connect_ok);
+    g_assert_false(ps.rpc_ok);
+    g_assert_cmpstr(ps.summary, ==, "Not reachable");
+    g_free(ps.summary);
+}
+
+static void test_multi_target_mixed_output(void) {
+    ProbeState ps = {0};
+    health_parse_probe_stdout("Target 1:\nConnect: failed\nTarget 2:\nConnect: ok\nRPC: ok\n", &ps);
+    g_assert_true(ps.reachable);
+    g_assert_true(ps.connect_ok);
+    g_assert_true(ps.rpc_ok);
+    g_free(ps.summary);
+}
+
+static void test_timeout_detection(void) {
+    ProbeState ps1 = {0};
+    health_parse_probe_stdout("Connect: ok\nRPC: timeout\n", &ps1);
+    g_assert_true(ps1.timed_out);
+    g_assert_true(ps1.connect_ok);
+    g_assert_cmpstr(ps1.summary, ==, "Connect OK, but RPC timed out");
+    g_free(ps1.summary);
+    
+    ProbeState ps2 = {0};
+    health_parse_probe_stdout("Connect: timed out\n", &ps2);
+    g_assert_true(ps2.timed_out);
+    g_free(ps2.summary);
+}
+
+static void test_ignoring_unrelated_lines(void) {
+    ProbeState ps = {0};
+    health_parse_probe_stdout("Starting probe...\nHere is some explanatory text\nConnect: ok\nRPC: ok\nDone.\n", &ps);
+    g_assert_true(ps.reachable);
+    g_assert_true(ps.connect_ok);
+    g_assert_true(ps.rpc_ok);
+    g_free(ps.summary);
+}
+
+static void test_no_summary_lines_safety(void) {
+    ProbeState ps1 = {0};
+    health_parse_probe_stdout("", &ps1);
+    g_assert_false(ps1.reachable);
+    g_assert_false(ps1.connect_ok);
+    g_assert_false(ps1.rpc_ok);
+    g_assert_false(ps1.timed_out);
+    g_assert_cmpstr(ps1.summary, ==, "Not reachable");
+    g_free(ps1.summary);
+
+    ProbeState ps2 = {0};
+    health_parse_probe_stdout(NULL, &ps2);
+    g_assert_false(ps2.reachable);
+    g_assert_false(ps2.connect_ok);
+    g_assert_false(ps2.rpc_ok);
+    g_assert_false(ps2.timed_out);
+    g_assert_cmpstr(ps2.summary, ==, "No output from probe");
+    g_free(ps2.summary);
+}
+
+// Dummy stubs for linking with health.c
+void state_update_health(const HealthState *health_state) { (void)health_state; }
+void state_set_health_in_flight(gboolean in_flight) { (void)in_flight; }
+void state_set_probe_in_flight(gboolean in_flight) { (void)in_flight; }
+void state_update_probe(const ProbeState *probe_state) { (void)probe_state; }
+AppState state_get_current(void) { return STATE_NOT_INSTALLED; }
+guint64 state_get_health_generation(void) { return 0; }
+SystemdState* state_get_systemd(void) { return NULL; }
+HealthState* state_get_health(void) { return NULL; }
+ProbeState* state_get_probe(void) { return NULL; }
+const gchar* systemd_get_canonical_unit_name(void) { return NULL; }
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    
+    g_test_add_func("/health_parse/single_target_success", test_single_target_success);
+    g_test_add_func("/health_parse/single_target_connect_success_no_rpc", test_single_target_connect_success_no_rpc);
+    g_test_add_func("/health_parse/single_target_failure", test_single_target_failure);
+    g_test_add_func("/health_parse/multi_target_mixed_output", test_multi_target_mixed_output);
+    g_test_add_func("/health_parse/timeout_detection", test_timeout_detection);
+    g_test_add_func("/health_parse/ignoring_unrelated_lines", test_ignoring_unrelated_lines);
+    g_test_add_func("/health_parse/no_summary_lines_safety", test_no_summary_lines_safety);
+    
+    return g_test_run();
+}

--- a/apps/linux/tests/test_state.c
+++ b/apps/linux/tests/test_state.c
@@ -1,0 +1,210 @@
+#include <glib.h>
+#include "../src/state.h"
+
+// Stubs for callbacks
+void notify_on_transition(AppState old_state, AppState new_state) {
+    (void)old_state;
+    (void)new_state;
+}
+void tray_update_from_state(AppState state) {
+    (void)state;
+}
+void state_on_probe_refresh_requested(void) {}
+
+static void test_initial_state(void) {
+    state_init();
+    g_assert_cmpint(state_get_current(), ==, STATE_NOT_INSTALLED);
+}
+
+static void test_installed_inactive(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = FALSE;
+    state_update_systemd(&sys);
+    g_assert_cmpint(state_get_current(), ==, STATE_STOPPED);
+}
+
+static void test_active_without_fresh_health(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+}
+
+static void test_warning_health(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+    
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.loaded = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.health_healthy = TRUE;
+    hs.config_audit_ok = FALSE;
+    hs.config_issues_count = 1;
+    state_update_health(&hs);
+    
+    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING_WITH_WARNING);
+}
+
+static void test_degraded_health(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+    
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.loaded = TRUE;
+    hs.rpc_ok = FALSE; // Degraded
+    hs.health_healthy = FALSE;
+    state_update_health(&hs);
+    
+    g_assert_cmpint(state_get_current(), ==, STATE_DEGRADED);
+}
+
+static void test_entering_probe_disabled_clears_freshness(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+    
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.loaded = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.health_healthy = TRUE;
+    state_update_health(&hs);
+    
+    ProbeState ps = {0};
+    ps.last_updated = 12345;
+    ps.summary = g_strdup("Fully reachable");
+    state_update_probe(&ps);
+    g_free(ps.summary);
+    
+    // Transition to stopped
+    sys.active = FALSE;
+    state_update_systemd(&sys);
+    
+    g_assert_cmpint(state_get_health()->last_updated, ==, 0);
+    g_assert_cmpint(state_get_probe()->last_updated, ==, 0);
+    g_assert_null(state_get_probe()->summary);
+}
+
+static void test_activation_boundary_prevents_stale_inheritance(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+    
+    // Seed old degraded health
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.loaded = TRUE;
+    hs.rpc_ok = FALSE;
+    hs.health_healthy = FALSE;
+    state_update_health(&hs);
+    g_assert_cmpint(state_get_current(), ==, STATE_DEGRADED);
+    
+    // Stop it
+    sys.active = FALSE;
+    state_update_systemd(&sys);
+    g_assert_cmpint(state_get_current(), ==, STATE_STOPPED);
+    
+    // Start it again
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+    
+    // Should NOT inherit the degraded state before fresh health arrives
+    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+}
+
+static void test_unit_retarget_bumps_generation(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    sys.unit_name = "unitA.service";
+    state_update_systemd(&sys);
+    
+    guint64 gen1 = state_get_health_generation();
+    
+    sys.unit_name = "unitB.service";
+    state_update_systemd(&sys);
+    
+    guint64 gen2 = state_get_health_generation();
+    g_assert_cmpuint(gen2, >, gen1);
+}
+
+static void test_probe_disabled_transition_bumps_generation(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+    
+    guint64 gen1 = state_get_health_generation();
+    
+    sys.active = FALSE;
+    state_update_systemd(&sys);
+    
+    guint64 gen2 = state_get_health_generation();
+    g_assert_cmpuint(gen2, >, gen1);
+}
+
+static void test_restart_clears_payload_fields(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+    
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.loaded = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.health_healthy = TRUE;
+    hs.bind_host = g_strdup("127.0.0.1");
+    hs.probe_url = g_strdup("http://localhost");
+    state_update_health(&hs);
+    
+    // Restart (stop then start)
+    sys.active = FALSE;
+    state_update_systemd(&sys);
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+    
+    g_assert_cmpint(state_get_health()->rpc_ok, ==, FALSE);
+    g_assert_cmpint(state_get_health()->health_healthy, ==, FALSE);
+    g_assert_null(state_get_health()->bind_host);
+    g_assert_null(state_get_health()->probe_url);
+    
+    g_free(hs.bind_host);
+    g_free(hs.probe_url);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    
+    g_test_add_func("/state/initial_state", test_initial_state);
+    g_test_add_func("/state/installed_inactive", test_installed_inactive);
+    g_test_add_func("/state/active_without_fresh_health", test_active_without_fresh_health);
+    g_test_add_func("/state/warning_health", test_warning_health);
+    g_test_add_func("/state/degraded_health", test_degraded_health);
+    g_test_add_func("/state/entering_probe_disabled_clears_freshness", test_entering_probe_disabled_clears_freshness);
+    g_test_add_func("/state/activation_boundary_prevents_stale_inheritance", test_activation_boundary_prevents_stale_inheritance);
+    g_test_add_func("/state/unit_retarget_bumps_generation", test_unit_retarget_bumps_generation);
+    g_test_add_func("/state/probe_disabled_transition_bumps_generation", test_probe_disabled_transition_bumps_generation);
+    g_test_add_func("/state/restart_clears_payload_fields", test_restart_clears_payload_fields);
+    
+    return g_test_run();
+}

--- a/apps/linux/tests/test_systemd_helpers.c
+++ b/apps/linux/tests/test_systemd_helpers.c
@@ -1,0 +1,93 @@
+#include <glib.h>
+#include "../src/state.h"
+
+extern gboolean systemd_is_gateway_unit(const gchar *filename, const gchar *contents);
+extern gchar* systemd_normalize_unit_override(const gchar *raw_unit);
+extern gchar* systemd_normalize_profile(const gchar *raw_profile);
+
+static void test_gateway_filename_acceptance(void) {
+    g_assert_true(systemd_is_gateway_unit("openclaw-gateway.service", ""));
+}
+
+static void test_profiled_gateway_filename_acceptance(void) {
+    g_assert_true(systemd_is_gateway_unit("openclaw-gateway-work.service", ""));
+}
+
+static void test_legacy_gateway_filename_acceptance(void) {
+    g_assert_true(systemd_is_gateway_unit("clawdbot-gateway.service", ""));
+    g_assert_true(systemd_is_gateway_unit("moltbot-gateway.service", ""));
+}
+
+static void test_node_filename_rejection(void) {
+    g_assert_false(systemd_is_gateway_unit("openclaw-node.service", ""));
+}
+
+static void test_manual_filename_only_without_marker(void) {
+    g_assert_true(systemd_is_gateway_unit("openclaw-gateway.service", "[Service]\nExecStart=/usr/bin/openclaw"));
+}
+
+static void test_kind_marker_accepts_gateway(void) {
+    g_assert_true(systemd_is_gateway_unit("some-custom-name.service", "OPENCLAW_SERVICE_KIND=gateway"));
+}
+
+static void test_normalize_explicit_unit_override_without_suffix(void) {
+    gchar *res = systemd_normalize_unit_override("my-unit");
+    g_assert_cmpstr(res, ==, "my-unit.service");
+    g_free(res);
+}
+
+static void test_normalize_explicit_unit_override_with_suffix(void) {
+    gchar *res = systemd_normalize_unit_override("my-unit.service");
+    g_assert_cmpstr(res, ==, "my-unit.service");
+    g_free(res);
+}
+
+static void test_normalize_trim_whitespace_in_explicit_override(void) {
+    gchar *res = systemd_normalize_unit_override("  my-unit  ");
+    g_assert_cmpstr(res, ==, "my-unit.service");
+    g_free(res);
+}
+
+static void test_normalize_default_profile(void) {
+    gchar *res = systemd_normalize_profile("default");
+    g_assert_cmpstr(res, ==, "openclaw-gateway.service");
+    g_free(res);
+}
+
+static void test_normalize_empty_whitespace_profile(void) {
+    gchar *res1 = systemd_normalize_profile("");
+    g_assert_cmpstr(res1, ==, "openclaw-gateway.service");
+    g_free(res1);
+
+    gchar *res2 = systemd_normalize_profile("   ");
+    g_assert_cmpstr(res2, ==, "openclaw-gateway.service");
+    g_free(res2);
+}
+
+static void test_normalize_named_profile(void) {
+    gchar *res = systemd_normalize_profile("work");
+    g_assert_cmpstr(res, ==, "openclaw-gateway-work.service");
+    g_free(res);
+}
+
+// Dummy stubs for linking with systemd.c
+void state_update_systemd(const SystemdState *sys_state) { (void)sys_state; }
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    
+    g_test_add_func("/systemd/gateway_filename_acceptance", test_gateway_filename_acceptance);
+    g_test_add_func("/systemd/profiled_gateway_filename_acceptance", test_profiled_gateway_filename_acceptance);
+    g_test_add_func("/systemd/legacy_gateway_filename_acceptance", test_legacy_gateway_filename_acceptance);
+    g_test_add_func("/systemd/node_filename_rejection", test_node_filename_rejection);
+    g_test_add_func("/systemd/manual_filename_only_without_marker", test_manual_filename_only_without_marker);
+    g_test_add_func("/systemd/kind_marker_accepts_gateway", test_kind_marker_accepts_gateway);
+    g_test_add_func("/systemd/normalize_explicit_unit_override_without_suffix", test_normalize_explicit_unit_override_without_suffix);
+    g_test_add_func("/systemd/normalize_explicit_unit_override_with_suffix", test_normalize_explicit_unit_override_with_suffix);
+    g_test_add_func("/systemd/normalize_trim_whitespace_in_explicit_override", test_normalize_trim_whitespace_in_explicit_override);
+    g_test_add_func("/systemd/normalize_default_profile", test_normalize_default_profile);
+    g_test_add_func("/systemd/normalize_empty_whitespace_profile", test_normalize_empty_whitespace_profile);
+    g_test_add_func("/systemd/normalize_named_profile", test_normalize_named_profile);
+    
+    return g_test_run();
+}


### PR DESCRIPTION
Add GLib/Meson unit tests for the Linux companion's highest-risk logic: state normalization and freshness boundaries, systemd unit classification/override normalization, and deep-probe stdout parsing.

This patch also extracts small pure helper seams from production code so the tests can run hermetically without GTK, D-Bus, or subprocess integration. No GitHub Actions integration is included yet.

Close #5 