### PR TITLE
fix+feat(linux): fix g_autoptr/goto crash and add structured logging (#9)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -35,7 +35,8 @@ sources = [
   'src/health_helpers.c',
   'src/state.c',
   'src/notify.c',
-  'src/diagnostics.c'
+  'src/diagnostics.c',
+  'src/log.c'
 ]
 
 executable('openclaw-linux',
@@ -60,7 +61,7 @@ install_data('ai.openclaw.Companion.desktop',
 
 # Local Tests
 test_state_exe = executable('test_state',
-  ['tests/test_state.c', 'src/state.c'],
+  ['tests/test_state.c', 'src/state.c', 'src/log.c'],
   dependencies : [glib_dep, gio_dep])
 test('state', test_state_exe)
 

--- a/apps/linux/src/health.c
+++ b/apps/linux/src/health.c
@@ -238,6 +238,10 @@ static void on_health_probe_finished(GObject *source_object, GAsyncResult *res, 
     
     GSubprocess *subprocess = G_SUBPROCESS(source_object);
     g_autoptr(GError) error = NULL;
+    // Declared before any goto to prevent __attribute__((cleanup)) from
+    // firing on an uninitialized garbage pointer when goto jumps past
+    // the assignment.  Initialized to NULL so cleanup is a safe no-op.
+    g_autoptr(JsonParser) parser = NULL;
     gchar *stdout_buf = NULL;
     gchar *stderr_buf = NULL;
     
@@ -260,7 +264,7 @@ static void on_health_probe_finished(GObject *source_object, GAsyncResult *res, 
         goto check_pending;
     }
     
-    g_autoptr(JsonParser) parser = json_parser_new();
+    parser = json_parser_new();
     if (!json_parser_load_from_data(parser, stdout_buf, -1, &error)) {
         HealthState hs = {0};
         hs.last_updated = g_get_real_time();

--- a/apps/linux/src/log.c
+++ b/apps/linux/src/log.c
@@ -1,0 +1,133 @@
+/*
+ * log.c
+ *
+ * Implementation of the runtime-configurable logging layer.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "log.h"
+#include <stdarg.h>
+#include <string.h>
+
+static OpenClawLogLevel current_level = OPENCLAW_LOG_WARN; // Default to WARN (quiet execution)
+static guint current_categories = OPENCLAW_LOG_CAT_ALL;
+
+static gboolean has_multiple_bits(guint mask) {
+    return mask && (mask & (mask - 1));
+}
+
+void openclaw_log_init(void) {
+    // Default to a quiet execution (ERROR and WARN)
+    current_level = OPENCLAW_LOG_WARN;
+
+    const gchar *env_level = g_getenv("OPENCLAW_LINUX_LOG");
+    if (env_level) {
+        if (g_ascii_strcasecmp(env_level, "trace") == 0) {
+            current_level = OPENCLAW_LOG_TRACE;
+        } else if (g_ascii_strcasecmp(env_level, "debug") == 0) {
+            current_level = OPENCLAW_LOG_DEBUG;
+        } else if (g_ascii_strcasecmp(env_level, "info") == 0) {
+            current_level = OPENCLAW_LOG_INFO;
+        } else if (g_ascii_strcasecmp(env_level, "warn") == 0) {
+            current_level = OPENCLAW_LOG_WARN;
+        } else if (g_ascii_strcasecmp(env_level, "error") == 0) {
+            current_level = OPENCLAW_LOG_ERROR;
+        }
+    }
+
+    const gchar *env_cats = g_getenv("OPENCLAW_LINUX_LOG_CATEGORIES");
+    if (env_cats && *env_cats != '\0') {
+        current_categories = 0;
+        gchar **cats = g_strsplit(env_cats, ",", -1);
+        for (gint i = 0; cats[i] != NULL; i++) {
+            gchar *cat = g_strstrip(cats[i]);
+            if (g_ascii_strcasecmp(cat, "systemd") == 0) {
+                current_categories |= OPENCLAW_LOG_CAT_SYSTEMD;
+            } else if (g_ascii_strcasecmp(cat, "tray") == 0) {
+                current_categories |= OPENCLAW_LOG_CAT_TRAY;
+            } else if (g_ascii_strcasecmp(cat, "state") == 0) {
+                current_categories |= OPENCLAW_LOG_CAT_STATE;
+            } else if (g_ascii_strcasecmp(cat, "notify") == 0) {
+                current_categories |= OPENCLAW_LOG_CAT_NOTIFY;
+            } else if (g_ascii_strcasecmp(cat, "health") == 0) {
+                current_categories |= OPENCLAW_LOG_CAT_HEALTH;
+            }
+        }
+        g_strfreev(cats);
+        // If they provided a totally bogus string, fall back to ALL
+        if (current_categories == 0) {
+            current_categories = OPENCLAW_LOG_CAT_ALL;
+        }
+    } else {
+        // If OPENCLAW_LINUX_LOG_CATEGORIES is unset, all categories are enabled subject to the selected level.
+        current_categories = OPENCLAW_LOG_CAT_ALL;
+    }
+}
+
+gboolean openclaw_log_enabled(OpenClawLogLevel level, guint category_mask) {
+    if (level > current_level) {
+        return FALSE;
+    }
+    if ((category_mask & current_categories) == 0) {
+        return FALSE;
+    }
+    return TRUE;
+}
+
+void openclaw_log_write(OpenClawLogLevel level, guint category_mask, const char *file, int line, const char *func, const char *fmt, ...) {
+
+    const char *level_str = "UNKNOWN";
+    switch (level) {
+        case OPENCLAW_LOG_ERROR: level_str = "ERROR"; break;
+        case OPENCLAW_LOG_WARN:  level_str = "WARN "; break;
+        case OPENCLAW_LOG_INFO:  level_str = "INFO "; break;
+        case OPENCLAW_LOG_DEBUG: level_str = "DEBUG"; break;
+        case OPENCLAW_LOG_TRACE: level_str = "TRACE"; break;
+    }
+
+    const char *cat_str = "UNKN";
+    // Defensive: handle multiple category bits by showing MULTI
+    if (has_multiple_bits(category_mask)) {
+        cat_str = "MULTI";
+    } else if (category_mask & OPENCLAW_LOG_CAT_SYSTEMD) {
+        cat_str = "SYSD";
+    } else if (category_mask & OPENCLAW_LOG_CAT_TRAY) {
+        cat_str = "TRAY";
+    } else if (category_mask & OPENCLAW_LOG_CAT_STATE) {
+        cat_str = "STAT";
+    } else if (category_mask & OPENCLAW_LOG_CAT_NOTIFY) {
+        cat_str = "NOTI";
+    } else if (category_mask & OPENCLAW_LOG_CAT_HEALTH) {
+        cat_str = "HLTH";
+    }
+
+    // Extract filename from path for terser logging
+    const char *short_file = strrchr(file, '/');
+    if (short_file) short_file++;
+    else short_file = file;
+
+    g_autofree gchar *msg = NULL;
+    va_list args;
+    va_start(args, fmt);
+    msg = g_strdup_vprintf(fmt, args);
+    va_end(args);
+
+    switch (level) {
+        case OPENCLAW_LOG_ERROR:
+            // Route ERROR through g_warning() for safety - avoids process abort under G_DEBUG=fatal-criticals
+            // ERROR is reserved for serious but recoverable conditions (e.g., helper spawn failure)
+            g_warning("[OC:%s][%s] %s:%d %s() %s", level_str, cat_str, short_file, line, func, msg);
+            break;
+        case OPENCLAW_LOG_WARN:
+            // WARN is for recoverable issues that don't prevent normal operation
+            g_warning("[OC:%s][%s] %s:%d %s() %s", level_str, cat_str, short_file, line, func, msg);
+            break;
+        case OPENCLAW_LOG_INFO:
+        case OPENCLAW_LOG_DEBUG:
+        case OPENCLAW_LOG_TRACE:
+        default:
+            g_message("[OC:%s][%s] %s:%d %s() %s", level_str, cat_str, short_file, line, func, msg);
+            break;
+    }
+}

--- a/apps/linux/src/log.h
+++ b/apps/linux/src/log.h
@@ -1,0 +1,53 @@
+/*
+ * log.h
+ *
+ * Centralized, runtime-configurable logging layer for the Linux Companion App.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LOG_H
+#define OPENCLAW_LOG_H
+
+#include <glib.h>
+
+typedef enum {
+    OPENCLAW_LOG_ERROR = 0,
+    OPENCLAW_LOG_WARN,
+    OPENCLAW_LOG_INFO,
+    OPENCLAW_LOG_DEBUG,
+    OPENCLAW_LOG_TRACE,
+} OpenClawLogLevel;
+
+typedef enum {
+    OPENCLAW_LOG_CAT_SYSTEMD = 1 << 0,
+    OPENCLAW_LOG_CAT_TRAY    = 1 << 1,
+    OPENCLAW_LOG_CAT_STATE   = 1 << 2,
+    OPENCLAW_LOG_CAT_NOTIFY  = 1 << 3,
+    OPENCLAW_LOG_CAT_HEALTH  = 1 << 4,
+    OPENCLAW_LOG_CAT_ALL     = OPENCLAW_LOG_CAT_SYSTEMD | OPENCLAW_LOG_CAT_TRAY | OPENCLAW_LOG_CAT_STATE | OPENCLAW_LOG_CAT_NOTIFY | OPENCLAW_LOG_CAT_HEALTH
+} OpenClawLogCategory;
+
+void openclaw_log_init(void);
+gboolean openclaw_log_enabled(OpenClawLogLevel level, guint category_mask);
+void openclaw_log_write(OpenClawLogLevel level, guint category_mask, const char *file, int line, const char *func, const char *fmt, ...) G_GNUC_PRINTF(6, 7);
+
+// NOTE: OC_LOG_ERROR routes through g_warning() intentionally to avoid process
+// abort under G_DEBUG=fatal-criticals. ERROR is reserved for serious but
+// recoverable conditions (e.g., helper spawn failure).
+#define OC_LOG_ERROR(cat, fmt, ...) \
+    do { if (openclaw_log_enabled(OPENCLAW_LOG_ERROR, (cat))) openclaw_log_write(OPENCLAW_LOG_ERROR, (cat), __FILE__, __LINE__, G_STRFUNC, (fmt), ##__VA_ARGS__); } while (0)
+
+#define OC_LOG_WARN(cat, fmt, ...) \
+    do { if (openclaw_log_enabled(OPENCLAW_LOG_WARN, (cat))) openclaw_log_write(OPENCLAW_LOG_WARN, (cat), __FILE__, __LINE__, G_STRFUNC, (fmt), ##__VA_ARGS__); } while (0)
+
+#define OC_LOG_INFO(cat, fmt, ...) \
+    do { if (openclaw_log_enabled(OPENCLAW_LOG_INFO, (cat))) openclaw_log_write(OPENCLAW_LOG_INFO, (cat), __FILE__, __LINE__, G_STRFUNC, (fmt), ##__VA_ARGS__); } while (0)
+
+#define OC_LOG_DEBUG(cat, fmt, ...) \
+    do { if (openclaw_log_enabled(OPENCLAW_LOG_DEBUG, (cat))) openclaw_log_write(OPENCLAW_LOG_DEBUG, (cat), __FILE__, __LINE__, G_STRFUNC, (fmt), ##__VA_ARGS__); } while (0)
+
+#define OC_LOG_TRACE(cat, fmt, ...) \
+    do { if (openclaw_log_enabled(OPENCLAW_LOG_TRACE, (cat))) openclaw_log_write(OPENCLAW_LOG_TRACE, (cat), __FILE__, __LINE__, G_STRFUNC, (fmt), ##__VA_ARGS__); } while (0)
+
+#endif // OPENCLAW_LOG_H

--- a/apps/linux/src/main.c
+++ b/apps/linux/src/main.c
@@ -15,6 +15,8 @@
 #include <adwaita.h>
 #include <glib.h>
 
+#include "log.h"
+
 extern void tray_init(void);
 extern void systemd_init(void);
 extern void systemd_refresh(void);
@@ -83,6 +85,8 @@ static void on_activate(GtkApplication *app, gpointer user_data) {
 }
 
 int main(int argc, char **argv) {
+    openclaw_log_init();
+    
     g_autoptr(AdwApplication) app = adw_application_new("ai.openclaw.Companion", G_APPLICATION_DEFAULT_FLAGS);
     g_signal_connect(app, "activate", G_CALLBACK(on_activate), NULL);
 

--- a/apps/linux/src/notify.c
+++ b/apps/linux/src/notify.c
@@ -15,6 +15,7 @@
 #include <glib.h>
 #include <gtk/gtk.h>
 #include "state.h"
+#include "log.h"
 
 void notify_init(void) {
     // Basic init, application holds notification scope
@@ -22,9 +23,13 @@ void notify_init(void) {
 
 void notify_on_transition(AppState old_state, AppState new_state) {
     GApplication *app = g_application_get_default();
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_NOTIFY, "notify_on_transition entry old=%d new=%d app=%p registered=%d",
+              old_state, new_state, (void *)app, app ? g_application_get_is_registered(app) : 0);
     
     // Safety guard: do not send notifications before app is registered
     if (!app || !g_application_get_is_registered(app)) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_NOTIFY, "notify_on_transition skip (not registered)");
         return;
     }
 
@@ -50,8 +55,12 @@ void notify_on_transition(AppState old_state, AppState new_state) {
     }
 
     if (should_notify) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_NOTIFY, "notify_on_transition pre-send body='%s'", body);
         g_autoptr(GNotification) notification = g_notification_new(title);
         g_notification_set_body(notification, body);
         g_application_send_notification(app, "openclaw-status", notification);
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_NOTIFY, "notify_on_transition post-send");
+    } else {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_NOTIFY, "notify_on_transition no-send");
     }
 }

--- a/apps/linux/src/state.c
+++ b/apps/linux/src/state.c
@@ -12,6 +12,7 @@
  */
 
 #include <glib.h>
+#include "log.h"
 #include "state.h"
 
 static AppState current_state = STATE_NOT_INSTALLED;
@@ -77,18 +78,44 @@ void state_init(void) {
     initial_probe_fired = FALSE;
 }
 
+static const char* state_enum_to_string(AppState s) {
+    switch (s) {
+        case STATE_NOT_INSTALLED: return "NOT_INSTALLED";
+        case STATE_USER_SYSTEMD_UNAVAILABLE: return "USER_SYSTEMD_UNAVAILABLE";
+        case STATE_SYSTEM_UNSUPPORTED: return "SYSTEM_UNSUPPORTED";
+        case STATE_STOPPED: return "STOPPED";
+        case STATE_STARTING: return "STARTING";
+        case STATE_STOPPING: return "STOPPING";
+        case STATE_RUNNING: return "RUNNING";
+        case STATE_RUNNING_WITH_WARNING: return "RUNNING_WITH_WARNING";
+        case STATE_DEGRADED: return "DEGRADED";
+        case STATE_ERROR: return "ERROR";
+        default: return "UNKNOWN";
+    }
+}
+
 static void trigger_updates(AppState new_state) {
+    OC_LOG_INFO(OPENCLAW_LOG_CAT_STATE, "trigger_updates entry old=%s new=%s changed=%d hydrated=%d",
+              state_enum_to_string(current_state), state_enum_to_string(new_state),
+              new_state != current_state, initial_hydration_done);
+
     if (new_state != current_state) {
         AppState old_state = current_state;
         current_state = new_state;
         if (initial_hydration_done) {
+            OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "trigger_updates pre-notify old=%s new=%s",
+                      state_enum_to_string(old_state), state_enum_to_string(new_state));
             notify_on_transition(old_state, new_state);
+            OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "trigger_updates post-notify");
         }
     }
     // Note: Tray/UI updates may still occur even when the normalized state enum
     // does not change. This is intentional because detailed lane data (like
     // in_flight flags, timestamps, probe summary) can still change and needs rendering.
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "trigger_updates pre-tray state=%s",
+              state_enum_to_string(current_state));
     tray_update_from_state(current_state);
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "trigger_updates post-tray");
 }
 
 static gboolean idle_request_probe_refresh(gpointer user_data) {

--- a/apps/linux/src/systemd.c
+++ b/apps/linux/src/systemd.c
@@ -19,6 +19,7 @@
 #include <glib/gstdio.h>
 #include <string.h>
 #include "state.h"
+#include "log.h"
 
 #include "systemd_helpers.h"
 
@@ -32,6 +33,7 @@ static guint properties_changed_signal_id = 0;
 
 static void fetch_unit_properties(void);
 extern void systemd_refresh(void);
+static void clear_unit_subscription(const gchar *reason);
 
 static gboolean check_system_scope_units(void) {
     const gchar *paths[] = {"/etc/systemd/system", "/usr/lib/systemd/system", "/lib/systemd/system"};
@@ -126,7 +128,7 @@ const gchar* systemd_get_canonical_unit_name(void) {
                     return cached_unit_name;
                 }
             }
-            g_warning("Environment requested unit '%s' but it was not discovered as a valid gateway; falling back to discovery.", env_override);
+            OC_LOG_WARN(OPENCLAW_LOG_CAT_SYSTEMD, "Environment requested unit '%s' but it was not discovered as a valid gateway; falling back to discovery.", env_override);
             g_free(env_override);
         }
         
