### PR TITLE
fix(linux): unit discovery and probe stability (#30)

### DIFF
--- a/apps/linux/src/health.c
+++ b/apps/linux/src/health.c
@@ -315,12 +315,19 @@ static void on_health_probe_finished(GObject *source_object, GAsyncResult *res, 
         goto check_pending;
     }
     
+    if (!comm_ok) {
+        // Do not publish a zeroed health state if we couldn't communicate with the probe
+        g_free(stdout_buf);
+        g_free(stderr_buf);
+        goto check_pending;
+    }
+    
     HealthState hs = {0};
     
-    if (comm_ok && !error && g_subprocess_get_if_exited(subprocess) && g_subprocess_get_exit_status(subprocess) == 0) {
+    if (!error && g_subprocess_get_if_exited(subprocess) && g_subprocess_get_exit_status(subprocess) == 0) {
         hs.last_updated = g_get_real_time();
         parse_health_json(stdout_buf, &hs);
-    } else if (comm_ok) {
+    } else {
         // Subprocess ran but exited non-zero — still mark timestamp so stale data is cleared
         hs.last_updated = g_get_real_time();
     }

--- a/apps/linux/src/systemd.c
+++ b/apps/linux/src/systemd.c
@@ -36,44 +36,36 @@ extern void systemd_refresh(void);
 static void clear_unit_subscription(const gchar *reason);
 
 static gboolean check_system_scope_units(void) {
-    const gchar *paths[] = {"/etc/systemd/system", "/usr/lib/systemd/system", "/lib/systemd/system"};
-    for (size_t i = 0; i < G_N_ELEMENTS(paths); i++) {
-        GDir *dir = g_dir_open(paths[i], 0, NULL);
+    GPtrArray *paths = systemd_helpers_get_system_unit_paths();
+    gboolean found = FALSE;
+    for (guint i = 0; i < paths->len; i++) {
+        const gchar *path = g_ptr_array_index(paths, i);
+        GDir *dir = g_dir_open(path, 0, NULL);
         if (!dir) continue;
         const gchar *filename;
         while ((filename = g_dir_read_name(dir)) != NULL) {
             if (g_str_has_suffix(filename, ".service")) {
-                g_autofree gchar *filepath = g_build_filename(paths[i], filename, NULL);
+                g_autofree gchar *filepath = g_build_filename(path, filename, NULL);
                 gchar *contents = NULL;
                 if (g_file_get_contents(filepath, &contents, NULL, NULL)) {
                     if (systemd_is_gateway_unit(filename, contents)) {
+                        found = TRUE;
                         g_free(contents);
-                        g_dir_close(dir);
-                        return TRUE;
+                        break;
                     }
                     g_free(contents);
                 }
             }
         }
         g_dir_close(dir);
+        if (found) break;
     }
-    return FALSE;
+    g_ptr_array_free(paths, TRUE);
+    return found;
 }
 
 static gint sort_marked_units(gconstpointer a, gconstpointer b) {
     return g_strcmp0(*(const gchar **)a, *(const gchar **)b);
-}
-
-static GPtrArray* systemd_get_user_unit_paths(const gchar *home_dir) {
-    GPtrArray *paths = g_ptr_array_new_with_free_func(g_free);
-    if (home_dir) {
-        g_ptr_array_add(paths, g_build_filename(home_dir, ".config", "systemd", "user", NULL));
-        g_ptr_array_add(paths, g_build_filename(home_dir, ".local", "share", "systemd", "user", NULL));
-    }
-    g_ptr_array_add(paths, g_strdup("/etc/systemd/user"));
-    g_ptr_array_add(paths, g_strdup("/usr/lib/systemd/user"));
-    g_ptr_array_add(paths, g_strdup("/lib/systemd/user"));
-    return paths;
 }
 
 const gchar* systemd_get_canonical_unit_name(void) {
@@ -82,7 +74,7 @@ const gchar* systemd_get_canonical_unit_name(void) {
     const gchar *home_dir = g_get_home_dir();
 
     GPtrArray *marked_units = g_ptr_array_new_with_free_func(g_free);
-    GPtrArray *paths = systemd_get_user_unit_paths(home_dir);
+    GPtrArray *paths = systemd_helpers_get_user_unit_paths(home_dir);
 
     for (guint i = 0; i < paths->len; i++) {
         const gchar *path = g_ptr_array_index(paths, i);
@@ -141,7 +133,17 @@ const gchar* systemd_get_canonical_unit_name(void) {
         return cached_unit_name;
     }
 
-    if (marked_units->len >= 1) {
+    gboolean has_default = FALSE;
+    for (guint i = 0; i < marked_units->len; i++) {
+        if (g_strcmp0("openclaw-gateway.service", (const gchar *)g_ptr_array_index(marked_units, i)) == 0) {
+            has_default = TRUE;
+            break;
+        }
+    }
+
+    if (has_default) {
+        cached_unit_name = g_strdup("openclaw-gateway.service");
+    } else if (marked_units->len >= 1) {
         g_ptr_array_sort(marked_units, sort_marked_units);
         cached_unit_name = g_strdup(g_ptr_array_index(marked_units, 0));
     } else {
@@ -164,7 +166,7 @@ static void extract_service_config_from_file(gchar **exec_start_out, gchar ***en
     g_autoptr(GError) error = NULL;
     gchar *unit_path = NULL;
 
-    GPtrArray *paths = systemd_get_user_unit_paths(home_dir);
+    GPtrArray *paths = systemd_helpers_get_user_unit_paths(home_dir);
     for (guint i = 0; i < paths->len; i++) {
         gchar *test_path = g_build_filename(g_ptr_array_index(paths, i), unit_name, NULL);
         if (g_file_get_contents(test_path, &contents, NULL, &error)) {
@@ -464,14 +466,27 @@ static void on_get_service_properties_ready(GObject *source_object, GAsyncResult
     if (!config_loaded) {
         OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_service_properties_ready D-Bus Service props unavailable, falling back to file parse");
         gchar *fallback_exec = NULL;
-        extract_service_config_from_file(&fallback_exec, &cached_environment, &cached_working_directory);
-        if (fallback_exec) {
-            gint argcp;
-            gchar **argvp = NULL;
-            if (g_shell_parse_argv(fallback_exec, &argcp, &argvp, NULL)) {
-                cached_exec_start_argv = argvp;
+        gchar **fallback_env = NULL;
+        gchar *fallback_wd = NULL;
+        extract_service_config_from_file(&fallback_exec, &fallback_env, &fallback_wd);
+        if (fallback_exec || fallback_env || fallback_wd) {
+            if (fallback_exec) {
+                gint argcp;
+                gchar **argvp = NULL;
+                if (g_shell_parse_argv(fallback_exec, &argcp, &argvp, NULL)) {
+                    g_strfreev(cached_exec_start_argv);
+                    cached_exec_start_argv = argvp;
+                }
+                g_free(fallback_exec);
             }
-            g_free(fallback_exec);
+            if (fallback_env) {
+                g_strfreev(cached_environment);
+                cached_environment = fallback_env;
+            }
+            if (fallback_wd) {
+                g_free(cached_working_directory);
+                cached_working_directory = fallback_wd;
+            }
         }
     }
 

--- a/apps/linux/src/systemd_helpers.c
+++ b/apps/linux/src/systemd_helpers.c
@@ -1,3 +1,17 @@
+/*
+ * systemd_helpers.c
+ *
+ * Helper functions for systemd integration in the OpenClaw Linux Companion App.
+ *
+ * Provides utilities for:
+ * - Identifying OpenClaw gateway unit files by name and content
+ * - Normalizing environment variable overrides and profile names
+ * - Parsing systemd service properties from D-Bus
+ * - Discovering systemd unit files across all standard search paths
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
 #include "systemd_helpers.h"
 #include "log.h"
 #include <string.h>
@@ -127,6 +141,30 @@ gchar* systemd_normalize_profile(const gchar *raw_profile) {
     }
     g_free(trimmed);
     return res;
+}
+
+GPtrArray* systemd_helpers_get_user_unit_paths(const gchar *home_dir) {
+    GPtrArray *paths = g_ptr_array_new_with_free_func(g_free);
+    if (home_dir) {
+        g_ptr_array_add(paths, g_build_filename(home_dir, ".config", "systemd", "user", NULL));
+        g_ptr_array_add(paths, g_build_filename(home_dir, ".local", "share", "systemd", "user", NULL));
+    }
+    g_ptr_array_add(paths, g_strdup("/etc/systemd/user"));
+    g_ptr_array_add(paths, g_strdup("/etc/xdg/systemd/user"));
+    g_ptr_array_add(paths, g_strdup("/usr/lib/systemd/user"));
+    g_ptr_array_add(paths, g_strdup("/usr/local/lib/systemd/user"));
+    g_ptr_array_add(paths, g_strdup("/usr/share/systemd/user"));
+    g_ptr_array_add(paths, g_strdup("/lib/systemd/user"));
+    return paths;
+}
+
+GPtrArray* systemd_helpers_get_system_unit_paths(void) {
+    GPtrArray *paths = g_ptr_array_new_with_free_func(g_free);
+    g_ptr_array_add(paths, g_strdup("/etc/systemd/system"));
+    g_ptr_array_add(paths, g_strdup("/usr/lib/systemd/system"));
+    g_ptr_array_add(paths, g_strdup("/usr/local/lib/systemd/system"));
+    g_ptr_array_add(paths, g_strdup("/lib/systemd/system"));
+    return paths;
 }
 
 gboolean systemd_parse_service_properties(GVariant *props, const gchar *home_dir, gchar ***exec_start_argv_out, gchar **working_directory_out, gchar ***environment_out) {

--- a/apps/linux/src/systemd_helpers.h
+++ b/apps/linux/src/systemd_helpers.h
@@ -8,6 +8,9 @@ gboolean systemd_is_gateway_unit(const gchar *filename, const gchar *contents);
 gchar* systemd_normalize_unit_override(const gchar *raw_unit);
 gchar* systemd_normalize_profile(const gchar *raw_profile);
 
+GPtrArray* systemd_helpers_get_user_unit_paths(const gchar *home_dir);
+GPtrArray* systemd_helpers_get_system_unit_paths(void);
+
 gboolean systemd_parse_service_properties(GVariant *props, const gchar *home_dir, gchar ***exec_start_argv_out, gchar **working_directory_out, gchar ***environment_out);
 
 // Exposed for testing

--- a/apps/linux/tests/test_systemd_helpers.c
+++ b/apps/linux/tests/test_systemd_helpers.c
@@ -369,6 +369,66 @@ static void test_parse_service_props_invalid_signature(void) {
     g_variant_unref(props);
 }
 
+static void test_helpers_get_user_unit_paths_contains_all(void) {
+    GPtrArray *paths = systemd_helpers_get_user_unit_paths("/home/test");
+    
+    gboolean found_config = FALSE;
+    gboolean found_local_share = FALSE;
+    gboolean found_etc = FALSE;
+    gboolean found_xdg = FALSE;
+    gboolean found_usr_lib = FALSE;
+    gboolean found_usr_local_lib = FALSE;
+    gboolean found_usr_share = FALSE;
+    gboolean found_lib = FALSE;
+
+    for (guint i = 0; i < paths->len; i++) {
+        const gchar *path = g_ptr_array_index(paths, i);
+        if (g_strcmp0(path, "/home/test/.config/systemd/user") == 0) found_config = TRUE;
+        if (g_strcmp0(path, "/home/test/.local/share/systemd/user") == 0) found_local_share = TRUE;
+        if (g_strcmp0(path, "/etc/systemd/user") == 0) found_etc = TRUE;
+        if (g_strcmp0(path, "/etc/xdg/systemd/user") == 0) found_xdg = TRUE;
+        if (g_strcmp0(path, "/usr/lib/systemd/user") == 0) found_usr_lib = TRUE;
+        if (g_strcmp0(path, "/usr/local/lib/systemd/user") == 0) found_usr_local_lib = TRUE;
+        if (g_strcmp0(path, "/usr/share/systemd/user") == 0) found_usr_share = TRUE;
+        if (g_strcmp0(path, "/lib/systemd/user") == 0) found_lib = TRUE;
+    }
+    
+    g_assert_true(found_config);
+    g_assert_true(found_local_share);
+    g_assert_true(found_etc);
+    g_assert_true(found_xdg);
+    g_assert_true(found_usr_lib);
+    g_assert_true(found_usr_local_lib);
+    g_assert_true(found_usr_share);
+    g_assert_true(found_lib);
+    
+    g_ptr_array_free(paths, TRUE);
+}
+
+static void test_helpers_get_system_unit_paths_contains_all(void) {
+    GPtrArray *paths = systemd_helpers_get_system_unit_paths();
+    
+    gboolean found_etc = FALSE;
+    gboolean found_usr_lib = FALSE;
+    gboolean found_usr_local_lib = FALSE;
+    gboolean found_lib = FALSE;
+
+    for (guint i = 0; i < paths->len; i++) {
+        const gchar *path = g_ptr_array_index(paths, i);
+        if (g_strcmp0(path, "/etc/systemd/system") == 0) found_etc = TRUE;
+        if (g_strcmp0(path, "/usr/lib/systemd/system") == 0) found_usr_lib = TRUE;
+        if (g_strcmp0(path, "/usr/local/lib/systemd/system") == 0) found_usr_local_lib = TRUE;
+        if (g_strcmp0(path, "/lib/systemd/system") == 0) found_lib = TRUE;
+    }
+    
+    g_assert_true(found_etc);
+    g_assert_true(found_usr_lib);
+    g_assert_true(found_usr_local_lib);
+    g_assert_true(found_lib);
+    
+    g_ptr_array_free(paths, TRUE);
+}
+
 int main(int argc, char **argv) {
     g_test_init(&argc, &argv, NULL);
     
@@ -406,6 +466,9 @@ int main(int argc, char **argv) {
     g_test_add_func("/systemd/parse_service_props_working_directory_multiple_prefixes", test_parse_service_props_working_directory_multiple_prefixes);
     g_test_add_func("/systemd/parse_service_props_invalid_working_directory", test_parse_service_props_invalid_working_directory);
     g_test_add_func("/systemd/parse_service_props_invalid_signature", test_parse_service_props_invalid_signature);
+    
+    g_test_add_func("/systemd/helpers_get_user_unit_paths_contains_all", test_helpers_get_user_unit_paths_contains_all);
+    g_test_add_func("/systemd/helpers_get_system_unit_paths_contains_all", test_helpers_get_system_unit_paths_contains_all);
     
     return g_test_run();
 }


### PR DESCRIPTION
systemd_helpers.c/.h: add systemd_helpers_get_user_unit_paths(home_dir) returning 8 standard user unit paths (~/.config/systemd/user, ~/.local/share/systemd/user, /etc/systemd/user, /etc/xdg/systemd/user, /usr/lib/systemd/user, /usr/local/lib/systemd/user, /usr/share/systemd/user, /lib/systemd/user) and systemd_helpers_get_system_unit_paths() returning 4 system paths (/etc/systemd/system, /usr/lib/systemd/system, /usr/local/lib/systemd/system, /lib/systemd/system). Add file header comment.

systemd.c: remove private systemd_get_user_unit_paths(); update systemd_get_canonical_unit_name(), extract_service_config_from_file(), and check_system_scope_units() to use the new shared helpers. Fix check_system_scope_units() to use a local found flag and break cleanly instead of returning from inside a nested loop, then free the paths array.

systemd.c: in systemd_get_canonical_unit_name(), before sorting, check whether openclaw-gateway.service is present in marked_units; if found, select it directly without sorting. Lexical sort + index 0 only applies when the default unit is absent.

systemd.c: in on_get_service_properties_ready(), parse fallback config into local fallback_exec, fallback_env, fallback_wd. Free and replace each cached field individually only when the corresponding local is non-NULL, preventing memory leaks on repeated D-Bus fallback invocations.

health.c: add an early return on !comm_ok before HealthState hs = {0}, freeing stdout_buf/stderr_buf and jumping to check_pending. Remove the now-redundant comm_ok condition from the success branch.

tests: add test_helpers_get_user_unit_paths_contains_all and test_helpers_get_system_unit_paths_contains_all to test_systemd_helpers.c asserting all expected paths are present in the respective arrays.