### PR TITLE
fix(linux): support inline auth args and preserve systemd env ordering (#23)

### DIFF
--- a/apps/linux/src/health.c
+++ b/apps/linux/src/health.c
@@ -31,17 +31,6 @@ void health_init(void) {
     pending_deep_probe = FALSE;
 }
 
-static gboolean gateway_arg_should_be_forwarded(const gchar *arg, const gchar *subcommand) {
-    if (!arg) return FALSE;
-    if (g_strcmp0(subcommand, "probe") == 0 || g_strcmp0(subcommand, "status") == 0) {
-        return (g_strcmp0(arg, "--token") == 0 || g_strcmp0(arg, "-t") == 0 ||
-                g_strcmp0(arg, "--password") == 0);
-    }
-    return (g_strcmp0(arg, "--port") == 0 || g_strcmp0(arg, "-p") == 0 ||
-            g_strcmp0(arg, "--token") == 0 || g_strcmp0(arg, "-t") == 0 ||
-            g_strcmp0(arg, "--password") == 0);
-}
-
 static gchar** build_standard_argv(const gchar **prefix, const gchar *subcommand) {
     GPtrArray *arr = g_ptr_array_new();
     for (gint i = 0; prefix[i] != NULL; i++) {
@@ -93,9 +82,9 @@ static gchar** resolve_from_systemd(const gchar *subcommand) {
         // avoiding unsupported `run` flags that crash `status` or `probe`.
         for (gint i = gateway_idx + 1; i < len; i++) {
             const gchar *arg = sys->exec_start_argv[i];
-            if (gateway_arg_should_be_forwarded(arg, subcommand)) {
+            if (health_gateway_arg_should_be_forwarded(arg, subcommand)) {
                 g_ptr_array_add(arr, g_strdup(arg));
-                if (i + 1 < len) {
+                if (health_gateway_arg_consumes_next_value(arg) && i + 1 < len) {
                     g_ptr_array_add(arr, g_strdup(sys->exec_start_argv[i + 1]));
                     i++; // Skip the value since we just consumed it
                 }

--- a/apps/linux/src/health_helpers.c
+++ b/apps/linux/src/health_helpers.c
@@ -1,6 +1,31 @@
 #include "health_helpers.h"
 #include <string.h>
 
+gboolean health_gateway_arg_should_be_forwarded(const gchar *arg, const gchar *subcommand) {
+    if (!arg) return FALSE;
+    if (g_strcmp0(subcommand, "probe") == 0 || g_strcmp0(subcommand, "status") == 0) {
+        return (g_strcmp0(arg, "--token") == 0 || g_str_has_prefix(arg, "--token=") ||
+                g_strcmp0(arg, "-t") == 0 ||
+                g_strcmp0(arg, "--password") == 0 || g_str_has_prefix(arg, "--password="));
+    }
+    return (g_strcmp0(arg, "--port") == 0 || g_str_has_prefix(arg, "--port=") || 
+            g_strcmp0(arg, "-p") == 0 ||
+            g_strcmp0(arg, "--token") == 0 || g_str_has_prefix(arg, "--token=") || 
+            g_strcmp0(arg, "-t") == 0 ||
+            g_strcmp0(arg, "--password") == 0 || g_str_has_prefix(arg, "--password="));
+}
+
+gboolean health_gateway_arg_consumes_next_value(const gchar *arg) {
+    if (!arg) return FALSE;
+    // Only exact split-form flags consume the next argument.
+    // If it contains '=', it is an inline assignment and does not consume the next token.
+    return (g_strcmp0(arg, "--token") == 0 || 
+            g_strcmp0(arg, "-t") == 0 ||
+            g_strcmp0(arg, "--password") == 0 || 
+            g_strcmp0(arg, "--port") == 0 || 
+            g_strcmp0(arg, "-p") == 0);
+}
+
 void health_parse_probe_stdout(const gchar *stdout_buf, ProbeState *ps) {
     if (!ps) return;
     if (stdout_buf) {

--- a/apps/linux/src/health_helpers.h
+++ b/apps/linux/src/health_helpers.h
@@ -5,5 +5,7 @@
 #include "state.h"
 
 void health_parse_probe_stdout(const gchar *stdout_buf, ProbeState *ps);
+gboolean health_gateway_arg_should_be_forwarded(const gchar *arg, const gchar *subcommand);
+gboolean health_gateway_arg_consumes_next_value(const gchar *arg);
 
 #endif // OPENCLAW_LINUX_HEALTH_HELPERS_H

--- a/apps/linux/src/systemd.c
+++ b/apps/linux/src/systemd.c
@@ -227,7 +227,7 @@ const gchar* systemd_get_canonical_unit_name(void) {
     return cached_unit_name;
 }
 
-static gchar** parse_single_env_file(const gchar *env_file, const gchar *home_dir, gboolean is_optional, gchar **file_env) {
+gchar** systemd_parse_single_env_file(const gchar *env_file, const gchar *home_dir, const gchar *unit_dir, gboolean is_optional, gchar **file_env) {
     gchar *expanded_h = NULL;
     const gchar *target_file = env_file;
     
@@ -240,9 +240,13 @@ static gchar** parse_single_env_file(const gchar *env_file, const gchar *home_di
     
     gchar *resolved_path = NULL;
     if (!g_path_is_absolute(target_file)) {
-        gchar *systemd_user_dir = g_build_filename(home_dir, ".config", "systemd", "user", NULL);
-        resolved_path = g_build_filename(systemd_user_dir, target_file, NULL);
-        g_free(systemd_user_dir);
+        if (unit_dir) {
+            resolved_path = g_build_filename(unit_dir, target_file, NULL);
+        } else {
+            gchar *systemd_user_dir = g_build_filename(home_dir, ".config", "systemd", "user", NULL);
+            resolved_path = g_build_filename(systemd_user_dir, target_file, NULL);
+            g_free(systemd_user_dir);
+        }
         target_file = resolved_path;
     }
     
@@ -279,7 +283,7 @@ static gchar** parse_single_env_file(const gchar *env_file, const gchar *home_di
     return file_env;
 }
 
-static gchar** parse_environment_file(const gchar *env_val, const gchar *home_dir, gchar **file_env) {
+gchar** systemd_parse_environment_file(const gchar *env_val, const gchar *home_dir, const gchar *unit_dir, gchar **file_env) {
     gint argc = 0;
     gchar **argv = NULL;
     
@@ -296,7 +300,7 @@ static gchar** parse_environment_file(const gchar *env_val, const gchar *home_di
             
             if (env_file[0] == '\0') continue;
             
-            file_env = parse_single_env_file(env_file, home_dir, is_optional, file_env);
+            file_env = systemd_parse_single_env_file(env_file, home_dir, unit_dir, is_optional, file_env);
         }
         g_strfreev(argv);
     }
@@ -330,14 +334,15 @@ static void extract_service_config_from_file(gchar **exec_start_out, gchar ***en
     if (!unit_path) {
         return;
     }
+    
+    gchar *unit_dir = g_path_get_dirname(unit_path);
     g_free(unit_path);
 
     gchar **lines = g_strsplit(contents, "\n", -1);
     gboolean in_service_section = FALSE;
     gchar *exec_start = NULL;
     gchar *working_directory = NULL;
-    gchar **inline_env = g_new0(gchar*, 1);
-    gchar **file_env = g_new0(gchar*, 1);
+    gchar **merged_env = g_new0(gchar*, 1);
 
     for (gint i = 0; lines[i] != NULL; i++) {
         gchar *line = g_strstrip(lines[i]);
@@ -378,35 +383,23 @@ static void extract_service_config_from_file(gchar **exec_start_out, gchar ***en
                         gchar *eq = strchr(argv[j], '=');
                         if (eq) {
                             *eq = '\0';
-                            inline_env = g_environ_setenv(inline_env, argv[j], eq + 1, TRUE);
+                            merged_env = g_environ_setenv(merged_env, argv[j], eq + 1, TRUE);
                         }
                     }
                     g_strfreev(argv);
                 }
             } else if (g_str_has_prefix(line, "EnvironmentFile=")) {
                 gchar *env_val = line + 16;
-                file_env = parse_environment_file(env_val, home_dir, file_env);
+                merged_env = systemd_parse_environment_file(env_val, home_dir, unit_dir, merged_env);
             }
         }
     }
 
     g_strfreev(lines);
+    g_free(unit_dir);
 
     *exec_start_out = exec_start;
     *working_directory_out = working_directory;
-    
-    // Merge: file_env overrides inline_env
-    gchar **merged_env = inline_env;
-    for (gint i = 0; file_env && file_env[i]; i++) {
-        gchar *eq = strchr(file_env[i], '=');
-        if (eq) {
-            *eq = '\0';
-            merged_env = g_environ_setenv(merged_env, file_env[i], eq + 1, TRUE);
-            *eq = '=';
-        }
-    }
-    
-    g_strfreev(file_env);
     
     if (g_strv_length(merged_env) > 0) {
         *environment_out = merged_env;

--- a/apps/linux/src/systemd_helpers.h
+++ b/apps/linux/src/systemd_helpers.h
@@ -7,4 +7,8 @@ gboolean systemd_is_gateway_unit(const gchar *filename, const gchar *contents);
 gchar* systemd_normalize_unit_override(const gchar *raw_unit);
 gchar* systemd_normalize_profile(const gchar *raw_profile);
 
+// Exposed for testing
+gchar** systemd_parse_single_env_file(const gchar *env_file, const gchar *home_dir, const gchar *unit_dir, gboolean is_optional, gchar **file_env);
+gchar** systemd_parse_environment_file(const gchar *env_val, const gchar *home_dir, const gchar *unit_dir, gchar **file_env);
+
 #endif // OPENCLAW_LINUX_SYSTEMD_HELPERS_H

--- a/apps/linux/tests/test_health_parse.c
+++ b/apps/linux/tests/test_health_parse.c
@@ -150,6 +150,46 @@ static void test_combined_summary_line_mixed(void) {
     g_free(ps.summary);
 }
 
+static void test_arg_forwarding(void) {
+    // Tests for split auth
+    g_assert_true(health_gateway_arg_should_be_forwarded("--token", "probe"));
+    g_assert_true(health_gateway_arg_should_be_forwarded("--token", "status"));
+    g_assert_true(health_gateway_arg_consumes_next_value("--token"));
+
+    g_assert_true(health_gateway_arg_should_be_forwarded("-t", "probe"));
+    g_assert_true(health_gateway_arg_should_be_forwarded("-t", "status"));
+    g_assert_true(health_gateway_arg_consumes_next_value("-t"));
+
+    g_assert_true(health_gateway_arg_should_be_forwarded("--password", "probe"));
+    g_assert_true(health_gateway_arg_should_be_forwarded("--password", "status"));
+    g_assert_true(health_gateway_arg_consumes_next_value("--password"));
+
+    // Tests for inline auth
+    g_assert_true(health_gateway_arg_should_be_forwarded("--token=abc", "probe"));
+    g_assert_true(health_gateway_arg_should_be_forwarded("--token=abc", "status"));
+    g_assert_false(health_gateway_arg_consumes_next_value("--token=abc"));
+
+    g_assert_true(health_gateway_arg_should_be_forwarded("--password=xyz", "probe"));
+    g_assert_true(health_gateway_arg_should_be_forwarded("--password=xyz", "status"));
+    g_assert_false(health_gateway_arg_consumes_next_value("--password=xyz"));
+
+    // Verify probe/status do NOT forward port
+    g_assert_false(health_gateway_arg_should_be_forwarded("--port", "probe"));
+    g_assert_false(health_gateway_arg_should_be_forwarded("--port", "status"));
+    g_assert_false(health_gateway_arg_should_be_forwarded("--port=8080", "probe"));
+    g_assert_false(health_gateway_arg_should_be_forwarded("--port=8080", "status"));
+    g_assert_false(health_gateway_arg_should_be_forwarded("-p", "probe"));
+    g_assert_false(health_gateway_arg_should_be_forwarded("-p", "status"));
+
+    // Verify run-compatible paths still forward port
+    g_assert_true(health_gateway_arg_should_be_forwarded("--port", "run"));
+    g_assert_true(health_gateway_arg_consumes_next_value("--port"));
+    g_assert_true(health_gateway_arg_should_be_forwarded("--port=8080", "run"));
+    g_assert_false(health_gateway_arg_consumes_next_value("--port=8080"));
+    g_assert_true(health_gateway_arg_should_be_forwarded("-p", "run"));
+    g_assert_true(health_gateway_arg_consumes_next_value("-p"));
+}
+
 int main(int argc, char **argv) {
     g_test_init(&argc, &argv, NULL);
     
@@ -167,6 +207,7 @@ int main(int argc, char **argv) {
     g_test_add_func("/health_parse/no_summary_lines_safety", test_no_summary_lines_safety);
     g_test_add_func("/health_parse/combined_summary_line", test_combined_summary_line);
     g_test_add_func("/health_parse/combined_summary_line_mixed", test_combined_summary_line_mixed);
+    g_test_add_func("/health_parse/arg_forwarding", test_arg_forwarding);
     
     return g_test_run();
 }

--- a/apps/linux/tests/test_systemd_helpers.c
+++ b/apps/linux/tests/test_systemd_helpers.c
@@ -120,3 +120,4 @@ int main(int argc, char **argv) {
     
     return g_test_run();
 }
+


### PR DESCRIPTION
Fixes Linux companion systemd integration issues affecting gateway probe/status command reconstruction and runtime environment resolution.

- Forward inline auth arguments like --token=... and --password=... for gateway status/probe invocations
- Only consume the next argv token for split-form flags, avoiding corruption when inline assignments are used
- Preserve Environment= and EnvironmentFile= declaration order by applying both into a single sequential environment accumulator
- Resolve relative EnvironmentFile paths against the actual discovered unit file directory instead of a hardcoded user path
- Add tests covering split and inline auth argument forwarding behavior

This restores correct health monitoring for units using inline credentials and ensures environment resolution more closely matches systemd unit semantics across different installation layouts.