@@ -188,7 +190,7 @@ const gchar* systemd_get_canonical_unit_name(void) {
         }
         
         if (!best_is_active && !best_is_enabled) {
-            g_warning("Multiple OpenClaw systemd units found but none are active or enabled. "
+            OC_LOG_WARN(OPENCLAW_LOG_CAT_SYSTEMD, "Multiple OpenClaw systemd units found but none are active or enabled. "
                       "Deterministically selecting '%s' via lexical fallback.", best_candidate);
         }
         
@@ -209,8 +211,7 @@ static void extract_service_config_from_file(gchar **exec_start_out, gchar ***en
     const gchar *home_dir = g_get_home_dir();
     if (!home_dir) return;
 
-    const gchar *unit_name = systemd_get_canonical_unit_name();
-    g_autofree gchar *unit_path = g_build_filename(home_dir, ".config", "systemd", "user", unit_name, NULL);
+    g_autofree gchar *unit_path = g_build_filename(home_dir, ".config", "systemd", "user", systemd_get_canonical_unit_name(), NULL);
     
     g_autofree gchar *contents = NULL;
     g_autoptr(GError) error = NULL;
@@ -328,7 +329,7 @@ static void extract_service_config_from_file(gchar **exec_start_out, gchar ***en
                             g_strfreev(env_lines);
                             g_free(file_contents);
                         } else if (!is_optional) {
-                            g_warning("Failed to read EnvironmentFile: %s", env_file);
+                            OC_LOG_WARN(OPENCLAW_LOG_CAT_SYSTEMD, "Failed to read EnvironmentFile: %s", env_file);
                         }
                         
                         g_free(expanded_h);
@@ -366,25 +367,40 @@ static void extract_service_config_from_file(gchar **exec_start_out, gchar ***en
     }
 }
 
+static void clear_unit_subscription(const gchar *reason) {
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "clear-start reason=%s proxy=%p signal_id=%u unit=%s",
+              reason, (void *)unit_proxy, properties_changed_signal_id,
+              systemd_get_canonical_unit_name());
+
+    if (unit_proxy && properties_changed_signal_id > 0) {
+        g_signal_handler_disconnect(unit_proxy, properties_changed_signal_id);
+    }
+    properties_changed_signal_id = 0;
+
+    if (unit_proxy) {
+        g_object_unref(unit_proxy);
+        unit_proxy = NULL;
+    }
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "clear-done reason=%s proxy=%p signal_id=%u", reason, (void *)unit_proxy, properties_changed_signal_id);
+}
+
 static void on_unit_properties_changed(GDBusProxy *proxy, GVariant *changed_properties, const gchar* const *invalidated_properties, gpointer user_data) {
-    (void)proxy;
     (void)changed_properties;
     (void)invalidated_properties;
     (void)user_data;
     
+    OC_LOG_TRACE(OPENCLAW_LOG_CAT_SYSTEMD, "on_unit_properties_changed entry proxy=%p signal_id=%u", (void *)proxy, properties_changed_signal_id);
+
     // We simply re-fetch the properties whenever they change
     fetch_unit_properties();
 }
 
 static void subscribe_to_unit(GDBusConnection *bus, const gchar *unit_path) {
-    if (unit_proxy) {
-        if (properties_changed_signal_id > 0) {
-            g_signal_handler_disconnect(unit_proxy, properties_changed_signal_id);
-            properties_changed_signal_id = 0;
-        }
-        g_object_unref(unit_proxy);
-        unit_proxy = NULL;
-    }
+    GDBusProxy *old_proxy = unit_proxy;
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "subscribe-enter old_proxy=%p unit_path=%s", (void *)old_proxy, unit_path);
+
+    clear_unit_subscription("re-subscribe");
 
     g_autoptr(GError) error = NULL;
     unit_proxy = g_dbus_proxy_new_sync(
@@ -395,13 +411,19 @@ static void subscribe_to_unit(GDBusConnection *bus, const gchar *unit_path) {
         NULL, &error);
 
     if (!unit_proxy) {
-        g_warning("Failed to create Unit proxy: %s", error->message);
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_SYSTEMD, "Failed to create Unit proxy: %s", error->message);
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "subscribe-failed unit_path=%s error=%s",
+                  unit_path, error->message);
         return;
     }
 
     properties_changed_signal_id = g_signal_connect(unit_proxy, "g-properties-changed", G_CALLBACK(on_unit_properties_changed), NULL);
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "subscribe-acquired new_proxy=%p signal_id=%u unit_path=%s", (void *)unit_proxy, properties_changed_signal_id, unit_path);
     
     fetch_unit_properties();
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "subscribe-exit owned_proxy=%p unit_path=%s", (void *)unit_proxy, unit_path);
 }
 
 static void on_manager_signal(GDBusProxy *proxy, gchar *sender_name, gchar *signal_name, GVariant *parameters, gpointer user_data) {
@@ -412,12 +434,19 @@ static void on_manager_signal(GDBusProxy *proxy, gchar *sender_name, gchar *sign
 
     // If unit files changed or a new unit appeared, re-evaluate our connection
     if (g_strcmp0(signal_name, "UnitNew") == 0 || g_strcmp0(signal_name, "UnitFilesChanged") == 0) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_manager_signal signal=%s unit=%s proxy=%p",
+                  signal_name, systemd_get_canonical_unit_name(), (void *)unit_proxy);
         systemd_refresh(); 
     }
 }
 
 static void fetch_unit_properties(void) {
-    if (!unit_proxy) return;
+    OC_LOG_TRACE(OPENCLAW_LOG_CAT_SYSTEMD, "fetch_unit_properties entry proxy=%p signal_id=%u", (void *)unit_proxy, properties_changed_signal_id);
+
+    if (!unit_proxy) {
+        OC_LOG_TRACE(OPENCLAW_LOG_CAT_SYSTEMD, "fetch_unit_properties skip proxy=%p", (void *)unit_proxy);
+        return;
+    }
 
     g_autoptr(GVariant) active_state_v = g_dbus_proxy_get_cached_property(unit_proxy, "ActiveState");
     g_autoptr(GVariant) sub_state_v = g_dbus_proxy_get_cached_property(unit_proxy, "SubState");
@@ -460,6 +489,11 @@ static void fetch_unit_properties(void) {
 
     state_update_systemd(&sys_state);
 
+    OC_LOG_TRACE(OPENCLAW_LOG_CAT_SYSTEMD, "fetch_unit_properties exit active_state=%s sub_state=%s proxy=%p",
+              sys_state.active_state ? sys_state.active_state : "(null)",
+              sys_state.sub_state ? sys_state.sub_state : "(null)",
+              (void *)unit_proxy);
+
     g_free(sys_state.unit_name);
     g_free(sys_state.working_directory);
     g_free(sys_state.active_state);
@@ -472,7 +506,7 @@ void systemd_init(void) {
     g_autoptr(GError) error = NULL;
     g_autoptr(GDBusConnection) session_bus = g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, &error);
     if (!session_bus) {
-        g_warning("Failed to connect to session bus: %s", error->message);
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_SYSTEMD, "Failed to connect to session bus: %s", error->message);
         SystemdState sys_state = {0};
         sys_state.systemd_unavailable = TRUE;
         state_update_systemd(&sys_state);
@@ -487,7 +521,7 @@ void systemd_init(void) {
         NULL, &error);
 
     if (!manager_proxy) {
-        g_warning("Failed to create systemd Manager proxy: %s", error->message);
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_SYSTEMD, "Failed to create systemd Manager proxy: %s", error->message);
         SystemdState sys_state = {0};
         sys_state.systemd_unavailable = TRUE;
         state_update_systemd(&sys_state);
@@ -507,9 +541,16 @@ static void on_get_unit_ready(GObject *source_object, GAsyncResult *res, gpointe
     g_autoptr(GError) error = NULL;
     g_autoptr(GVariant) result = g_dbus_proxy_call_finish(G_DBUS_PROXY(source_object), res, &error);
 
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_ready entry requested=%s current=%s proxy=%p",
+              requested_unit_name ? requested_unit_name : "(null)",
+              systemd_get_canonical_unit_name(),
+              (void *)unit_proxy);
+
     // If the canonical unit has changed since we requested this unit, discard the stale reply
     if (requested_unit_name) {
         if (g_strcmp0(requested_unit_name, systemd_get_canonical_unit_name()) != 0) {
+            OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_ready stale-discard requested=%s current=%s",
+                      requested_unit_name, systemd_get_canonical_unit_name());
             g_free(requested_unit_name);
             return;
         }
@@ -518,15 +559,10 @@ static void on_get_unit_ready(GObject *source_object, GAsyncResult *res, gpointe
 
     // 3 (continued). Evaluate runtime state result
     if (!result) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_ready !result proxy=%p error=%s",
+                  (void *)unit_proxy, error ? error->message : "(null)");
         // Drop the previous unit subscription when retargeting to an unloaded unit
-        if (unit_proxy) {
-            if (properties_changed_signal_id > 0) {
-                g_signal_handler_disconnect(unit_proxy, properties_changed_signal_id);
-                properties_changed_signal_id = 0;
-            }
-            g_object_unref(unit_proxy);
-            unit_proxy = NULL;
-        }
+        clear_unit_subscription("unit-unloaded");
 
         // Unit is installed but completely stopped/inactive/unloaded
         SystemdState sys_state = {0};
@@ -567,6 +603,9 @@ static void on_get_unit_ready(GObject *source_object, GAsyncResult *res, gpointe
     const gchar *unit_path = NULL;
     g_variant_get(result, "(&o)", &unit_path);
 
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_ready success unit_path=%s proxy=%p",
+              unit_path ? unit_path : "(null)", (void *)unit_proxy);
+
     if (unit_path) {
         subscribe_to_unit(g_dbus_proxy_get_connection(manager_proxy), unit_path);
     }
@@ -577,9 +616,16 @@ static void on_get_unit_file_state_ready(GObject *source_object, GAsyncResult *r
     g_autoptr(GError) error = NULL;
     g_autoptr(GVariant) result = g_dbus_proxy_call_finish(G_DBUS_PROXY(source_object), res, &error);
 
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_file_state_ready entry requested=%s current=%s proxy=%p",
+              requested_unit_name ? requested_unit_name : "(null)",
+              systemd_get_canonical_unit_name(),
+              (void *)unit_proxy);
+
     // If the canonical unit has changed since we requested this unit, discard the stale reply
     if (requested_unit_name) {
         if (g_strcmp0(requested_unit_name, systemd_get_canonical_unit_name()) != 0) {
+            OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_file_state_ready stale-discard requested=%s current=%s",
+                      requested_unit_name, systemd_get_canonical_unit_name());
             g_free(requested_unit_name);
             return;
         }
@@ -606,15 +652,10 @@ static void on_get_unit_file_state_ready(GObject *source_object, GAsyncResult *r
 
     // 2. If GetUnitFileState fails or state is "not-found", treat as not installed
     if (!is_installed) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_file_state_ready !is_installed proxy=%p",
+                  (void *)unit_proxy);
         // Drop the previous unit subscription if the selected unit is no longer installed
-        if (unit_proxy) {
-            if (properties_changed_signal_id > 0) {
-                g_signal_handler_disconnect(unit_proxy, properties_changed_signal_id);
-                properties_changed_signal_id = 0;
-            }
-            g_object_unref(unit_proxy);
-            unit_proxy = NULL;
-        }
+        clear_unit_subscription("unit-not-installed");
 
         // Failed to get file state or unit not found -> assume not installed
         SystemdState sys_state = {0};
@@ -626,6 +667,9 @@ static void on_get_unit_file_state_ready(GObject *source_object, GAsyncResult *r
         g_free(sys_state.unit_name);
         return;
     }
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_file_state_ready is_installed proxy=%p",
+              (void *)unit_proxy);
 
     // 3. Fetch runtime unit path asynchronously
     const gchar *current_unit = systemd_get_canonical_unit_name();
@@ -641,7 +685,12 @@ void systemd_refresh(void) {
 
     g_free(cached_unit_name);
     cached_unit_name = NULL;
+
     const gchar *unit_name = systemd_get_canonical_unit_name();
+    OC_LOG_TRACE(OPENCLAW_LOG_CAT_SYSTEMD, "systemd_refresh entry proxy=%p signal_id=%u unit=%s",
+              (void *)unit_proxy, properties_changed_signal_id, unit_name ? unit_name : "(null)");
+
+    if (!unit_name) return;
 
     // 1. Start async check if unit file exists/is installed at all
     g_dbus_proxy_call(
@@ -651,26 +700,52 @@ void systemd_refresh(void) {
         on_get_unit_file_state_ready, g_strdup(unit_name));
 }
 
+static void on_manager_unit_action_finished(GObject *source_object, GAsyncResult *res, gpointer user_data) {
+    const gchar *method = (const gchar *)user_data;
+    g_autoptr(GError) error = NULL;
+    g_autoptr(GVariant) result = g_dbus_proxy_call_finish(G_DBUS_PROXY(source_object), res, &error);
+
+    if (result) {
+        const gchar *job_path = NULL;
+        g_variant_get(result, "(&o)", &job_path);
+        OC_LOG_INFO(OPENCLAW_LOG_CAT_SYSTEMD, "on_manager_unit_action_finished success method=%s job=%s manager=%p unit=%s",
+                  method, job_path ? job_path : "(null)",
+                  (void *)manager_proxy, systemd_get_canonical_unit_name());
+    } else {
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_SYSTEMD, "on_manager_unit_action_finished error method=%s manager=%p unit=%s error=%s",
+                  method, (void *)manager_proxy, systemd_get_canonical_unit_name(), error ? error->message : "(null)");
+    }
+}
+
 void systemd_start_gateway(void) {
     if (!manager_proxy) return;
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "systemd_start_gateway pre-call manager=%p unit=%s",
+              (void *)manager_proxy, systemd_get_canonical_unit_name());
     g_dbus_proxy_call(
         manager_proxy, "StartUnit",
         g_variant_new("(ss)", systemd_get_canonical_unit_name(), "replace"),
-        G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL, NULL); 
+        G_DBUS_CALL_FLAGS_NONE, -1, NULL,
+        on_manager_unit_action_finished, (gpointer)"StartUnit");
 }
 
 void systemd_stop_gateway(void) {
     if (!manager_proxy) return;
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "systemd_stop_gateway pre-call manager=%p unit=%s",
+              (void *)manager_proxy, systemd_get_canonical_unit_name());
     g_dbus_proxy_call(
         manager_proxy, "StopUnit",
         g_variant_new("(ss)", systemd_get_canonical_unit_name(), "replace"),
-        G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL, NULL);
+        G_DBUS_CALL_FLAGS_NONE, -1, NULL,
+        on_manager_unit_action_finished, (gpointer)"StopUnit");
 }
 
 void systemd_restart_gateway(void) {
     if (!manager_proxy) return;
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "systemd_restart_gateway pre-call manager=%p unit=%s",
+              (void *)manager_proxy, systemd_get_canonical_unit_name());
     g_dbus_proxy_call(
         manager_proxy, "RestartUnit",
         g_variant_new("(ss)", systemd_get_canonical_unit_name(), "replace"),
-        G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL, NULL);
+        G_DBUS_CALL_FLAGS_NONE, -1, NULL,
+        on_manager_unit_action_finished, (gpointer)"RestartUnit");
 }

