### PR TITLE
feat(linux): fix runtime-context config resolution and hello-ok validation (#34)

### DIFF
--- a/apps/linux/src/gateway_client.c
+++ b/apps/linux/src/gateway_client.c
@@ -30,6 +30,33 @@ static gboolean initialized = FALSE;
 static guint health_poll_timer_id = 0;
 #define HEALTH_POLL_INTERVAL_S 10
 
+static GatewayConfig* load_config_with_context(void) {
+    GatewayConfigContext ctx = {0};
+    gchar *derived_state_dir = NULL;
+    gchar *derived_profile = NULL;
+    gchar *derived_config_path = NULL;
+
+    systemd_get_runtime_context(&derived_profile, &derived_state_dir, &derived_config_path);
+
+    if (derived_config_path) {
+        ctx.explicit_config_path = derived_config_path;
+    }
+    if (derived_state_dir) {
+        ctx.effective_state_dir = derived_state_dir;
+    }
+    if (derived_profile) {
+        ctx.profile = derived_profile;
+    }
+
+    GatewayConfig *cfg = gateway_config_load(&ctx);
+    
+    g_free(derived_config_path);
+    g_free(derived_state_dir);
+    g_free(derived_profile);
+    
+    return cfg;
+}
+
 static void publish_health_state(gboolean http_ok, gboolean ws_connected,
                                   gboolean rpc_ok, gboolean auth_ok,
                                   const gchar *gateway_version,
@@ -206,7 +233,7 @@ void gateway_client_init(void) {
     gateway_ws_init();
 
     /* Load config */
-    current_config = gateway_config_load();
+    current_config = load_config_with_context();
     if (!current_config || !current_config->valid) {
         OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY, "gateway config invalid: %s",
                   current_config ? current_config->error : "load failed");
@@ -224,7 +251,7 @@ void gateway_client_refresh(void) {
     }
 
     /* Always reload config */
-    GatewayConfig *new_config = gateway_config_load();
+    GatewayConfig *new_config = load_config_with_context();
     gboolean equivalent = gateway_config_equivalent(current_config, new_config);
 
     if (equivalent) {

--- a/apps/linux/src/gateway_config.c
+++ b/apps/linux/src/gateway_config.c
@@ -25,10 +25,18 @@
 #include <json-glib/json-glib.h>
 #include <string.h>
 
-static gchar* resolve_config_path(void) {
+static gchar* resolve_config_path(const GatewayConfigContext *ctx) {
     const gchar *override = g_getenv("OPENCLAW_CONFIG_PATH");
     if (override && override[0] != '\0') {
         return g_strdup(override);
+    }
+
+    if (ctx && ctx->explicit_config_path && ctx->explicit_config_path[0] != '\0') {
+        return g_strdup(ctx->explicit_config_path);
+    }
+
+    if (ctx && ctx->effective_state_dir && ctx->effective_state_dir[0] != '\0') {
+        return g_build_filename(ctx->effective_state_dir, "openclaw.json", NULL);
     }
 
     const gchar *state_dir_override = g_getenv("OPENCLAW_STATE_DIR");
@@ -42,7 +50,7 @@ static gchar* resolve_config_path(void) {
         return NULL;
     }
 
-    /* Primary: ~/.openclaw/openclaw.json */
+    /* Primary fallback: ~/.openclaw/openclaw.json */
     gchar *primary = g_build_filename(home, ".openclaw", "openclaw.json", NULL);
     if (g_file_test(primary, G_FILE_TEST_EXISTS)) {
         return primary;
@@ -109,15 +117,25 @@ static void resolve_auth(JsonObject *auth_obj, GatewayConfig *config) {
             }
         }
         if (json_object_has_member(auth_obj, "token")) {
-            const gchar *tok = json_object_get_string_member(auth_obj, "token");
-            if (tok && tok[0] != '\0') {
-                cfg_token = g_strdup(tok);
+            JsonNode *tok_node = json_object_get_member(auth_obj, "token");
+            if (JSON_NODE_HOLDS_OBJECT(tok_node)) {
+                config->token_is_secret_ref = TRUE;
+            } else if (json_node_get_value_type(tok_node) == G_TYPE_STRING) {
+                const gchar *tok = json_node_get_string(tok_node);
+                if (tok && tok[0] != '\0') {
+                    cfg_token = g_strdup(tok);
+                }
             }
         }
         if (json_object_has_member(auth_obj, "password")) {
-            const gchar *pw = json_object_get_string_member(auth_obj, "password");
-            if (pw && pw[0] != '\0') {
-                cfg_password = g_strdup(pw);
+            JsonNode *pw_node = json_object_get_member(auth_obj, "password");
+            if (JSON_NODE_HOLDS_OBJECT(pw_node)) {
+                config->password_is_secret_ref = TRUE;
+            } else if (json_node_get_value_type(pw_node) == G_TYPE_STRING) {
+                const gchar *pw = json_node_get_string(pw_node);
+                if (pw && pw[0] != '\0') {
+                    cfg_password = g_strdup(pw);
+                }
             }
         }
     }
@@ -127,19 +145,21 @@ static void resolve_auth(JsonObject *auth_obj, GatewayConfig *config) {
     if (env_token && env_token[0] != '\0') {
         g_free(cfg_token);
         cfg_token = g_strdup(env_token);
+        config->token_is_secret_ref = FALSE;
     }
 
     const gchar *env_password = g_getenv("OPENCLAW_GATEWAY_PASSWORD");
     if (env_password && env_password[0] != '\0') {
         g_free(cfg_password);
         cfg_password = g_strdup(env_password);
+        config->password_is_secret_ref = FALSE;
     }
 
     /* 3. Infer auth_mode if not explicitly set (matches gateway server auth.ts:256-268) */
     if (!cfg_auth_mode) {
-        if (cfg_password) {
+        if (cfg_password || config->password_is_secret_ref) {
             cfg_auth_mode = g_strdup("password");
-        } else if (cfg_token) {
+        } else if (cfg_token || config->token_is_secret_ref) {
             cfg_auth_mode = g_strdup("token");
         } else {
             cfg_auth_mode = g_strdup("token");
@@ -168,33 +188,49 @@ static gboolean validate_auth(GatewayConfig *config) {
         return FALSE;
     }
 
-    if (g_strcmp0(config->auth_mode, "token") == 0 && !config->token) {
-        config->valid = FALSE;
-        config->error_code = GW_CFG_ERR_TOKEN_MISSING;
-        config->error = g_strdup(
-            "Gateway auth mode is token, but no token was configured "
-            "(set gateway.auth.token or OPENCLAW_GATEWAY_TOKEN)");
-        return FALSE;
+    if (g_strcmp0(config->auth_mode, "token") == 0) {
+        if (config->token_is_secret_ref) {
+            config->valid = FALSE;
+            config->error_code = GW_CFG_ERR_SECRET_REF_UNSUPPORTED;
+            config->error = g_strdup("Gateway token is configured as a SecretRef object, which is not yet supported by the Linux companion.");
+            return FALSE;
+        }
+        if (!config->token) {
+            config->valid = FALSE;
+            config->error_code = GW_CFG_ERR_TOKEN_MISSING;
+            config->error = g_strdup(
+                "Gateway auth mode is token, but no token was configured "
+                "(set gateway.auth.token or OPENCLAW_GATEWAY_TOKEN)");
+            return FALSE;
+        }
     }
 
-    if (g_strcmp0(config->auth_mode, "password") == 0 && !config->password) {
-        config->valid = FALSE;
-        config->error_code = GW_CFG_ERR_PASSWORD_MISSING;
-        config->error = g_strdup(
-            "Gateway auth mode is password, but no password was configured "
-            "(set gateway.auth.password or OPENCLAW_GATEWAY_PASSWORD)");
-        return FALSE;
+    if (g_strcmp0(config->auth_mode, "password") == 0) {
+        if (config->password_is_secret_ref) {
+            config->valid = FALSE;
+            config->error_code = GW_CFG_ERR_SECRET_REF_UNSUPPORTED;
+            config->error = g_strdup("Gateway password is configured as a SecretRef object, which is not yet supported by the Linux companion.");
+            return FALSE;
+        }
+        if (!config->password) {
+            config->valid = FALSE;
+            config->error_code = GW_CFG_ERR_PASSWORD_MISSING;
+            config->error = g_strdup(
+                "Gateway auth mode is password, but no password was configured "
+                "(set gateway.auth.password or OPENCLAW_GATEWAY_PASSWORD)");
+            return FALSE;
+        }
     }
 
     return TRUE;
 }
 
-GatewayConfig* gateway_config_load(void) {
+GatewayConfig* gateway_config_load(const GatewayConfigContext *ctx) {
     GatewayConfig *config = g_new0(GatewayConfig, 1);
     config->host = g_strdup(GATEWAY_DEFAULT_HOST);
     config->port = GATEWAY_DEFAULT_PORT;
     config->error_code = GW_CFG_OK;
-    config->config_path = resolve_config_path();
+    config->config_path = resolve_config_path(ctx);
 
     if (!config->config_path) {
         config->valid = FALSE;
@@ -343,6 +379,8 @@ gboolean gateway_config_equivalent(const GatewayConfig *a, const GatewayConfig *
     /* credentials */
     if (g_strcmp0(a->token, b->token) != 0) return FALSE;
     if (g_strcmp0(a->password, b->password) != 0) return FALSE;
+    if (a->token_is_secret_ref != b->token_is_secret_ref) return FALSE;
+    if (a->password_is_secret_ref != b->password_is_secret_ref) return FALSE;
 
     /* Derived normalized URLs (catches any normalization edge cases) */
     g_autofree gchar *a_http = gateway_config_http_url(a);

--- a/apps/linux/src/gateway_config.h
+++ b/apps/linux/src/gateway_config.h
@@ -33,22 +33,31 @@ typedef enum {
     GW_CFG_ERR_TOKEN_MISSING,
     GW_CFG_ERR_PASSWORD_MISSING,
     GW_CFG_ERR_READ_FAILED,
+    GW_CFG_ERR_SECRET_REF_UNSUPPORTED,
 } GatewayConfigError;
+
+typedef struct {
+    const gchar *explicit_config_path;
+    const gchar *effective_state_dir;
+    const gchar *profile;
+} GatewayConfigContext;
 
 typedef struct {
     gchar *mode;           /* gateway.mode: "local" or other (NULL treated as local) */
     gchar *host;           /* effective bind host (default 127.0.0.1) */
     gint port;             /* effective port (default 18789) */
-    gchar *auth_mode;     /* gateway.auth.mode: "token", "password", "none" */
+    gchar *auth_mode;      /* gateway.auth.mode: "token", "password", "none" */
     gchar *token;          /* resolved auth token (config + env override) */
     gchar *password;       /* resolved auth password (config + env override) */
+    gboolean token_is_secret_ref;
+    gboolean password_is_secret_ref;
     gchar *config_path;    /* resolved config file path */
     gboolean valid;        /* whether config was loaded successfully */
     GatewayConfigError error_code; /* stable error discriminator */
     gchar *error;          /* human-readable error message */
 } GatewayConfig;
 
-GatewayConfig* gateway_config_load(void);
+GatewayConfig* gateway_config_load(const GatewayConfigContext *ctx);
 void gateway_config_free(GatewayConfig *config);
 gboolean gateway_config_is_local(const GatewayConfig *config);
 gchar* gateway_config_http_url(const GatewayConfig *config);

--- a/apps/linux/src/gateway_protocol.c
+++ b/apps/linux/src/gateway_protocol.c
@@ -224,23 +224,27 @@ gboolean gateway_protocol_parse_hello_ok(const GatewayFrame *frame,
 
     JsonObject *obj = json_node_get_object(frame->payload);
 
+    /* A valid connect response must have 'auth' and 'policy' objects */
+    if (!json_object_has_member(obj, "auth") || !json_object_has_member(obj, "policy")) {
+        return FALSE;
+    }
+
+    JsonObject *auth = json_object_get_object_member(obj, "auth");
+    JsonObject *policy = json_object_get_object_member(obj, "policy");
+
+    if (!auth || !policy) return FALSE;
+
     if (out_auth_source) {
         *out_auth_source = NULL;
-        if (json_object_has_member(obj, "auth")) {
-            JsonObject *auth = json_object_get_object_member(obj, "auth");
-            if (auth && json_object_has_member(auth, "source")) {
-                *out_auth_source = g_strdup(json_object_get_string_member(auth, "source"));
-            }
+        if (json_object_has_member(auth, "source")) {
+            *out_auth_source = g_strdup(json_object_get_string_member(auth, "source"));
         }
     }
 
     if (out_tick_interval_ms) {
         *out_tick_interval_ms = 30000.0;
-        if (json_object_has_member(obj, "policy")) {
-            JsonObject *policy = json_object_get_object_member(obj, "policy");
-            if (policy && json_object_has_member(policy, "tickIntervalMs")) {
-                *out_tick_interval_ms = json_object_get_double_member(policy, "tickIntervalMs");
-            }
+        if (json_object_has_member(policy, "tickIntervalMs")) {
+            *out_tick_interval_ms = json_object_get_double_member(policy, "tickIntervalMs");
         }
     }
 

--- a/apps/linux/src/gateway_ws.c
+++ b/apps/linux/src/gateway_ws.c
@@ -287,27 +287,33 @@ static void ws_handle_frame(const gchar *text) {
                 /* connect-ok */
                 gchar *auth_src = NULL;
                 gdouble tick_ms = DEFAULT_TICK_INTERVAL_MS;
-                gateway_protocol_parse_hello_ok(frame, &auth_src, &tick_ms);
+                
+                if (!gateway_protocol_parse_hello_ok(frame, &auth_src, &tick_ms)) {
+                    OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY, "ws protocol validation failed: malformed hello-ok response");
+                    ws_set_error("Protocol validation failed: invalid hello response");
+                    ws_set_state(GATEWAY_WS_ERROR);
+                    ws_cleanup_connection();
+                } else {
+                    g_free(ws_client->auth_source);
+                    ws_client->auth_source = auth_src;
+                    ws_client->tick_interval_ms = tick_ms;
+                    ws_client->rpc_ok = TRUE;
+                    ws_client->backoff_ms = BACKOFF_INITIAL_MS;
+                    ws_client->reconnect_paused_for_auth = FALSE;
+                    ws_client->last_tick_us = g_get_monotonic_time();
 
-                g_free(ws_client->auth_source);
-                ws_client->auth_source = auth_src;
-                ws_client->tick_interval_ms = tick_ms;
-                ws_client->rpc_ok = TRUE;
-                ws_client->backoff_ms = BACKOFF_INITIAL_MS;
-                ws_client->reconnect_paused_for_auth = FALSE;
-                ws_client->last_tick_us = g_get_monotonic_time();
+                    if (ws_client->connect_timeout_id) {
+                        g_source_remove(ws_client->connect_timeout_id);
+                        ws_client->connect_timeout_id = 0;
+                    }
 
-                if (ws_client->connect_timeout_id) {
-                    g_source_remove(ws_client->connect_timeout_id);
-                    ws_client->connect_timeout_id = 0;
+                    OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY, "ws connected auth_source=%s tick_ms=%.0f",
+                              auth_src ? auth_src : "none", tick_ms);
+
+                    ws_start_keepalive();
+                    ws_start_tick_watchdog();
+                    ws_set_state(GATEWAY_WS_CONNECTED);
                 }
-
-                OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY, "ws connected auth_source=%s tick_ms=%.0f",
-                          auth_src ? auth_src : "none", tick_ms);
-
-                ws_start_keepalive();
-                ws_start_tick_watchdog();
-                ws_set_state(GATEWAY_WS_CONNECTED);
             }
         }
         break;

--- a/apps/linux/src/state.h
+++ b/apps/linux/src/state.h
@@ -78,6 +78,7 @@ SystemdState* state_get_systemd(void);
 HealthState* state_get_health(void);
 
 const gchar* systemd_get_canonical_unit_name(void);
+void systemd_get_runtime_context(gchar **out_profile, gchar **out_state_dir, gchar **out_config_path);
 
 /* Callbacks (implemented elsewhere) */
 void notify_on_transition(AppState old_state, AppState new_state);

--- a/apps/linux/src/systemd.c
+++ b/apps/linux/src/systemd.c
@@ -154,6 +154,46 @@ const gchar* systemd_get_canonical_unit_name(void) {
     return cached_unit_name;
 }
 
+void systemd_get_runtime_context(gchar **out_profile, gchar **out_state_dir, gchar **out_config_path) {
+    if (out_profile) *out_profile = NULL;
+    if (out_state_dir) *out_state_dir = NULL;
+    if (out_config_path) *out_config_path = NULL;
+
+    const gchar *unit = systemd_get_canonical_unit_name();
+    if (!unit) return;
+
+    /* Profile label derived from unit name (informational only, not used for path derivation) */
+    if (out_profile) {
+        if (g_str_has_prefix(unit, "openclaw-gateway-") && g_str_has_suffix(unit, ".service")) {
+            *out_profile = g_strndup(unit + 17, strlen(unit) - 17 - 8);
+        } else if (g_strcmp0(unit, "openclaw-gateway.service") == 0) {
+            *out_profile = g_strdup("default");
+        }
+    }
+
+    /*
+     * Read the authoritative runtime context from the unit file's Environment= directives.
+     * This is the same environment the gateway service receives at runtime, set by the
+     * installer (src/daemon/systemd-unit.ts:renderEnvLines).
+     */
+    const gchar *home_override = g_getenv("OPENCLAW_HOME");
+    const gchar *home_dir = (home_override && home_override[0] != '\0') ? home_override : g_get_home_dir();
+    g_autofree gchar *unit_file_path = systemd_helpers_find_unit_file(unit, home_dir);
+    if (!unit_file_path) return;
+
+    gchar *contents = NULL;
+    if (!g_file_get_contents(unit_file_path, &contents, NULL, NULL)) return;
+
+    if (out_state_dir) {
+        *out_state_dir = systemd_helpers_parse_unit_env(contents, "OPENCLAW_STATE_DIR");
+    }
+    if (out_config_path) {
+        *out_config_path = systemd_helpers_parse_unit_env(contents, "OPENCLAW_CONFIG_PATH");
+    }
+
+    g_free(contents);
+}
+
 static void clear_unit_subscription(const gchar *reason) {
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "clear-start reason=%s proxy=%p signal_id=%u unit=%s",
               reason, (void *)unit_proxy, properties_changed_signal_id,

--- a/apps/linux/src/systemd_helpers.c
+++ b/apps/linux/src/systemd_helpers.c
@@ -89,3 +89,84 @@ GPtrArray* systemd_helpers_get_system_unit_paths(void) {
     g_ptr_array_add(paths, g_strdup("/lib/systemd/system"));
     return paths;
 }
+
+gchar* systemd_helpers_find_unit_file(const gchar *unit_name, const gchar *home_dir) {
+    if (!unit_name) return NULL;
+
+    GPtrArray *paths = systemd_helpers_get_user_unit_paths(home_dir);
+    gchar *result = NULL;
+
+    for (guint i = 0; i < paths->len && !result; i++) {
+        gchar *candidate = g_build_filename(
+            (const gchar *)g_ptr_array_index(paths, i), unit_name, NULL);
+        if (g_file_test(candidate, G_FILE_TEST_EXISTS)) {
+            result = candidate;
+        } else {
+            g_free(candidate);
+        }
+    }
+
+    g_ptr_array_free(paths, TRUE);
+    return result;
+}
+
+gchar* systemd_helpers_parse_unit_env(const gchar *unit_contents, const gchar *key) {
+    if (!unit_contents || !key || key[0] == '\0') return NULL;
+
+    gchar *search_key = g_strdup_printf("%s=", key);
+    gsize search_key_len = strlen(search_key);
+    gchar **lines = g_strsplit(unit_contents, "\n", -1);
+    gchar *result = NULL;
+
+    for (gint i = 0; lines[i] && !result; i++) {
+        gchar *line = g_strstrip(g_strdup(lines[i]));
+
+        if (!g_str_has_prefix(line, "Environment=")) {
+            g_free(line);
+            continue;
+        }
+
+        /*
+         * The installer emits one Environment= per line, in one of these forms:
+         *   Environment=KEY=VALUE
+         *   Environment="KEY=VALUE"
+         * (see src/daemon/systemd-unit.ts:renderEnvLines)
+         *
+         * We strip the Environment= prefix, then an optional leading/trailing
+         * double-quote, then search for KEY= within the assignment body.
+         */
+        const gchar *body = line + 12; /* strlen("Environment=") */
+
+        /* Strip optional surrounding quotes */
+        gchar *unquoted;
+        gsize body_len = strlen(body);
+        if (body_len >= 2 && body[0] == '"' && body[body_len - 1] == '"') {
+            unquoted = g_strndup(body + 1, body_len - 2);
+        } else {
+            unquoted = g_strdup(body);
+        }
+
+        /* Find KEY= within the (possibly multi-assignment) body */
+        const gchar *pos = strstr(unquoted, search_key);
+        if (pos) {
+            /* Ensure KEY= is at start of body or preceded by a space (multi-val) */
+            if (pos == unquoted || *(pos - 1) == ' ') {
+                const gchar *val_start = pos + search_key_len;
+                const gchar *val_end = val_start;
+                while (*val_end && *val_end != ' ' && *val_end != '"') {
+                    val_end++;
+                }
+                if (val_end > val_start) {
+                    result = g_strndup(val_start, val_end - val_start);
+                }
+            }
+        }
+
+        g_free(unquoted);
+        g_free(line);
+    }
+
+    g_strfreev(lines);
+    g_free(search_key);
+    return result;
+}

--- a/apps/linux/src/systemd_helpers.h
+++ b/apps/linux/src/systemd_helpers.h
@@ -11,4 +11,7 @@ gchar* systemd_normalize_profile(const gchar *raw_profile);
 GPtrArray* systemd_helpers_get_user_unit_paths(const gchar *home_dir);
 GPtrArray* systemd_helpers_get_system_unit_paths(void);
 
+gchar* systemd_helpers_find_unit_file(const gchar *unit_name, const gchar *home_dir);
+gchar* systemd_helpers_parse_unit_env(const gchar *unit_contents, const gchar *key);
+
 #endif // OPENCLAW_LINUX_SYSTEMD_HELPERS_H

--- a/apps/linux/tests/test_gateway.c
+++ b/apps/linux/tests/test_gateway.c
@@ -34,7 +34,7 @@ static void test_config_defaults_no_token_is_invalid(void) {
     clear_env();
     g_setenv("OPENCLAW_HOME", "/nonexistent_test_home_12345", TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_assert_false(config->valid);
     g_assert_cmpint(config->error_code, ==, GW_CFG_ERR_TOKEN_MISSING);
@@ -53,7 +53,7 @@ static void test_config_env_port_override(void) {
     g_setenv("OPENCLAW_GATEWAY_PORT", "9999", TRUE);
     g_setenv("OPENCLAW_GATEWAY_TOKEN", "tok", TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_assert_true(config->valid);
     g_assert_cmpint(config->port, ==, 9999);
@@ -67,7 +67,7 @@ static void test_config_env_token_override(void) {
     g_setenv("OPENCLAW_HOME", "/nonexistent_test_home_12345", TRUE);
     g_setenv("OPENCLAW_GATEWAY_TOKEN", "test-token-123", TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_assert_true(config->valid);
     g_assert_cmpstr(config->token, ==, "test-token-123");
@@ -82,7 +82,7 @@ static void test_config_http_url(void) {
     g_setenv("OPENCLAW_HOME", "/nonexistent_test_home_12345", TRUE);
     g_setenv("OPENCLAW_GATEWAY_TOKEN", "tok", TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_autofree gchar *url = gateway_config_http_url(config);
     g_assert_cmpstr(url, ==, "http://127.0.0.1:18789");
@@ -96,7 +96,7 @@ static void test_config_ws_url(void) {
     g_setenv("OPENCLAW_HOME", "/nonexistent_test_home_12345", TRUE);
     g_setenv("OPENCLAW_GATEWAY_TOKEN", "tok", TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_autofree gchar *url = gateway_config_ws_url(config);
     g_assert_cmpstr(url, ==, "ws://127.0.0.1:18789");
@@ -114,7 +114,7 @@ static void test_config_invalid_json(void) {
     clear_env();
     g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_assert_false(config->valid);
     g_assert_cmpint(config->error_code, ==, GW_CFG_ERR_PARSE);
@@ -137,7 +137,7 @@ static void test_config_valid_json_with_auth_token(void) {
     clear_env();
     g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_assert_true(config->valid);
     g_assert_cmpint(config->error_code, ==, GW_CFG_OK);
@@ -163,7 +163,7 @@ static void test_config_auth_password_from_config(void) {
     clear_env();
     g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_assert_true(config->valid);
     g_assert_cmpstr(config->auth_mode, ==, "password");
@@ -186,7 +186,7 @@ static void test_config_auth_mode_none_no_credentials_needed(void) {
     clear_env();
     g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_assert_true(config->valid);
     g_assert_cmpstr(config->auth_mode, ==, "none");
@@ -209,7 +209,7 @@ static void test_config_auth_mode_inferred_from_password(void) {
     clear_env();
     g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_assert_true(config->valid);
     g_assert_cmpstr(config->auth_mode, ==, "password");
@@ -231,7 +231,7 @@ static void test_config_auth_unsupported_mode(void) {
     clear_env();
     g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_assert_false(config->valid);
     g_assert_cmpint(config->error_code, ==, GW_CFG_ERR_AUTH_MODE_UNSUPPORTED);
@@ -253,7 +253,7 @@ static void test_config_env_overrides_config_token(void) {
     g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
     g_setenv("OPENCLAW_GATEWAY_TOKEN", "env-token", TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_assert_true(config->valid);
     g_assert_cmpstr(config->token, ==, "env-token");
@@ -274,7 +274,7 @@ static void test_config_password_mode_missing_password(void) {
     clear_env();
     g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_assert_false(config->valid);
     g_assert_cmpint(config->error_code, ==, GW_CFG_ERR_PASSWORD_MISSING);
@@ -295,13 +295,99 @@ static void test_config_remote_mode_rejected(void) {
     clear_env();
     g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
 
-    GatewayConfig *config = gateway_config_load();
+    GatewayConfig *config = gateway_config_load(NULL);
     g_assert_nonnull(config);
     g_assert_false(config->valid);
     g_assert_cmpint(config->error_code, ==, GW_CFG_ERR_MODE_UNSUPPORTED);
     gateway_config_free(config);
 
     g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_secret_ref_unsupported(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"mode\":\"token\",\"token\":{\"_secret\":\"my-key\"}}}}", -1, NULL);
+
+    clear_env();
+    GatewayConfigContext ctx = { .explicit_config_path = config_path };
+    GatewayConfig *config = gateway_config_load(&ctx);
+
+    g_assert_nonnull(config);
+    g_assert_false(config->valid);
+    g_assert_cmpint(config->error_code, ==, GW_CFG_ERR_SECRET_REF_UNSUPPORTED);
+    gateway_config_free(config);
+
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_precedence_explicit_over_state_dir(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_autofree gchar *explicit_path = g_build_filename(tmpdir, "explicit.json", NULL);
+    g_autofree gchar *state_dir_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    
+    g_file_set_contents(explicit_path,
+        "{\"gateway\":{\"auth\":{\"mode\":\"none\"},\"port\":1001}}", -1, NULL);
+    g_file_set_contents(state_dir_path,
+        "{\"gateway\":{\"auth\":{\"mode\":\"none\"},\"port\":1002}}", -1, NULL);
+
+    clear_env();
+    GatewayConfigContext ctx = { 
+        .explicit_config_path = explicit_path,
+        .effective_state_dir = tmpdir
+    };
+    GatewayConfig *config = gateway_config_load(&ctx);
+
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    g_assert_cmpint(config->port, ==, 1001);
+    gateway_config_free(config);
+
+    g_unlink(explicit_path);
+    g_unlink(state_dir_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_precedence_state_dir_over_home(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_autofree gchar *state_dir = g_build_filename(tmpdir, "state", NULL);
+    g_autofree gchar *home_dir = g_build_filename(tmpdir, "home", NULL);
+    g_mkdir(state_dir, 0700);
+    g_mkdir(home_dir, 0700);
+    g_autofree gchar *home_dot = g_build_filename(home_dir, ".openclaw", NULL);
+    g_mkdir(home_dot, 0700);
+    
+    g_autofree gchar *state_path = g_build_filename(state_dir, "openclaw.json", NULL);
+    g_autofree gchar *home_path = g_build_filename(home_dot, "openclaw.json", NULL);
+
+    g_file_set_contents(state_path,
+        "{\"gateway\":{\"auth\":{\"mode\":\"none\"},\"port\":2001}}", -1, NULL);
+    g_file_set_contents(home_path,
+        "{\"gateway\":{\"auth\":{\"mode\":\"none\"},\"port\":2002}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_HOME", home_dir, TRUE);
+    GatewayConfigContext ctx = { 
+        .effective_state_dir = state_dir
+    };
+    GatewayConfig *config = gateway_config_load(&ctx);
+
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    g_assert_cmpint(config->port, ==, 2001);
+    gateway_config_free(config);
+
+    g_unlink(state_path);
+    g_unlink(home_path);
+    g_rmdir(state_dir);
+    g_rmdir(home_dot);
+    g_rmdir(home_dir);
     g_rmdir(tmpdir);
     clear_env();
 }
@@ -317,8 +403,8 @@ static void test_config_equiv_identical(void) {
     clear_env();
     g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
 
-    GatewayConfig *a = gateway_config_load();
-    GatewayConfig *b = gateway_config_load();
+    GatewayConfig *a = gateway_config_load(NULL);
+    GatewayConfig *b = gateway_config_load(NULL);
     g_assert_true(gateway_config_equivalent(a, b));
     gateway_config_free(a);
     gateway_config_free(b);
@@ -337,11 +423,11 @@ static void test_config_equiv_token_change_not_equivalent(void) {
 
     g_file_set_contents(config_path,
         "{\"gateway\":{\"auth\":{\"token\":\"token-A\"}}}", -1, NULL);
-    GatewayConfig *a = gateway_config_load();
+    GatewayConfig *a = gateway_config_load(NULL);
 
     g_file_set_contents(config_path,
         "{\"gateway\":{\"auth\":{\"token\":\"token-B\"}}}", -1, NULL);
-    GatewayConfig *b = gateway_config_load();
+    GatewayConfig *b = gateway_config_load(NULL);
 
     g_assert_false(gateway_config_equivalent(a, b));
     gateway_config_free(a);
@@ -361,11 +447,11 @@ static void test_config_equiv_auth_mode_change_not_equivalent(void) {
 
     g_file_set_contents(config_path,
         "{\"gateway\":{\"auth\":{\"mode\":\"token\",\"token\":\"tok\"}}}", -1, NULL);
-    GatewayConfig *a = gateway_config_load();
+    GatewayConfig *a = gateway_config_load(NULL);
 
     g_file_set_contents(config_path,
         "{\"gateway\":{\"auth\":{\"mode\":\"none\"}}}", -1, NULL);
-    GatewayConfig *b = gateway_config_load();
+    GatewayConfig *b = gateway_config_load(NULL);
 
     g_assert_false(gateway_config_equivalent(a, b));
     gateway_config_free(a);
@@ -387,14 +473,14 @@ static void test_config_equiv_invalid_different_reasons_not_equivalent(void) {
     /* Missing token: token mode but no token */
     g_file_set_contents(config_path,
         "{\"gateway\":{\"auth\":{\"mode\":\"token\"}}}", -1, NULL);
-    GatewayConfig *a = gateway_config_load();
+    GatewayConfig *a = gateway_config_load(NULL);
     g_assert_false(a->valid);
     g_assert_cmpint(a->error_code, ==, GW_CFG_ERR_TOKEN_MISSING);
 
     /* Unsupported auth mode */
     g_file_set_contents(config_path,
         "{\"gateway\":{\"auth\":{\"mode\":\"trusted-proxy\"}}}", -1, NULL);
-    GatewayConfig *b = gateway_config_load();
+    GatewayConfig *b = gateway_config_load(NULL);
     g_assert_false(b->valid);
     g_assert_cmpint(b->error_code, ==, GW_CFG_ERR_AUTH_MODE_UNSUPPORTED);
 
@@ -417,8 +503,8 @@ static void test_config_equiv_same_invalid_reason_same_fields(void) {
 
     g_file_set_contents(config_path,
         "{\"gateway\":{\"auth\":{\"mode\":\"token\"}}}", -1, NULL);
-    GatewayConfig *a = gateway_config_load();
-    GatewayConfig *b = gateway_config_load();
+    GatewayConfig *a = gateway_config_load(NULL);
+    GatewayConfig *b = gateway_config_load(NULL);
     g_assert_false(a->valid);
     g_assert_false(b->valid);
     g_assert_true(gateway_config_equivalent(a, b));
@@ -442,12 +528,12 @@ static void test_config_equiv_invalid_different_port_not_equivalent(void) {
     g_file_set_contents(p1,
         "{\"gateway\":{\"port\":1111,\"auth\":{\"mode\":\"token\"}}}", -1, NULL);
     g_setenv("OPENCLAW_CONFIG_PATH", p1, TRUE);
-    GatewayConfig *a = gateway_config_load();
+    GatewayConfig *a = gateway_config_load(NULL);
 
     g_file_set_contents(p2,
         "{\"gateway\":{\"port\":2222,\"auth\":{\"mode\":\"token\"}}}", -1, NULL);
     g_setenv("OPENCLAW_CONFIG_PATH", p2, TRUE);
-    GatewayConfig *b = gateway_config_load();
+    GatewayConfig *b = gateway_config_load(NULL);
 
     g_assert_false(a->valid);
     g_assert_false(b->valid);
@@ -492,6 +578,26 @@ static void test_protocol_parse_response_ok(void) {
     g_assert_cmpstr(auth_source, ==, "token");
     g_assert_cmpfloat_with_epsilon(tick_ms, 25000.0, 0.1);
     g_free(auth_source);
+
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_response_malformed_hello(void) {
+    /* Valid JSON, 'res' frame, ok=true (no error), but payload doesn't match expected hello shape */
+    const gchar *json = "{\"type\":\"res\",\"id\":\"req-1\",\"payload\":{\"not_hello\":\"something\"}}";
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_cmpstr(frame->id, ==, "req-1");
+    g_assert_null(frame->error);
+
+    gchar *auth_source = NULL;
+    gdouble tick_ms = 0;
+    gboolean ok = gateway_protocol_parse_hello_ok(frame, &auth_source, &tick_ms);
+    
+    /* The parse must fail because the payload is not a valid hello-ok */
+    g_assert_false(ok);
+    g_assert_null(auth_source);
 
     gateway_frame_free(frame);
 }
@@ -679,6 +785,9 @@ int main(int argc, char **argv) {
     g_test_add_func("/gateway/config/env_overrides_config_token", test_config_env_overrides_config_token);
     g_test_add_func("/gateway/config/password_mode_missing_password", test_config_password_mode_missing_password);
     g_test_add_func("/gateway/config/remote_mode_rejected", test_config_remote_mode_rejected);
+    g_test_add_func("/gateway/config/secret_ref_unsupported", test_config_secret_ref_unsupported);
+    g_test_add_func("/gateway/config/precedence_explicit_over_state_dir", test_config_precedence_explicit_over_state_dir);
+    g_test_add_func("/gateway/config/precedence_state_dir_over_home", test_config_precedence_state_dir_over_home);
 
     /* Config equivalence tests */
     g_test_add_func("/gateway/config/equiv_identical", test_config_equiv_identical);
@@ -691,6 +800,7 @@ int main(int argc, char **argv) {
     /* Protocol tests */
     g_test_add_func("/gateway/protocol/parse_event", test_protocol_parse_event);
     g_test_add_func("/gateway/protocol/parse_response_ok", test_protocol_parse_response_ok);
+    g_test_add_func("/gateway/protocol/parse_response_malformed_hello", test_protocol_parse_response_malformed_hello);
     g_test_add_func("/gateway/protocol/parse_response_error", test_protocol_parse_response_error);
     g_test_add_func("/gateway/protocol/parse_request", test_protocol_parse_request);
     g_test_add_func("/gateway/protocol/parse_invalid", test_protocol_parse_invalid);

--- a/apps/linux/tests/test_systemd_helpers.c
+++ b/apps/linux/tests/test_systemd_helpers.c
@@ -158,6 +158,56 @@ static void test_helpers_get_user_unit_paths_contains_all(void) {
     g_ptr_array_free(paths, TRUE);
 }
 
+static void test_parse_unit_env_simple(void) {
+    const gchar *contents =
+        "[Unit]\nDescription=OpenClaw Gateway\n\n"
+        "[Service]\nExecStart=/usr/bin/openclaw gateway run\n"
+        "Environment=OPENCLAW_STATE_DIR=/home/user/.openclaw-work\n"
+        "Environment=OPENCLAW_SERVICE_KIND=gateway\n";
+
+    gchar *state_dir = systemd_helpers_parse_unit_env(contents, "OPENCLAW_STATE_DIR");
+    g_assert_cmpstr(state_dir, ==, "/home/user/.openclaw-work");
+    g_free(state_dir);
+
+    gchar *kind = systemd_helpers_parse_unit_env(contents, "OPENCLAW_SERVICE_KIND");
+    g_assert_cmpstr(kind, ==, "gateway");
+    g_free(kind);
+
+    gchar *missing = systemd_helpers_parse_unit_env(contents, "OPENCLAW_CONFIG_PATH");
+    g_assert_null(missing);
+}
+
+static void test_parse_unit_env_quoted(void) {
+    const gchar *contents =
+        "[Service]\n"
+        "Environment=\"OPENCLAW_STATE_DIR=/home/user/.openclaw-work\"\n"
+        "Environment=\"OPENCLAW_CONFIG_PATH=/etc/openclaw/config.json\"\n";
+
+    gchar *state_dir = systemd_helpers_parse_unit_env(contents, "OPENCLAW_STATE_DIR");
+    g_assert_cmpstr(state_dir, ==, "/home/user/.openclaw-work");
+    g_free(state_dir);
+
+    gchar *config_path = systemd_helpers_parse_unit_env(contents, "OPENCLAW_CONFIG_PATH");
+    g_assert_cmpstr(config_path, ==, "/etc/openclaw/config.json");
+    g_free(config_path);
+}
+
+static void test_parse_unit_env_null_safe(void) {
+    g_assert_null(systemd_helpers_parse_unit_env(NULL, "KEY"));
+    g_assert_null(systemd_helpers_parse_unit_env("Environment=KEY=val", NULL));
+    g_assert_null(systemd_helpers_parse_unit_env("Environment=KEY=val", ""));
+}
+
+static void test_parse_unit_env_no_false_prefix_match(void) {
+    /* OPENCLAW_STATE_DIR_EXTRA should not match OPENCLAW_STATE_DIR */
+    const gchar *contents =
+        "[Service]\n"
+        "Environment=OPENCLAW_STATE_DIR_EXTRA=/wrong/path\n";
+
+    gchar *result = systemd_helpers_parse_unit_env(contents, "OPENCLAW_STATE_DIR");
+    g_assert_null(result);
+}
+
 static void test_helpers_get_system_unit_paths_contains_all(void) {
     GPtrArray *paths = systemd_helpers_get_system_unit_paths();
     
@@ -212,6 +262,11 @@ int main(int argc, char **argv) {
 
     g_test_add_func("/systemd/helpers_get_user_unit_paths_contains_all", test_helpers_get_user_unit_paths_contains_all);
     g_test_add_func("/systemd/helpers_get_system_unit_paths_contains_all", test_helpers_get_system_unit_paths_contains_all);
-    
+
+    g_test_add_func("/systemd/parse_unit_env_simple", test_parse_unit_env_simple);
+    g_test_add_func("/systemd/parse_unit_env_quoted", test_parse_unit_env_quoted);
+    g_test_add_func("/systemd/parse_unit_env_null_safe", test_parse_unit_env_null_safe);
+    g_test_add_func("/systemd/parse_unit_env_no_false_prefix_match", test_parse_unit_env_no_false_prefix_match);
+
     return g_test_run();
 }


### PR DESCRIPTION
Load Linux gateway config from runtime context derived from the active systemd unit instead of relying only on default home-directory paths.

Add GatewayConfigContext and update gateway_config_load() to accept explicit config path, effective state dir, and profile context. Resolve config with precedence of OPENCLAW_CONFIG_PATH, context-provided explicit config path, context-provided state dir, OPENCLAW_STATE_DIR, then default home and legacy fallback paths.

Teach gateway auth parsing to distinguish plain-string SecretInput values from object-valued SecretRefs. Add token_is_secret_ref and password_is_secret_ref flags plus GW_CFG_ERR_SECRET_REF_UNSUPPORTED so unsupported SecretRefs surface as explicit typed errors rather than false TOKEN_MISSING/PASSWORD_MISSING failures. Include these flags in config equivalence checks.

Expose systemd_get_runtime_context() and add unit-file helpers to locate the active unit and parse Environment= lines for OPENCLAW_STATE_DIR and OPENCLAW_CONFIG_PATH.

Tighten gateway_protocol_parse_hello_ok() so it requires valid auth and policy objects. Update gateway_ws.c to treat hello-ok parsing as a hard success gate: malformed connect responses now fail validation instead of transitioning the websocket client into CONNECTED.

Extend Linux tests for SecretRef rejection, config precedence, malformed hello parsing, and unit Environment parsing.
