### PR TITLE
fix(linux): harden systemd Service property parsing (#27)

### DIFF
--- a/apps/linux/src/systemd.c
+++ b/apps/linux/src/systemd.c
@@ -389,87 +389,6 @@ static void publish_systemd_state_with_cached_config(const gchar *active_state, 
     g_strfreev(sys_state.environment);
 }
 
-static void apply_service_config_from_variant(GVariant *props) {
-    g_strfreev(cached_exec_start_argv);
-    cached_exec_start_argv = NULL;
-    g_free(cached_working_directory);
-    cached_working_directory = NULL;
-    g_strfreev(cached_environment);
-    cached_environment = NULL;
-
-    GVariant *exec_start_v = g_variant_lookup_value(props, "ExecStart", NULL);
-    GVariant *working_dir_v = g_variant_lookup_value(props, "WorkingDirectory", G_VARIANT_TYPE_STRING);
-    GVariant *env_v = g_variant_lookup_value(props, "Environment", NULL);
-    GVariant *env_files_v = g_variant_lookup_value(props, "EnvironmentFiles", NULL);
-
-    if (exec_start_v) {
-        // Signature: a(sasbttuii)
-        GVariantIter *iter;
-        g_variant_get(exec_start_v, "a(sasbttuii)", &iter);
-        gchar *path;
-        gchar **argv;
-        gboolean ignore_errors;
-        guint64 start_time, stop_time;
-        guint32 pid;
-        gint32 code, status;
-
-        if (g_variant_iter_next(iter, "(s^asbttuii)", &path, &argv, &ignore_errors, &start_time, &stop_time, &pid, &code, &status)) {
-            cached_exec_start_argv = argv;
-            g_free(path);
-        }
-        g_variant_iter_free(iter);
-        g_variant_unref(exec_start_v);
-    }
-
-    if (working_dir_v) {
-        cached_working_directory = g_strdup(g_variant_get_string(working_dir_v, NULL));
-        if (g_strcmp0(cached_working_directory, "") == 0) {
-            g_free(cached_working_directory);
-            cached_working_directory = NULL;
-        }
-        g_variant_unref(working_dir_v);
-    }
-
-    gchar **merged_env = g_new0(gchar*, 1);
-
-    if (env_v) {
-        const gchar **env_array = g_variant_get_strv(env_v, NULL);
-        if (env_array) {
-            for (gsize i = 0; env_array[i] != NULL; i++) {
-                gchar *eq = strchr(env_array[i], '=');
-                if (eq) {
-                    g_autofree gchar *key = g_strndup(env_array[i], eq - env_array[i]);
-                    merged_env = g_environ_setenv(merged_env, key, eq + 1, TRUE);
-                }
-            }
-            g_free(env_array);
-        }
-        g_variant_unref(env_v);
-    }
-
-    if (env_files_v) {
-        // Signature: a(sb) - array of (path, optional boolean)
-        GVariantIter *iter;
-        g_variant_get(env_files_v, "a(sb)", &iter);
-        gchar *path;
-        gboolean optional;
-        const gchar *home_dir = g_get_home_dir();
-
-        while (g_variant_iter_next(iter, "(sb)", &path, &optional)) {
-            merged_env = systemd_parse_single_env_file(path, home_dir, NULL, optional, merged_env);
-            g_free(path);
-        }
-        g_variant_iter_free(iter);
-        g_variant_unref(env_files_v);
-    }
-
-    if (g_strv_length(merged_env) > 0) {
-        cached_environment = merged_env;
-    } else {
-        g_strfreev(merged_env);
-    }
-}
-
 typedef struct {
     gchar *unit_name;
     gchar *unit_object_path;
@@ -518,11 +437,25 @@ static void on_get_service_properties_ready(GObject *source_object, GAsyncResult
         // GetAll returns (a{sv})
         GVariant *props = g_variant_get_child_value(result, 0);
         if (props) {
-            GVariant *exec_check = g_variant_lookup_value(props, "ExecStart", NULL);
-            if (exec_check) {
-                apply_service_config_from_variant(props);
+            gchar **new_exec_argv = NULL;
+            gchar *new_working_dir = NULL;
+            gchar **new_env = NULL;
+
+            if (systemd_parse_service_properties(props, g_get_home_dir(), &new_exec_argv, &new_working_dir, &new_env)) {
+                g_strfreev(cached_exec_start_argv);
+                cached_exec_start_argv = new_exec_argv;
+                
+                g_free(cached_working_directory);
+                cached_working_directory = new_working_dir;
+                
+                g_strfreev(cached_environment);
+                cached_environment = new_env;
+                
                 config_loaded = TRUE;
-                g_variant_unref(exec_check);
+            } else {
+                g_strfreev(new_exec_argv);
+                g_free(new_working_dir);
+                g_strfreev(new_env);
             }
             g_variant_unref(props);
         }

--- a/apps/linux/src/systemd_helpers.c
+++ b/apps/linux/src/systemd_helpers.c
@@ -128,3 +128,147 @@ gchar* systemd_normalize_profile(const gchar *raw_profile) {
     g_free(trimmed);
     return res;
 }
+
+gboolean systemd_parse_service_properties(GVariant *props, const gchar *home_dir, gchar ***exec_start_argv_out, gchar **working_directory_out, gchar ***environment_out) {
+    if (!props || !exec_start_argv_out || !working_directory_out || !environment_out) {
+        return FALSE;
+    }
+
+    *exec_start_argv_out = NULL;
+    *working_directory_out = NULL;
+    *environment_out = NULL;
+
+    GVariant *exec_start_v = g_variant_lookup_value(props, "ExecStart", NULL);
+    GVariant *working_dir_v = g_variant_lookup_value(props, "WorkingDirectory", G_VARIANT_TYPE_STRING);
+    GVariant *env_v = g_variant_lookup_value(props, "Environment", NULL);
+    GVariant *env_files_v = g_variant_lookup_value(props, "EnvironmentFiles", NULL);
+
+    gboolean parse_success = FALSE;
+
+    if (exec_start_v) {
+        const gchar *type_string = g_variant_get_type_string(exec_start_v);
+        GVariantIter *iter = NULL;
+        
+        // Handle both observed systemd signatures
+        if (g_strcmp0(type_string, "a(sasbttuii)") == 0) {
+            g_variant_get(exec_start_v, "a(sasbttuii)", &iter);
+            gchar *path;
+            gchar **argv;
+            gboolean ignore_errors;
+            guint64 start_time, stop_time;
+            guint32 pid;
+            gint32 code, status;
+
+            if (g_variant_iter_next(iter, "(s^asbttuii)", &path, &argv, &ignore_errors, &start_time, &stop_time, &pid, &code, &status)) {
+                if (argv && g_strv_length(argv) > 0) {
+                    *exec_start_argv_out = argv;
+                    parse_success = TRUE;
+                } else {
+                    g_strfreev(argv);
+                }
+                g_free(path);
+            }
+            g_variant_iter_free(iter);
+        } else if (g_strcmp0(type_string, "a(sasbttttuii)") == 0) {
+            g_variant_get(exec_start_v, "a(sasbttttuii)", &iter);
+            gchar *path;
+            gchar **argv;
+            gboolean ignore_errors;
+            guint64 start_time, stop_time, exec_time, something_else; // The extra 'tt' fields
+            guint32 pid;
+            gint32 code, status;
+
+            if (g_variant_iter_next(iter, "(s^asbttttuii)", &path, &argv, &ignore_errors, &start_time, &stop_time, &exec_time, &something_else, &pid, &code, &status)) {
+                if (argv && g_strv_length(argv) > 0) {
+                    *exec_start_argv_out = argv;
+                    parse_success = TRUE;
+                } else {
+                    g_strfreev(argv);
+                }
+                g_free(path);
+            }
+            g_variant_iter_free(iter);
+        } else {
+            OC_LOG_WARN(OPENCLAW_LOG_CAT_SYSTEMD, "Unexpected ExecStart GVariant signature: %s", type_string);
+        }
+        g_variant_unref(exec_start_v);
+    }
+
+    if (!parse_success) {
+        // Required field failed, clean up any partial state
+        if (working_dir_v) g_variant_unref(working_dir_v);
+        if (env_v) g_variant_unref(env_v);
+        if (env_files_v) g_variant_unref(env_files_v);
+        return FALSE;
+    }
+
+    if (working_dir_v) {
+        const gchar *raw_wd = g_variant_get_string(working_dir_v, NULL);
+        if (raw_wd && raw_wd[0] != '\0') {
+            const gchar *clean_wd = raw_wd;
+            // Systemd uses prefixes like '!' and '-' to modify working directory behavior.
+            // We conservatively strip these observed syntactic modifiers to get the real absolute path.
+            while (*clean_wd == '!' || *clean_wd == '-') {
+                clean_wd++;
+            }
+            
+            if (clean_wd[0] == '/') {
+                *working_directory_out = g_strdup(clean_wd);
+            } else if (clean_wd[0] != '\0') {
+                // Not an absolute path after stripping, invalid format
+                parse_success = FALSE;
+            }
+        }
+        g_variant_unref(working_dir_v);
+    }
+
+    if (!parse_success) {
+        g_strfreev(*exec_start_argv_out);
+        *exec_start_argv_out = NULL;
+        if (env_v) g_variant_unref(env_v);
+        if (env_files_v) g_variant_unref(env_files_v);
+        return FALSE;
+    }
+
+    gchar **merged_env = g_new0(gchar*, 1);
+
+    if (env_v) {
+        const gchar **env_array = g_variant_get_strv(env_v, NULL);
+        if (env_array) {
+            for (gsize i = 0; env_array[i] != NULL; i++) {
+                gchar *eq = strchr(env_array[i], '=');
+                if (eq) {
+                    g_autofree gchar *key = g_strndup(env_array[i], eq - env_array[i]);
+                    merged_env = g_environ_setenv(merged_env, key, eq + 1, TRUE);
+                }
+            }
+            g_free(env_array);
+        }
+        g_variant_unref(env_v);
+    }
+
+    if (env_files_v) {
+        // Signature: a(sb) - array of (path, optional boolean)
+        if (g_strcmp0(g_variant_get_type_string(env_files_v), "a(sb)") == 0) {
+            GVariantIter *iter;
+            g_variant_get(env_files_v, "a(sb)", &iter);
+            gchar *path;
+            gboolean optional;
+
+            while (g_variant_iter_next(iter, "(sb)", &path, &optional)) {
+                merged_env = systemd_parse_single_env_file(path, home_dir, NULL, optional, merged_env);
+                g_free(path);
+            }
+            g_variant_iter_free(iter);
+        }
+        g_variant_unref(env_files_v);
+    }
+
+    if (g_strv_length(merged_env) > 0) {
+        *environment_out = merged_env;
+    } else {
+        g_strfreev(merged_env);
+    }
+
+    return TRUE;
+}

--- a/apps/linux/src/systemd_helpers.h
+++ b/apps/linux/src/systemd_helpers.h
@@ -8,6 +8,8 @@ gboolean systemd_is_gateway_unit(const gchar *filename, const gchar *contents);
 gchar* systemd_normalize_unit_override(const gchar *raw_unit);
 gchar* systemd_normalize_profile(const gchar *raw_profile);
 
+gboolean systemd_parse_service_properties(GVariant *props, const gchar *home_dir, gchar ***exec_start_argv_out, gchar **working_directory_out, gchar ***environment_out);
+
 // Exposed for testing
 gchar** systemd_parse_single_env_file(const gchar *env_file, const gchar *home_dir, const gchar *unit_dir, gboolean is_optional, gchar **file_env);
 gchar** systemd_parse_environment_file(const gchar *env_val, const gchar *home_dir, const gchar *unit_dir, gchar **file_env);

--- a/apps/linux/tests/test_systemd_helpers.c
+++ b/apps/linux/tests/test_systemd_helpers.c
@@ -167,6 +167,208 @@ static void test_optional_env_file(void) {
     g_strfreev(env);
 }
 
+static void test_parse_service_props_old_signature(void) {
+    GVariantBuilder dict_builder;
+    g_variant_builder_init(&dict_builder, G_VARIANT_TYPE("a{sv}"));
+
+    // Build ExecStart a(sasbttuii)
+    GVariantBuilder exec_builder;
+    g_variant_builder_init(&exec_builder, G_VARIANT_TYPE("a(sasbttuii)"));
+    
+    GVariantBuilder argv_builder;
+    g_variant_builder_init(&argv_builder, G_VARIANT_TYPE("as"));
+    g_variant_builder_add(&argv_builder, "s", "/usr/bin/openclaw");
+    g_variant_builder_add(&argv_builder, "s", "gateway");
+    
+    g_variant_builder_add(&exec_builder, "(s@asbttuii)",
+                          "/usr/bin/openclaw",
+                          g_variant_builder_end(&argv_builder),
+                          FALSE,
+                          (guint64)0, (guint64)0,
+                          (guint32)0, (gint32)0, (gint32)0);
+
+    g_variant_builder_add(&dict_builder, "{sv}", "ExecStart", g_variant_builder_end(&exec_builder));
+    
+    GVariant *props = g_variant_builder_end(&dict_builder);
+    
+    gchar **exec_start_argv = NULL;
+    gchar *working_dir = NULL;
+    gchar **env = NULL;
+    
+    gboolean success = systemd_parse_service_properties(props, "/home/test", &exec_start_argv, &working_dir, &env);
+    
+    g_assert_true(success);
+    g_assert_nonnull(exec_start_argv);
+    g_assert_cmpstr(exec_start_argv[0], ==, "/usr/bin/openclaw");
+    g_assert_cmpstr(exec_start_argv[1], ==, "gateway");
+    g_assert_null(exec_start_argv[2]);
+    g_assert_null(working_dir);
+    g_assert_null(env);
+    
+    g_strfreev(exec_start_argv);
+    g_variant_unref(props);
+}
+
+static void test_parse_service_props_new_signature(void) {
+    GVariantBuilder dict_builder;
+    g_variant_builder_init(&dict_builder, G_VARIANT_TYPE("a{sv}"));
+
+    // Build ExecStart a(sasbttttuii)
+    GVariantBuilder exec_builder;
+    g_variant_builder_init(&exec_builder, G_VARIANT_TYPE("a(sasbttttuii)"));
+    
+    GVariantBuilder argv_builder;
+    g_variant_builder_init(&argv_builder, G_VARIANT_TYPE("as"));
+    g_variant_builder_add(&argv_builder, "s", "/usr/bin/openclaw");
+    
+    g_variant_builder_add(&exec_builder, "(s@asbttttuii)",
+                          "/usr/bin/openclaw",
+                          g_variant_builder_end(&argv_builder),
+                          FALSE,
+                          (guint64)0, (guint64)0, (guint64)0, (guint64)0,
+                          (guint32)0, (gint32)0, (gint32)0);
+
+    g_variant_builder_add(&dict_builder, "{sv}", "ExecStart", g_variant_builder_end(&exec_builder));
+    
+    GVariant *props = g_variant_builder_end(&dict_builder);
+    
+    gchar **exec_start_argv = NULL;
+    gchar *working_dir = NULL;
+    gchar **env = NULL;
+    
+    gboolean success = systemd_parse_service_properties(props, "/home/test", &exec_start_argv, &working_dir, &env);
+    
+    g_assert_true(success);
+    g_assert_nonnull(exec_start_argv);
+    g_assert_cmpstr(exec_start_argv[0], ==, "/usr/bin/openclaw");
+    g_assert_null(exec_start_argv[1]);
+    
+    g_strfreev(exec_start_argv);
+    g_variant_unref(props);
+}
+
+static void test_parse_service_props_working_directory_normalization(void) {
+    GVariantBuilder dict_builder;
+    g_variant_builder_init(&dict_builder, G_VARIANT_TYPE("a{sv}"));
+
+    // Valid ExecStart required for success
+    GVariantBuilder exec_builder;
+    g_variant_builder_init(&exec_builder, G_VARIANT_TYPE("a(sasbttuii)"));
+    GVariantBuilder argv_builder;
+    g_variant_builder_init(&argv_builder, G_VARIANT_TYPE("as"));
+    g_variant_builder_add(&argv_builder, "s", "test");
+    g_variant_builder_add(&exec_builder, "(s@asbttuii)", "test", g_variant_builder_end(&argv_builder), FALSE, (guint64)0, (guint64)0, (guint32)0, (gint32)0, (gint32)0);
+    g_variant_builder_add(&dict_builder, "{sv}", "ExecStart", g_variant_builder_end(&exec_builder));
+    
+    // Regression test: the ! prefix
+    g_variant_builder_add(&dict_builder, "{sv}", "WorkingDirectory", g_variant_new_string("!/home/testuser"));
+    
+    GVariant *props = g_variant_builder_end(&dict_builder);
+    
+    gchar **exec_start_argv = NULL;
+    gchar *working_dir = NULL;
+    gchar **env = NULL;
+    
+    gboolean success = systemd_parse_service_properties(props, "/home/test", &exec_start_argv, &working_dir, &env);
+    
+    g_assert_true(success);
+    g_assert_cmpstr(working_dir, ==, "/home/testuser");
+    
+    g_strfreev(exec_start_argv);
+    g_free(working_dir);
+    g_variant_unref(props);
+}
+
+static void test_parse_service_props_working_directory_multiple_prefixes(void) {
+    GVariantBuilder dict_builder;
+    g_variant_builder_init(&dict_builder, G_VARIANT_TYPE("a{sv}"));
+
+    GVariantBuilder exec_builder;
+    g_variant_builder_init(&exec_builder, G_VARIANT_TYPE("a(sasbttuii)"));
+    GVariantBuilder argv_builder;
+    g_variant_builder_init(&argv_builder, G_VARIANT_TYPE("as"));
+    g_variant_builder_add(&argv_builder, "s", "test");
+    g_variant_builder_add(&exec_builder, "(s@asbttuii)", "test", g_variant_builder_end(&argv_builder), FALSE, (guint64)0, (guint64)0, (guint32)0, (gint32)0, (gint32)0);
+    g_variant_builder_add(&dict_builder, "{sv}", "ExecStart", g_variant_builder_end(&exec_builder));
+    
+    g_variant_builder_add(&dict_builder, "{sv}", "WorkingDirectory", g_variant_new_string("-!/opt/openclaw"));
+    
+    GVariant *props = g_variant_builder_end(&dict_builder);
+    
+    gchar **exec_start_argv = NULL;
+    gchar *working_dir = NULL;
+    gchar **env = NULL;
+    
+    gboolean success = systemd_parse_service_properties(props, "/home/test", &exec_start_argv, &working_dir, &env);
+    
+    g_assert_true(success);
+    g_assert_cmpstr(working_dir, ==, "/opt/openclaw");
+    
+    g_strfreev(exec_start_argv);
+    g_free(working_dir);
+    g_variant_unref(props);
+}
+
+static void test_parse_service_props_invalid_working_directory(void) {
+    GVariantBuilder dict_builder;
+    g_variant_builder_init(&dict_builder, G_VARIANT_TYPE("a{sv}"));
+
+    GVariantBuilder exec_builder;
+    g_variant_builder_init(&exec_builder, G_VARIANT_TYPE("a(sasbttuii)"));
+    GVariantBuilder argv_builder;
+    g_variant_builder_init(&argv_builder, G_VARIANT_TYPE("as"));
+    g_variant_builder_add(&argv_builder, "s", "test");
+    g_variant_builder_add(&exec_builder, "(s@asbttuii)", "test", g_variant_builder_end(&argv_builder), FALSE, (guint64)0, (guint64)0, (guint32)0, (gint32)0, (gint32)0);
+    g_variant_builder_add(&dict_builder, "{sv}", "ExecStart", g_variant_builder_end(&exec_builder));
+    
+    // Not an absolute path after stripping -> should fail
+    g_variant_builder_add(&dict_builder, "{sv}", "WorkingDirectory", g_variant_new_string("!relative/path"));
+    
+    GVariant *props = g_variant_builder_end(&dict_builder);
+    
+    gchar **exec_start_argv = NULL;
+    gchar *working_dir = NULL;
+    gchar **env = NULL;
+    
+    gboolean success = systemd_parse_service_properties(props, "/home/test", &exec_start_argv, &working_dir, &env);
+    
+    g_assert_false(success);
+    g_assert_null(exec_start_argv);
+    g_assert_null(working_dir);
+    g_assert_null(env);
+    
+    g_variant_unref(props);
+}
+
+static void test_parse_service_props_invalid_signature(void) {
+    GVariantBuilder dict_builder;
+    g_variant_builder_init(&dict_builder, G_VARIANT_TYPE("a{sv}"));
+
+    // Create an unsupported signature
+    GVariantBuilder exec_builder;
+    g_variant_builder_init(&exec_builder, G_VARIANT_TYPE("a(s)"));
+    g_variant_builder_add(&exec_builder, "(s)", "test");
+    g_variant_builder_add(&dict_builder, "{sv}", "ExecStart", g_variant_builder_end(&exec_builder));
+    
+    GVariant *props = g_variant_builder_end(&dict_builder);
+    
+    gchar **exec_start_argv = NULL;
+    gchar *working_dir = NULL;
+    gchar **env = NULL;
+    
+    // Expect a warning log about unexpected signature
+    g_test_expect_message(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, "*Unexpected ExecStart GVariant signature*");
+    
+    gboolean success = systemd_parse_service_properties(props, "/home/test", &exec_start_argv, &working_dir, &env);
+    
+    g_test_assert_expected_messages();
+    
+    g_assert_false(success);
+    g_assert_null(exec_start_argv);
+    
+    g_variant_unref(props);
+}
+
 int main(int argc, char **argv) {
     g_test_init(&argc, &argv, NULL);
     
@@ -197,6 +399,13 @@ int main(int argc, char **argv) {
 
     g_test_add_func("/systemd/env_file_parsing", test_env_file_parsing);
     g_test_add_func("/systemd/optional_env_file", test_optional_env_file);
+    
+    g_test_add_func("/systemd/parse_service_props_old_signature", test_parse_service_props_old_signature);
+    g_test_add_func("/systemd/parse_service_props_new_signature", test_parse_service_props_new_signature);
+    g_test_add_func("/systemd/parse_service_props_working_directory_normalization", test_parse_service_props_working_directory_normalization);
+    g_test_add_func("/systemd/parse_service_props_working_directory_multiple_prefixes", test_parse_service_props_working_directory_multiple_prefixes);
+    g_test_add_func("/systemd/parse_service_props_invalid_working_directory", test_parse_service_props_invalid_working_directory);
+    g_test_add_func("/systemd/parse_service_props_invalid_signature", test_parse_service_props_invalid_signature);
     
     return g_test_run();
 }


### PR DESCRIPTION
Remove apply_service_config_from_variant() from systemd.c. Add a pure systemd_parse_service_properties() helper to systemd_helpers.c that parses Service D-Bus properties into output parameters without touching any global cache, returning TRUE only when the result is usable.

ExecStart: inspect the runtime GVariant type string and dispatch to the correct format. Support both observed signatures: a(sasbttuii) and a(sasbttttuii). Log a warning and return FALSE for any other type. Require non-empty argv for success.

WorkingDirectory: strip leading ! and - syntactic modifiers conservatively. Accept the result only if it is empty or begins with /. Return FALSE for non-absolute non-empty results after stripping.

Environment / EnvironmentFiles: parse inline Environment as strv, then EnvironmentFiles as a(sb) via systemd_parse_single_env_file. Validate EnvironmentFiles type string before iterating.

In on_get_service_properties_ready(): call systemd_parse_service_properties() into local variables. On success, replace cached_exec_start_argv, cached_working_directory, and cached_environment and set config_loaded=TRUE. On failure, free locals and leave the cache untouched so the file-based fallback path proceeds unmodified.

Tests: add six regression tests in test_systemd_helpers.c covering both ExecStart signatures, WorkingDirectory normalization (single and compound prefixes), invalid working directory rejection, and unsupported signature rejection.