--- a/apps/linux/src/tray.c
+++ b/apps/linux/src/tray.c
@@ -16,10 +16,32 @@
 #include <stdio.h>
 #include <string.h>
 #include "state.h"
+#include "log.h"
 
 static GSubprocess *helper_process = NULL;
 static GOutputStream *helper_stdin = NULL;
 static GDataInputStream *helper_stdout_stream = NULL;
+static guint helper_seq = 0;
+
+static void on_helper_process_weak_notify(gpointer data, GObject *where_the_object_was) {
+    (void)data;
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "helper-finalize helper_process=%p", (void *)where_the_object_was);
+}
+
+static void on_helper_stdin_weak_notify(gpointer data, GObject *where_the_object_was) {
+    (void)data;
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "helper-finalize helper_stdin=%p", (void *)where_the_object_was);
+}
+
+static void on_helper_stdout_weak_notify(gpointer data, GObject *where_the_object_was) {
+    (void)data;
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "helper-finalize helper_stdout=%p", (void *)where_the_object_was);
+}
+
+static void on_helper_data_stream_weak_notify(gpointer data, GObject *where_the_object_was) {
+    (void)data;
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "helper-finalize helper_data_stream=%p", (void *)where_the_object_was);
+}
 
 extern void systemd_start_gateway(void);
 extern void systemd_stop_gateway(void);
@@ -31,6 +53,9 @@ extern void health_run_deep_probe_eager(void);
 extern void diagnostics_show_window(void);
 
 static void handle_helper_action(const gchar *action) {
+    guint seq = ++helper_seq;
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "handle_helper_action entry seq=%u action='%s' process=%p stdin=%p stream=%p",
+              seq, action, (void *)helper_process, (void *)helper_stdin, (void *)helper_stdout_stream);
     if (g_strcmp0(action, "START") == 0) {
         systemd_start_gateway();
     } else if (g_strcmp0(action, "STOP") == 0) {
@@ -52,6 +77,7 @@ static void handle_helper_action(const gchar *action) {
         GApplication *app = g_application_get_default();
         if (app) g_application_quit(app);
     }
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "handle_helper_action exit seq=%u action='%s'", seq, action);
 }
 
 static void on_helper_line_read(GObject *source_object, GAsyncResult *res, gpointer user_data) {
@@ -60,22 +86,38 @@ static void on_helper_line_read(GObject *source_object, GAsyncResult *res, gpoin
     g_autoptr(GError) error = NULL;
     gsize length = 0;
     
+    guint seq = ++helper_seq;
+    OC_LOG_TRACE(OPENCLAW_LOG_CAT_TRAY, "on_helper_line_read entry seq=%u source_object=%p data_stream=%p global_stream=%p match=%d",
+              seq, (void *)source_object, (void *)data_stream, (void *)helper_stdout_stream,
+              (source_object == (GObject *)helper_stdout_stream));
+
     gchar *line = g_data_input_stream_read_line_finish(data_stream, res, &length, &error);
     if (line) {
+        OC_LOG_TRACE(OPENCLAW_LOG_CAT_TRAY, "on_helper_line_read line='%s' len=%zu", line, length);
         if (g_str_has_prefix(line, "ACTION:")) {
             handle_helper_action(line + 7);
         }
         g_free(line);
         
-        // Read next line asynchronously on the main thread context
-        g_data_input_stream_read_line_async(data_stream, G_PRIORITY_DEFAULT, NULL, on_helper_line_read, NULL);
-    } else {
-        if (error) {
-            g_warning("Error reading from helper stdout: %s", error->message);
+        // Only re-arm if the helper stream is still alive (not cleared by on_helper_exited)
+        if (helper_stdout_stream && helper_process) {
+            OC_LOG_TRACE(OPENCLAW_LOG_CAT_TRAY, "on_helper_line_read pre-rearm data_stream=%p", (void *)data_stream);
+            g_data_input_stream_read_line_async(data_stream, G_PRIORITY_DEFAULT, NULL, on_helper_line_read, NULL);
+            OC_LOG_TRACE(OPENCLAW_LOG_CAT_TRAY, "on_helper_line_read post-rearm");
+        } else {
+            OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "on_helper_line_read skip-rearm stream=%p helper_process=%p",
+                      (void *)helper_stdout_stream, (void *)helper_process);
         }
-        // Stream ended, release reference kept for the loop
-        g_object_unref(data_stream);
-        helper_stdout_stream = NULL;
+    } else {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "on_helper_line_read stream-ended data_stream=%p error=%s",
+                  (void *)data_stream, error ? error->message : "(none)");
+        if (error) {
+            OC_LOG_WARN(OPENCLAW_LOG_CAT_TRAY, "Error reading from helper stdout: %s", error->message);
+        }
+        // Stream ended — drop our owned reference via g_clear_object so that
+        // on_helper_exited (which may also clear it) sees NULL and is a no-op.
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "helper-clear stdout_stream=%p (from stream-ended)", (void *)helper_stdout_stream);
+        g_clear_object(&helper_stdout_stream);
     }
 }
 
@@ -83,9 +125,29 @@ static void on_helper_exited(GObject *source_object, GAsyncResult *res, gpointer
     (void)user_data;
     g_autoptr(GError) error = NULL;
     g_subprocess_wait_finish(G_SUBPROCESS(source_object), res, &error);
-    g_print("Tray helper exited.\n");
+    guint seq = ++helper_seq;
+    OC_LOG_INFO(OPENCLAW_LOG_CAT_TRAY, "on_helper_exited entry seq=%u source=%p helper_process=%p helper_stdin=%p helper_stdout_stream=%p",
+              seq, (void *)source_object, (void *)helper_process, (void *)helper_stdin, (void *)helper_stdout_stream);
+    if (error) {
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_TRAY, "helper wait_finish error: %s", error->message);
+    }
+    OC_LOG_INFO(OPENCLAW_LOG_CAT_TRAY, "Tray helper exited");
+
+    // Cleanup order: stdout_stream first (may already be NULL if stream-ended
+    // callback ran first — g_clear_object is a no-op on NULL), then stdin
+    // (owned ref), then process last (so streams are released before the
+    // subprocess that backs them).
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "helper-clear stdout_stream=%p (from exited)", (void *)helper_stdout_stream);
+    g_clear_object(&helper_stdout_stream);
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "helper-clear stdin=%p (from exited)", (void *)helper_stdin);
+    g_clear_object(&helper_stdin);
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "helper-clear process=%p (from exited)", (void *)helper_process);
     g_clear_object(&helper_process);
-    helper_stdin = NULL;
+
+    OC_LOG_INFO(OPENCLAW_LOG_CAT_TRAY, "on_helper_exited post-clear process=%p stdin=%p stdout_stream=%p",
+              (void *)helper_process, (void *)helper_stdin, (void *)helper_stdout_stream);
     
     GApplication *app = g_application_get_default();
     if (app) {
@@ -113,7 +175,7 @@ void tray_init(void) {
 #ifdef OPENCLAW_LIBEXEC_DIR
         helper_path = g_build_filename(OPENCLAW_LIBEXEC_DIR, "openclaw-tray-helper", NULL);
 #else
-        g_warning("OPENCLAW_LIBEXEC_DIR not defined. Falling back to PWD.");
+        OC_LOG_ERROR(OPENCLAW_LOG_CAT_TRAY, "OPENCLAW_LIBEXEC_DIR not defined. Falling back to PWD.");
         helper_path = g_strdup("./openclaw-tray-helper");
 #endif
     }
@@ -124,17 +186,33 @@ void tray_init(void) {
                                        G_SUBPROCESS_FLAGS_STDIN_PIPE | G_SUBPROCESS_FLAGS_STDOUT_PIPE,
                                        &error);
     if (!helper_process) {
-        g_warning("Failed to spawn tray helper (%s): %s", helper_path, error->message);
+        OC_LOG_ERROR(OPENCLAW_LOG_CAT_TRAY, "Failed to spawn tray helper (%s): %s", helper_path, error->message);
         GApplication *app = g_application_get_default();
         if (app) g_application_quit(app);
         return;
     }
     
-    helper_stdin = g_subprocess_get_stdin_pipe(helper_process);
+    // Owned reference: g_subprocess_get_stdin_pipe returns a borrowed ref,
+    // so we take our own to guarantee validity across async callbacks.
+    helper_stdin = g_object_ref(g_subprocess_get_stdin_pipe(helper_process));
     GInputStream *helper_stdout = g_subprocess_get_stdout_pipe(helper_process);
     
+    // Owned reference: g_data_input_stream_new returns a new object (refcount=1).
+    // Shared cleanup responsibility with on_helper_line_read (stream-ended) and
+    // on_helper_exited — both use g_clear_object to avoid double-unref.
     helper_stdout_stream = g_data_input_stream_new(helper_stdout);
-    
+
+    helper_seq = 0;
+    OC_LOG_INFO(OPENCLAW_LOG_CAT_TRAY, "tray_init created seq=0 helper_process=%p helper_stdin=%p (owned) helper_stdout=%p (borrowed) helper_data_stream=%p (owned)",
+              (void *)helper_process, (void *)helper_stdin, (void *)helper_stdout, (void *)helper_stdout_stream);
+
+    g_object_weak_ref(G_OBJECT(helper_process), on_helper_process_weak_notify, NULL);
+    if (helper_stdin)
+        g_object_weak_ref(G_OBJECT(helper_stdin), on_helper_stdin_weak_notify, NULL);
+    if (helper_stdout)
+        g_object_weak_ref(G_OBJECT(helper_stdout), on_helper_stdout_weak_notify, NULL);
+    g_object_weak_ref(G_OBJECT(helper_stdout_stream), on_helper_data_stream_weak_notify, NULL);
+
     // Start reading output asynchronously on the main loop
     g_data_input_stream_read_line_async(helper_stdout_stream, G_PRIORITY_DEFAULT, NULL, on_helper_line_read, NULL);
     
@@ -142,16 +220,40 @@ void tray_init(void) {
 }
 
 static void send_to_helper(const gchar *cmd) {
-    if (!helper_stdin) return;
-    g_output_stream_write_all(helper_stdin, cmd, strlen(cmd), NULL, NULL, NULL);
-    g_output_stream_flush(helper_stdin, NULL, NULL);
+    if (!helper_stdin || !helper_process) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "send_to_helper skip stdin=%p process=%p",
+                  (void *)helper_stdin, (void *)helper_process);
+        return;
+    }
+    g_autoptr(GError) write_err = NULL;
+    g_autoptr(GError) flush_err = NULL;
+    gsize bytes_written = 0;
+    gboolean write_ok = g_output_stream_write_all(helper_stdin, cmd, strlen(cmd), &bytes_written, NULL, &write_err);
+    gboolean flush_ok = g_output_stream_flush(helper_stdin, NULL, &flush_err);
+    if (!write_ok || !flush_ok) {
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_TRAY, "send_to_helper error write_ok=%d flush_ok=%d write_err=%s flush_err=%s stdin=%p",
+                  write_ok, flush_ok,
+                  write_err ? write_err->message : "(none)",
+                  flush_err ? flush_err->message : "(none)",
+                  (void *)helper_stdin);
+    } else {
+        OC_LOG_TRACE(OPENCLAW_LOG_CAT_TRAY, "send_to_helper ok bytes=%zu stdin=%p cmd='%.80s'",
+                  bytes_written, (void *)helper_stdin, cmd);
+    }
 }
 
 void tray_update_from_state(AppState state) {
-    if (!helper_stdin) return;
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state entry state=%d helper_stdin=%p helper_process=%p",
+              state, (void *)helper_stdin, (void *)helper_process);
+
+    if (!helper_stdin) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state skip (no stdin)");
+        return;
+    }
     
     const char *status_str = state_get_current_string();
     g_autofree gchar *cmd = g_strdup_printf("STATE:%s\n", status_str);
+    OC_LOG_TRACE(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state pre-send-state cmd='%.80s'", cmd);
     send_to_helper(cmd);
     
     // Determine action sensitivities based on strict 8-case state
@@ -185,7 +287,9 @@ void tray_update_from_state(AppState state) {
     g_autofree gchar *cmd_stop = g_strdup_printf("SENSITIVE:STOP:%d\n", can_stop ? 1 : 0);
     g_autofree gchar *cmd_restart = g_strdup_printf("SENSITIVE:RESTART:%d\n", can_restart ? 1 : 0);
     
+    OC_LOG_TRACE(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state pre-send-sensitive");
     send_to_helper(cmd_start);
     send_to_helper(cmd_stop);
     send_to_helper(cmd_restart);
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state exit");
 }


### PR DESCRIPTION
Fix a segfault in on_health_probe_finished where g_autoptr(JsonParser) was declared after a goto label. GCC's cleanup attribute fired on an uninitialized pointer when any early goto path was taken. Fix moves the declaration to the top of the function and initializes it to NULL.

Introduce a centralized logging layer (log.h/log.c):
- Five levels: ERROR, WARN, INFO, DEBUG, TRACE (default: WARN)
- Five categories: SYSTEMD, TRAY, STATE, NOTIFY, HEALTH
- Runtime control via OPENCLAW_LINUX_LOG and OPENCLAW_LINUX_LOG_CATEGORIES
- OC_LOG_* macros guard openclaw_log_enabled() before any format work
- OC_LOG_ERROR routes through g_warning() intentionally to avoid process abort under G_DEBUG=fatal-criticals; documented in log.h
- G_GNUC_PRINTF(6,7) applied for compile-time format safety

Integrate logging across systemd.c, tray.c, state.c, and notify.c. Replace all g_message/g_warning/g_print with typed OC_LOG_* macros.

Additional tray.c correctness fixes:
- helper_stdin is now an owned reference (g_object_ref)
- all cleanup uses g_clear_object instead of manual NULL assignment
- on_helper_exited checks GError from g_subprocess_wait_finish
- StartUnit/StopUnit/RestartUnit use an async completion callback instead of fire-and-forget NULL callbacks
- helper_seq counter and GObject weak-ref notifiers added for tracing