### PR TITLE
feat(linux): readiness decision table and first-run semantics (#40)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -38,6 +38,7 @@ sources = [
   'src/gateway_ws.c',
   'src/gateway_client.c',
   'src/state.c',
+  'src/readiness.c',
   'src/notify.c',
   'src/diagnostics.c',
   'src/log.c'
@@ -65,7 +66,7 @@ install_data('ai.openclaw.Companion.desktop',
 
 # Local Tests
 test_state_exe = executable('test_state',
-  ['tests/test_state.c', 'src/state.c', 'src/log.c'],
+  ['tests/test_state.c', 'src/state.c', 'src/readiness.c', 'src/log.c'],
   dependencies : [glib_dep, gio_dep])
 test('state', test_state_exe)
 
@@ -73,6 +74,11 @@ test_systemd_exe = executable('test_systemd_helpers',
   ['tests/test_systemd_helpers.c', 'src/systemd_helpers.c'],
   dependencies : [glib_dep, gio_dep, gio_unix_dep])
 test('systemd_helpers', test_systemd_exe)
+
+test_readiness_exe = executable('test_readiness',
+  ['tests/test_readiness.c', 'src/readiness.c'],
+  dependencies : [glib_dep])
+test('readiness', test_readiness_exe)
 
 test_gateway_exe = executable('test_gateway',
   ['tests/test_gateway.c', 'src/gateway_config.c', 'src/gateway_protocol.c', 'src/log.c'],

--- a/apps/linux/src/diagnostics.c
+++ b/apps/linux/src/diagnostics.c
@@ -14,6 +14,7 @@
 #include <gtk/gtk.h>
 #include <adwaita.h>
 #include "state.h"
+#include "readiness.h"
 
 static GtkWidget *diag_window = NULL;
 static GtkWidget *copy_btn = NULL;
@@ -35,48 +36,55 @@ static gchar* format_age(gint64 timestamp_us) {
 }
 
 static gchar* build_diagnostics_text(void) {
-    const char *status = state_get_current_string();
+    AppState current = state_get_current();
     SystemdState *sys = state_get_systemd();
     HealthState *health = state_get_health();
 
+    ReadinessInfo ri;
+    readiness_evaluate(current, health, sys, &ri);
+
     g_autofree gchar *health_age = format_age(health->last_updated);
 
-    return g_strdup_printf(
-        "=== Systemd Service ===\n"
-        "Unit: %s\n"
-        "ActiveState: %s\n"
-        "SubState: %s\n\n"
-        "=== Gateway Client ===\n"
-        "Source: Native HTTP + WebSocket\n"
-        "Last updated: %s\n\n"
-        "Normalized Status: %s\n"
-        "Endpoint: %s:%d\n"
-        "HTTP Health: %s\n"
-        "WebSocket: %s\n"
-        "RPC OK: %s\n"
-        "Auth OK: %s\n"
-        "Auth Source: %s\n"
-        "Gateway Version: %s\n"
-        "Config Valid: %s\n"
-        "Config Issues: %d\n"
-        "Last Error: %s\n",
-        sys->unit_name ? sys->unit_name : "N/A",
-        sys->active_state ? sys->active_state : "Unknown",
-        sys->sub_state ? sys->sub_state : "Unknown",
-        health_age,
-        status,
+    GString *out = g_string_new(NULL);
+
+    /* Readiness summary */
+    g_string_append_printf(out, "=== Readiness ===\n");
+    g_string_append_printf(out, "Status: %s\n", ri.classification ? ri.classification : "Unknown");
+    if (ri.missing) {
+        g_string_append_printf(out, "Detail: %s\n", ri.missing);
+    }
+    if (ri.next_action) {
+        g_string_append_printf(out, "Next:   %s\n", ri.next_action);
+    }
+
+    /* Systemd service context */
+    g_string_append_printf(out, "\n=== Systemd Service ===\n");
+    g_string_append_printf(out, "Unit: %s\n", sys->unit_name ? sys->unit_name : "N/A");
+    g_string_append_printf(out, "ActiveState: %s\n", sys->active_state ? sys->active_state : "Unknown");
+    g_string_append_printf(out, "SubState: %s\n", sys->sub_state ? sys->sub_state : "Unknown");
+
+    /* Gateway connectivity */
+    g_string_append_printf(out, "\n=== Gateway Connectivity ===\n");
+    g_string_append_printf(out, "Source: Native HTTP + WebSocket\n");
+    g_string_append_printf(out, "Last updated: %s\n", health_age);
+    g_string_append_printf(out, "Endpoint: %s:%d\n",
         health->endpoint_host ? health->endpoint_host : "127.0.0.1",
-        health->endpoint_port,
-        health->http_ok ? "OK" : "Unreachable",
-        health->ws_connected ? "Connected" : "Disconnected",
-        health->rpc_ok ? "Yes" : "No",
-        health->auth_ok ? "Yes" : "No",
-        health->auth_source ? health->auth_source : "N/A",
-        health->gateway_version ? health->gateway_version : "N/A",
-        health->config_valid ? "Yes" : "No",
-        health->config_issues_count,
-        health->last_error ? health->last_error : "None"
-    );
+        health->endpoint_port);
+    g_string_append_printf(out, "HTTP Health: %s\n", health->http_ok ? "OK" : "Unreachable");
+    g_string_append_printf(out, "WebSocket: %s\n", health->ws_connected ? "Connected" : "Disconnected");
+    g_string_append_printf(out, "RPC OK: %s\n", health->rpc_ok ? "Yes" : "No");
+    g_string_append_printf(out, "Auth OK: %s\n", health->auth_ok ? "Yes" : "No");
+    g_string_append_printf(out, "Auth Source: %s\n", health->auth_source ? health->auth_source : "N/A");
+    g_string_append_printf(out, "Gateway Version: %s\n", health->gateway_version ? health->gateway_version : "N/A");
+
+    /* Configuration */
+    g_string_append_printf(out, "\n=== Configuration ===\n");
+    g_string_append_printf(out, "Config Valid: %s\n", health->config_valid ? "Yes" : "No");
+    g_string_append_printf(out, "Setup Detected: %s\n", health->setup_detected ? "Yes" : "No");
+    g_string_append_printf(out, "Config Issues: %d\n", health->config_issues_count);
+    g_string_append_printf(out, "Last Error: %s\n", health->last_error ? health->last_error : "None");
+
+    return g_string_free(out, FALSE);
 }
 
 static gboolean refresh_diagnostics_view(gpointer user_data) {

--- a/apps/linux/src/gateway_client.c
+++ b/apps/linux/src/gateway_client.c
@@ -32,9 +32,12 @@ static gchar *current_ws_url = NULL;
 static gboolean health_in_flight = FALSE;
 static gboolean initialized = FALSE;
 static guint current_health_generation = 0;
+static gboolean current_setup_detected = FALSE;
 
 static guint health_poll_timer_id = 0;
 #define HEALTH_POLL_INTERVAL_S 10
+
+static void do_health_check(void);
 
 static GatewayConfig* load_config_with_context(void) {
     GatewayConfigContext ctx = {0};
@@ -75,6 +78,7 @@ static void publish_health_state(gboolean http_ok, gboolean ws_connected,
     hs.rpc_ok = rpc_ok;
     hs.auth_ok = auth_ok;
     hs.config_valid = current_config ? current_config->valid : FALSE;
+    hs.setup_detected = current_setup_detected;
 
     /* TODO(MVP deferral): We do not populate config_audit_ok or config_issues_count 
      * here because those are not yet extracted or tracked in the Linux MVP.
@@ -102,6 +106,7 @@ static void publish_invalid_config_state(void) {
     HealthState hs = {0};
     hs.last_updated = g_get_real_time();
     hs.config_valid = FALSE;
+    hs.setup_detected = current_setup_detected;
     hs.last_error = g_strdup(current_config ? current_config->error : "Config load failed");
     if (current_config) {
         hs.endpoint_host = g_strdup(current_config->host);
@@ -126,9 +131,21 @@ static void on_ws_status(const GatewayWsStatus *status, gpointer user_data) {
               status->auth_source ? status->auth_source : "(null)",
               status->last_error ? status->last_error : "(null)");
 
-    /* Re-publish health with latest WS state. Keep the last known http_ok. */
+    /* Re-publish health with latest WS state. */
     HealthState *current = state_get_health();
     gboolean http_ok = current ? current->http_ok : FALSE;
+
+    /*
+     * Cross-transport coherence rule:
+     * If WS is connected with a successful RPC channel, the gateway endpoint
+     * is provably reachable. A stale http_ok=FALSE from before the connection
+     * was established must not persist — it would create the contradictory
+     * snapshot "HTTP unreachable + WS connected + RPC OK" which the readiness
+     * model would classify as DEGRADED even though the gateway is fully usable.
+     */
+    if (ws_connected && status->rpc_ok) {
+        http_ok = TRUE;
+    }
 
     publish_health_state(
         http_ok,
@@ -138,6 +155,15 @@ static void on_ws_status(const GatewayWsStatus *status, gpointer user_data) {
         current ? current->gateway_version : NULL,
         status->auth_source,
         auth_failed ? status->last_error : (ws_connected ? NULL : status->last_error));
+
+    /*
+     * When WS transitions to CONNECTED, trigger an immediate HTTP health
+     * check to refresh HTTP-specific fields (gateway version, healthy flag)
+     * instead of waiting up to HEALTH_POLL_INTERVAL_S for the next poll.
+     */
+    if (ws_connected) {
+        do_health_check();
+    }
 }
 
 static void on_health_result(const GatewayHealthResult *result, gpointer user_data) {
@@ -251,6 +277,19 @@ static void start_transport(void) {
                        on_ws_status, NULL);
 }
 
+static void detect_setup_presence(const GatewayConfig *config) {
+    current_setup_detected = FALSE;
+    if (!config || !config->config_path) return;
+    if (g_file_test(config->config_path, G_FILE_TEST_EXISTS)) {
+        current_setup_detected = TRUE;
+        return;
+    }
+    g_autofree gchar *parent = g_path_get_dirname(config->config_path);
+    if (parent && g_file_test(parent, G_FILE_TEST_IS_DIR)) {
+        current_setup_detected = TRUE;
+    }
+}
+
 void gateway_client_init(void) {
     if (initialized) return;
     initialized = TRUE;
@@ -258,8 +297,9 @@ void gateway_client_init(void) {
     gateway_http_init();
     gateway_ws_init();
 
-    /* Load config */
+    /* Load config and detect setup presence */
     current_config = load_config_with_context();
+    detect_setup_presence(current_config);
     if (!current_config || !current_config->valid) {
         OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY, "gateway config invalid: %s",
                   current_config ? current_config->error : "load failed");
@@ -276,8 +316,9 @@ void gateway_client_refresh(void) {
         return;
     }
 
-    /* Always reload config */
+    /* Always reload config and re-detect setup presence */
     GatewayConfig *new_config = load_config_with_context();
+    detect_setup_presence(new_config);
     gboolean equivalent = gateway_config_equivalent(current_config, new_config);
 
     if (equivalent) {

--- a/apps/linux/src/readiness.c
+++ b/apps/linux/src/readiness.c
@@ -1,0 +1,118 @@
+/*
+ * readiness.c
+ *
+ * Readiness presentation for the OpenClaw Linux Companion App.
+ *
+ * Derives user-facing readiness information from the canonical AppState.
+ * This module consumes the state derivation result from compute_state()
+ * and does NOT introduce a second decision table or alternate semantics.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "readiness.h"
+#include <stddef.h>
+
+void readiness_evaluate(AppState state, const HealthState *health,
+                        const SystemdState *sys, ReadinessInfo *out) {
+    if (!out) return;
+
+    out->classification = NULL;
+    out->missing = NULL;
+    out->next_action = NULL;
+
+    switch (state) {
+    case STATE_NEEDS_SETUP:
+        out->classification = "Setup Required";
+        out->missing = "No OpenClaw configuration or state directory detected.";
+        out->next_action = "Run 'openclaw setup' to initialize the OpenClaw environment.";
+        break;
+
+    case STATE_NEEDS_GATEWAY_INSTALL:
+        out->classification = "Gateway Not Installed";
+        out->missing = "OpenClaw is configured, but no gateway service is installed.";
+        out->next_action = "Run 'openclaw gateway install' to install the gateway service.";
+        break;
+
+    case STATE_USER_SYSTEMD_UNAVAILABLE:
+        out->classification = "Systemd Unavailable";
+        out->missing = "Cannot connect to the user systemd session bus.";
+        out->next_action = "Ensure your session supports user systemd services (systemctl --user).";
+        break;
+
+    case STATE_SYSTEM_UNSUPPORTED:
+        out->classification = "System Service (Unsupported)";
+        out->missing = "A system-scope gateway unit was found, but only user-scope services are supported.";
+        out->next_action = "Run 'openclaw gateway install' to install a user-scope service.";
+        break;
+
+    case STATE_CONFIG_INVALID:
+        out->classification = "Configuration Invalid";
+        if (health && health->last_error) {
+            out->missing = health->last_error;
+        } else {
+            out->missing = "Gateway configuration could not be loaded or failed validation.";
+        }
+        out->next_action = "Check your openclaw.json configuration file and correct any errors.";
+        break;
+
+    case STATE_STOPPED:
+        out->classification = "Stopped";
+        out->missing = "The gateway service is installed but not running.";
+        out->next_action = "Start the gateway service from the tray menu or run 'openclaw gateway run'.";
+        break;
+
+    case STATE_STARTING:
+        out->classification = "Starting";
+        out->missing = "The gateway service is starting up. Waiting for connectivity confirmation.";
+        out->next_action = NULL;
+        break;
+
+    case STATE_STOPPING:
+        out->classification = "Stopping";
+        out->missing = "The gateway service is shutting down.";
+        out->next_action = NULL;
+        break;
+
+    case STATE_RUNNING:
+        out->classification = "Fully Ready";
+        out->missing = NULL;
+        out->next_action = NULL;
+        break;
+
+    case STATE_RUNNING_WITH_WARNING:
+        out->classification = "Running (Config Warning)";
+        out->missing = "The gateway is running but configuration audit detected issues.";
+        out->next_action = "Review configuration warnings in the diagnostics panel.";
+        break;
+
+    case STATE_DEGRADED:
+        out->classification = "Degraded";
+        if (health && health->http_ok && !health->ws_connected) {
+            out->missing = "HTTP health OK, but WebSocket connection not established.";
+        } else if (health && health->http_ok && health->ws_connected) {
+            out->missing = "Connected, but RPC or auth handshake incomplete.";
+        } else if (health && !health->http_ok && sys && sys->active) {
+            out->missing = "Service reports active, but gateway is not reachable via HTTP.";
+        } else {
+            out->missing = "Gateway connectivity is partially established.";
+        }
+        out->next_action = "Check gateway logs and network configuration. Try restarting the service.";
+        break;
+
+    case STATE_ERROR:
+        out->classification = "Error";
+        out->missing = "The gateway service has entered a failed state.";
+        if (sys && sys->sub_state) {
+            out->missing = "The gateway service has failed (check systemd journal for details).";
+        }
+        out->next_action = "Check 'journalctl --user -u <unit>' for failure details, then restart.";
+        break;
+
+    default:
+        out->classification = "Unknown";
+        out->missing = "Unexpected application state.";
+        out->next_action = NULL;
+        break;
+    }
+}

--- a/apps/linux/src/readiness.h
+++ b/apps/linux/src/readiness.h
@@ -1,0 +1,28 @@
+/*
+ * readiness.h
+ *
+ * Readiness presentation for the OpenClaw Linux Companion App.
+ *
+ * Derives user-facing readiness information (classification, missing
+ * prerequisites, next recommended action) from the canonical AppState
+ * and supporting context. This module consumes the state derivation
+ * result — it does NOT introduce a second decision table.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_READINESS_H
+#define OPENCLAW_LINUX_READINESS_H
+
+#include "state.h"
+
+typedef struct {
+    const char *classification;  /* e.g. "Fully Ready", "Setup Required" */
+    const char *missing;         /* missing prerequisite(s), or NULL */
+    const char *next_action;     /* next recommended action, or NULL */
+} ReadinessInfo;
+
+void readiness_evaluate(AppState state, const HealthState *health,
+                        const SystemdState *sys, ReadinessInfo *out);
+
+#endif /* OPENCLAW_LINUX_READINESS_H */

--- a/apps/linux/src/state.c
+++ b/apps/linux/src/state.c
@@ -23,7 +23,7 @@
 #include "log.h"
 #include "state.h"
 
-static AppState current_state = STATE_NOT_INSTALLED;
+static AppState current_state = STATE_NEEDS_SETUP;
 static SystemdState current_sys_state = {0};
 static HealthState current_health_state = {0};
 static guint64 current_health_generation = 0;
@@ -36,20 +36,24 @@ static AppState compute_state(void) {
     gboolean gateway_connected = gateway_reachable && current_health_state.ws_connected;
 
     /*
-     * PRIMARY: Runtime connectivity determines operational state.
-     * If the native client has confirmed gateway reachability, this takes
-     * precedence over systemd state for the "is the gateway usable?" question.
-     * A local gateway may be started manually, by another supervisor, or by
-     * a pre-existing process outside the systemd unit the companion expects.
+     * Readiness Decision Table — evaluated top-down, first match wins.
+     *
+     * Precedence Rule:
+     *   1. Runtime reachability and protocol success decide "ready."
+     *   2. When runtime truth does not establish readiness, setup/config/install
+     *      context determines the user-visible explanation.
+     *   3. Systemd contributes lifecycle context but never by itself proves readiness.
      */
+
+    /* ── LAYER 1: RUNTIME TRUTH (rows 1-4) ── */
     if (gateway_connected) {
         if (!current_health_state.rpc_ok || !current_health_state.auth_ok) {
             return STATE_DEGRADED;
         }
         /* TODO(MVP deferral): STATE_RUNNING_WITH_WARNING is intentionally deferred.
-         * The Linux MVP does not yet populate config-audit inputs (config_audit_ok, 
-         * config_issues_count). We explicitly retain this branch to preserve the 
-         * intended UX shape, but do NOT synthesize warning-state behavior from 
+         * The Linux MVP does not yet populate config-audit inputs (config_audit_ok,
+         * config_issues_count). We explicitly retain this branch to preserve the
+         * intended UX shape, but do NOT synthesize warning-state behavior from
          * unrelated config errors just to make it live.
          */
         if (!current_health_state.config_audit_ok && current_health_state.config_issues_count > 0) {
@@ -57,47 +61,67 @@ static AppState compute_state(void) {
         }
         return STATE_RUNNING;
     }
-
     if (gateway_reachable && !gateway_connected) {
-        /* HTTP /health succeeded but WebSocket not connected — partial health */
         return STATE_DEGRADED;
     }
 
-    /*
-     * SECONDARY: When native connectivity has not been established,
-     * consult systemd for install/management context.
-     */
+    /* ── LAYER 2: INFRASTRUCTURE FAILURES (rows 5-6) ── */
     if (current_sys_state.systemd_unavailable) {
         return STATE_USER_SYSTEMD_UNAVAILABLE;
     }
-    if (!current_sys_state.installed) {
-        if (current_sys_state.system_installed_unsupported) {
-            return STATE_SYSTEM_UNSUPPORTED;
-        }
-        return STATE_NOT_INSTALLED;
+    if (!current_sys_state.installed && current_sys_state.system_installed_unsupported) {
+        return STATE_SYSTEM_UNSUPPORTED;
     }
+
+    /* ── LAYER 3: INSTALL STATUS (rows 7-8) ── */
+    if (!current_sys_state.installed) {
+        if (has_health_data && current_health_state.setup_detected) {
+            return STATE_NEEDS_GATEWAY_INSTALL;
+        }
+        return STATE_NEEDS_SETUP;
+    }
+
+    /* ── LAYER 4: SYSTEMD TRANSITIONS (rows 10-12) ── */
     if (current_sys_state.failed) return STATE_ERROR;
     if (current_sys_state.activating) return STATE_STARTING;
     if (current_sys_state.deactivating) return STATE_STOPPING;
 
+    /* ── LAYER 5: CONFIG VALIDITY (row 9) ──
+     * If config is invalid and runtime truth has not proven usability,
+     * surface config invalidity as the primary explanation.
+     * Only evaluated after health data has arrived (otherwise config_valid
+     * is its default zero-value and would falsely trigger).
+     */
+    if (has_health_data && !current_health_state.config_valid) {
+        return STATE_CONFIG_INVALID;
+    }
+
+    /* ── LAYER 6: SYSTEMD ACTIVE (rows 14-15) ── */
     if (current_sys_state.active) {
         /*
          * Startup Hydration Guard:
          * Systemd says active but native client hasn't confirmed health yet.
+         * This is a transitional state — NOT equivalent to fully ready.
          * If we have health data showing HTTP unreachable, report degraded.
-         * Otherwise assume running while the native client establishes.
+         * Otherwise report STARTING while the native client establishes.
          */
         if (has_health_data && !current_health_state.http_ok) {
             return STATE_DEGRADED;
         }
-        return STATE_RUNNING;
+        if (!has_health_data) {
+            return STATE_STARTING;
+        }
+        /* has_health_data && http_ok implies gateway_reachable, which would
+         * have been caught in Layer 1. Should not reach here. */
+        return STATE_STARTING;
     }
 
+    /* ── DEFAULT (row 13) ── */
     return STATE_STOPPED;
 }
 
 void state_init(void) {
-    current_state = STATE_NOT_INSTALLED;
+    current_state = STATE_NEEDS_SETUP;
     initial_hydration_done = FALSE;
     initial_refresh_fired = FALSE;
 
@@ -112,9 +136,11 @@ void state_init(void) {
 
 static const char* state_enum_to_string(AppState s) {
     switch (s) {
-        case STATE_NOT_INSTALLED: return "NOT_INSTALLED";
+        case STATE_NEEDS_SETUP: return "NEEDS_SETUP";
+        case STATE_NEEDS_GATEWAY_INSTALL: return "NEEDS_GATEWAY_INSTALL";
         case STATE_USER_SYSTEMD_UNAVAILABLE: return "USER_SYSTEMD_UNAVAILABLE";
         case STATE_SYSTEM_UNSUPPORTED: return "SYSTEM_UNSUPPORTED";
+        case STATE_CONFIG_INVALID: return "CONFIG_INVALID";
         case STATE_STOPPED: return "STOPPED";
         case STATE_STARTING: return "STARTING";
         case STATE_STOPPING: return "STOPPING";
@@ -216,6 +242,7 @@ void state_update_health(const HealthState *health_state) {
     current_health_state.rpc_ok = health_state->rpc_ok;
     current_health_state.auth_ok = health_state->auth_ok;
     current_health_state.config_valid = health_state->config_valid;
+    current_health_state.setup_detected = health_state->setup_detected;
     current_health_state.endpoint_port = health_state->endpoint_port;
     current_health_state.config_audit_ok = health_state->config_audit_ok;
     current_health_state.config_issues_count = health_state->config_issues_count;
@@ -234,9 +261,11 @@ AppState state_get_current(void) {
 
 const char* state_get_current_string(void) {
     switch (current_state) {
-        case STATE_NOT_INSTALLED: return "Not Installed";
+        case STATE_NEEDS_SETUP: return "Setup Required";
+        case STATE_NEEDS_GATEWAY_INSTALL: return "Gateway Not Installed";
         case STATE_USER_SYSTEMD_UNAVAILABLE: return "User Systemd Unavailable";
         case STATE_SYSTEM_UNSUPPORTED: return "System Service (Unsupported)";
+        case STATE_CONFIG_INVALID: return "Configuration Invalid";
         case STATE_STOPPED: return "Stopped";
         case STATE_STARTING: return "Starting";
         case STATE_STOPPING: return "Stopping";

--- a/apps/linux/src/state.h
+++ b/apps/linux/src/state.h
@@ -21,9 +21,11 @@
 #include <glib.h>
 
 typedef enum {
-    STATE_NOT_INSTALLED,
+    STATE_NEEDS_SETUP,
+    STATE_NEEDS_GATEWAY_INSTALL,
     STATE_USER_SYSTEMD_UNAVAILABLE,
     STATE_SYSTEM_UNSUPPORTED,
+    STATE_CONFIG_INVALID,
     STATE_STOPPED,
     STATE_STARTING,
     STATE_STOPPING,
@@ -60,6 +62,8 @@ typedef struct {
     char *gateway_version;
     char *auth_source;
     char *last_error;
+
+    gboolean setup_detected;
 
     gboolean config_audit_ok;
     int config_issues_count;

--- a/apps/linux/src/tray.c
+++ b/apps/linux/src/tray.c
@@ -257,9 +257,11 @@ void tray_update_from_state(AppState state) {
     gboolean can_restart = FALSE;
     
     switch (state) {
-        case STATE_NOT_INSTALLED:
+        case STATE_NEEDS_SETUP:
+        case STATE_NEEDS_GATEWAY_INSTALL:
         case STATE_USER_SYSTEMD_UNAVAILABLE:
         case STATE_SYSTEM_UNSUPPORTED:
+        case STATE_CONFIG_INVALID:
             break;
         case STATE_STOPPED:
         case STATE_ERROR:

--- a/apps/linux/tests/test_readiness.c
+++ b/apps/linux/tests/test_readiness.c
@@ -1,0 +1,315 @@
+/*
+ * test_readiness.c
+ *
+ * Direct tests for the readiness presentation helper (readiness_evaluate).
+ *
+ * These tests validate the presenter output contract independently from
+ * the canonical state derivation logic tested in test_state.c.
+ * The presenter consumes AppState — tests pass canonical states directly
+ * and do NOT recreate the decision table.
+ *
+ * Assertions are kept narrow and structural:
+ *   - classification: non-NULL, exact text for critical states.
+ *   - missing: NULL/non-NULL as appropriate per state contract.
+ *   - next_action: NULL/non-NULL as appropriate per state contract.
+ *   - Substring checks only where a stable semantic fragment matters.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include <glib.h>
+#include <string.h>
+#include "../src/readiness.h"
+
+/* ── Helper: assert a string contains a substring ── */
+static void assert_contains(const char *haystack, const char *needle, const char *context) {
+    if (!haystack || !needle) {
+        g_test_message("assert_contains failed (%s): haystack=%p needle=%p", context,
+                       (const void *)haystack, (const void *)needle);
+        g_assert_not_reached();
+    }
+    if (!strstr(haystack, needle)) {
+        g_test_message("assert_contains failed (%s): '%s' not found in '%s'", context, needle, haystack);
+        g_assert_not_reached();
+    }
+}
+
+/* ── STATE_NEEDS_SETUP ── */
+
+static void test_presenter_needs_setup(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_NEEDS_SETUP, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Setup Required");
+    g_assert_nonnull(ri.missing);
+    g_assert_nonnull(ri.next_action);
+    assert_contains(ri.next_action, "openclaw setup", "needs_setup.next_action");
+}
+
+/* ── STATE_NEEDS_GATEWAY_INSTALL ── */
+
+static void test_presenter_needs_gateway_install(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_NEEDS_GATEWAY_INSTALL, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Gateway Not Installed");
+    g_assert_nonnull(ri.missing);
+    g_assert_nonnull(ri.next_action);
+    assert_contains(ri.next_action, "gateway install", "needs_install.next_action");
+}
+
+/* ── STATE_USER_SYSTEMD_UNAVAILABLE ── */
+
+static void test_presenter_systemd_unavailable(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_USER_SYSTEMD_UNAVAILABLE, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Systemd Unavailable");
+    g_assert_nonnull(ri.missing);
+    g_assert_nonnull(ri.next_action);
+}
+
+/* ── STATE_SYSTEM_UNSUPPORTED ── */
+
+static void test_presenter_system_unsupported(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_SYSTEM_UNSUPPORTED, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "System Service (Unsupported)");
+    g_assert_nonnull(ri.missing);
+    g_assert_nonnull(ri.next_action);
+}
+
+/* ── STATE_CONFIG_INVALID ── */
+
+static void test_presenter_config_invalid_with_error(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    hs.last_error = "mode 'remote' is not supported";
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_CONFIG_INVALID, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Configuration Invalid");
+    /* missing should surface the specific error from health */
+    g_assert_nonnull(ri.missing);
+    assert_contains(ri.missing, "remote", "config_invalid.missing_error");
+    g_assert_nonnull(ri.next_action);
+    assert_contains(ri.next_action, "openclaw.json", "config_invalid.next_action");
+}
+
+static void test_presenter_config_invalid_no_error(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    hs.last_error = NULL;
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_CONFIG_INVALID, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Configuration Invalid");
+    /* fallback missing text when no specific error */
+    g_assert_nonnull(ri.missing);
+    g_assert_nonnull(ri.next_action);
+}
+
+/* ── STATE_STOPPED ── */
+
+static void test_presenter_stopped(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_STOPPED, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Stopped");
+    g_assert_nonnull(ri.missing);
+    g_assert_nonnull(ri.next_action);
+}
+
+/* ── STATE_STARTING ── */
+
+static void test_presenter_starting(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_STARTING, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Starting");
+    /* transitional: explanation present, no user action needed */
+    g_assert_nonnull(ri.missing);
+    g_assert_null(ri.next_action);
+}
+
+/* ── STATE_RUNNING (fully ready) ── */
+
+static void test_presenter_running(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    hs.http_ok = TRUE;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_RUNNING, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Fully Ready");
+    g_assert_null(ri.missing);
+    g_assert_null(ri.next_action);
+}
+
+/* ── STATE_RUNNING_WITH_WARNING ── */
+
+static void test_presenter_running_with_warning(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_RUNNING_WITH_WARNING, &hs, &sys, &ri);
+
+    g_assert_nonnull(ri.classification);
+    assert_contains(ri.classification, "Warning", "running_warning.classification");
+    g_assert_nonnull(ri.missing);
+    g_assert_nonnull(ri.next_action);
+}
+
+/* ── STATE_DEGRADED: three distinct missing-text paths ── */
+
+static void test_presenter_degraded_http_ok_ws_disconnected(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    hs.http_ok = TRUE;
+    hs.ws_connected = FALSE;
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_DEGRADED, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Degraded");
+    g_assert_nonnull(ri.missing);
+    assert_contains(ri.missing, "WebSocket", "degraded_ws.missing");
+    g_assert_nonnull(ri.next_action);
+}
+
+static void test_presenter_degraded_connected_rpc_incomplete(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    hs.http_ok = TRUE;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = FALSE;
+    hs.auth_ok = FALSE;
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_DEGRADED, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Degraded");
+    g_assert_nonnull(ri.missing);
+    assert_contains(ri.missing, "RPC", "degraded_rpc.missing");
+    g_assert_nonnull(ri.next_action);
+}
+
+static void test_presenter_degraded_systemd_active_http_unreachable(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    hs.http_ok = FALSE;
+    SystemdState sys = {0};
+    sys.active = TRUE;
+
+    readiness_evaluate(STATE_DEGRADED, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Degraded");
+    g_assert_nonnull(ri.missing);
+    assert_contains(ri.missing, "not reachable", "degraded_active_http.missing");
+    g_assert_nonnull(ri.next_action);
+}
+
+static void test_presenter_degraded_fallback(void) {
+    /* No health context at all — fallback path */
+    ReadinessInfo ri;
+    readiness_evaluate(STATE_DEGRADED, NULL, NULL, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Degraded");
+    g_assert_nonnull(ri.missing);
+    g_assert_nonnull(ri.next_action);
+}
+
+/* ── STATE_ERROR ── */
+
+static void test_presenter_error(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_ERROR, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Error");
+    g_assert_nonnull(ri.missing);
+    g_assert_nonnull(ri.next_action);
+    assert_contains(ri.next_action, "journalctl", "error.next_action");
+}
+
+static void test_presenter_error_with_substate(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    SystemdState sys = {0};
+    sys.sub_state = "failed";
+
+    readiness_evaluate(STATE_ERROR, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Error");
+    g_assert_nonnull(ri.missing);
+    assert_contains(ri.missing, "journal", "error_substate.missing");
+    g_assert_nonnull(ri.next_action);
+}
+
+/* ── NULL output pointer guard ── */
+
+static void test_presenter_null_output(void) {
+    /* Must not crash when out is NULL */
+    readiness_evaluate(STATE_RUNNING, NULL, NULL, NULL);
+}
+
+/* ── Registration ── */
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    /* Per-state classification tests */
+    g_test_add_func("/readiness/needs_setup", test_presenter_needs_setup);
+    g_test_add_func("/readiness/needs_gateway_install", test_presenter_needs_gateway_install);
+    g_test_add_func("/readiness/systemd_unavailable", test_presenter_systemd_unavailable);
+    g_test_add_func("/readiness/system_unsupported", test_presenter_system_unsupported);
+    g_test_add_func("/readiness/config_invalid_with_error", test_presenter_config_invalid_with_error);
+    g_test_add_func("/readiness/config_invalid_no_error", test_presenter_config_invalid_no_error);
+    g_test_add_func("/readiness/stopped", test_presenter_stopped);
+    g_test_add_func("/readiness/starting", test_presenter_starting);
+    g_test_add_func("/readiness/running", test_presenter_running);
+    g_test_add_func("/readiness/running_with_warning", test_presenter_running_with_warning);
+
+    /* Degraded sub-path tests */
+    g_test_add_func("/readiness/degraded/http_ok_ws_disconnected", test_presenter_degraded_http_ok_ws_disconnected);
+    g_test_add_func("/readiness/degraded/connected_rpc_incomplete", test_presenter_degraded_connected_rpc_incomplete);
+    g_test_add_func("/readiness/degraded/systemd_active_http_unreachable", test_presenter_degraded_systemd_active_http_unreachable);
+    g_test_add_func("/readiness/degraded/fallback", test_presenter_degraded_fallback);
+
+    /* Error sub-path tests */
+    g_test_add_func("/readiness/error", test_presenter_error);
+    g_test_add_func("/readiness/error_with_substate", test_presenter_error_with_substate);
+
+    /* Guard */
+    g_test_add_func("/readiness/null_output", test_presenter_null_output);
+
+    return g_test_run();
+}

--- a/apps/linux/tests/test_state.c
+++ b/apps/linux/tests/test_state.c
@@ -15,7 +15,7 @@ void state_on_gateway_refresh_requested(void) {}
 
 static void test_initial_state(void) {
     state_init();
-    g_assert_cmpint(state_get_current(), ==, STATE_NOT_INSTALLED);
+    g_assert_cmpint(state_get_current(), ==, STATE_NEEDS_SETUP);
 }
 
 static void test_installed_inactive(void) {
@@ -33,8 +33,8 @@ static void test_active_without_fresh_health(void) {
     sys.installed = TRUE;
     sys.active = TRUE;
     state_update_systemd(&sys);
-    // Startup hydration guard: systemd active + no health data → RUNNING
-    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+    // Startup hydration guard: systemd active + no health data → STARTING (transitional, not RUNNING)
+    g_assert_cmpint(state_get_current(), ==, STATE_STARTING);
 }
 
 /* ── Native gateway connectivity tests ── */
@@ -165,13 +165,14 @@ static void test_precedence_systemd_active_http_down(void) {
     sys.installed = TRUE;
     sys.active = TRUE;
     state_update_systemd(&sys);
-    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+    g_assert_cmpint(state_get_current(), ==, STATE_STARTING);
 
-    // HTTP health check fails
+    // HTTP health check fails (config is valid but gateway unreachable)
     HealthState hs = {0};
     hs.last_updated = 12345;
     hs.http_ok = FALSE;
     hs.ws_connected = FALSE;
+    hs.config_valid = TRUE;
     state_update_health(&hs);
 
     g_assert_cmpint(state_get_current(), ==, STATE_DEGRADED);
@@ -183,7 +184,7 @@ static void test_precedence_not_installed_native_connected(void) {
     SystemdState sys = {0};
     sys.installed = FALSE;
     state_update_systemd(&sys);
-    g_assert_cmpint(state_get_current(), ==, STATE_NOT_INSTALLED);
+    g_assert_cmpint(state_get_current(), ==, STATE_NEEDS_SETUP);
 
     HealthState hs = {0};
     hs.last_updated = 12345;
@@ -263,7 +264,7 @@ static void test_repeated_running_stopped_transitions(void) {
 
     sys.active = TRUE;
     state_update_systemd(&sys);
-    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+    g_assert_cmpint(state_get_current(), ==, STATE_STARTING);
 
     sys.active = FALSE;
     state_update_systemd(&sys);
@@ -271,7 +272,7 @@ static void test_repeated_running_stopped_transitions(void) {
 
     sys.active = TRUE;
     state_update_systemd(&sys);
-    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+    g_assert_cmpint(state_get_current(), ==, STATE_STARTING);
 
     sys.active = FALSE;
     state_update_systemd(&sys);
@@ -284,7 +285,7 @@ static void test_transition_into_systemd_unavailable(void) {
     sys.installed = TRUE;
     sys.active = TRUE;
     state_update_systemd(&sys);
-    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+    g_assert_cmpint(state_get_current(), ==, STATE_STARTING);
 
     sys.systemd_unavailable = TRUE;
     state_update_systemd(&sys);
@@ -341,8 +342,8 @@ static void test_health_zero_timestamp_preserves_systemd_running(void) {
     hs_zero.last_updated = 0;
     state_update_health(&hs_zero);
 
-    // Systemd still active + no valid health data → startup hydration guard → RUNNING
-    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+    // Systemd still active + no valid health data → startup hydration guard → STARTING
+    g_assert_cmpint(state_get_current(), ==, STATE_STARTING);
 }
 
 static void test_activation_boundary_health_persists_through_stop(void) {
@@ -378,6 +379,7 @@ static void test_activation_boundary_health_persists_through_stop(void) {
     hs_down.last_updated = 12346;
     hs_down.http_ok = FALSE;
     hs_down.ws_connected = FALSE;
+    hs_down.config_valid = TRUE;
     state_update_health(&hs_down);
     // Now systemd says stopped + native says unreachable → STOPPED
     g_assert_cmpint(state_get_current(), ==, STATE_STOPPED);
@@ -406,6 +408,105 @@ static void test_systemd_stop_does_not_regress_native_connected(void) {
     // Systemd says stopped, but native health persists → RUNNING
     sys.active = FALSE;
     state_update_systemd(&sys);
+    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+}
+
+/* ── Readiness decision table tests ── */
+
+static void test_readiness_needs_setup(void) {
+    // No unit installed, no setup detected → NEEDS_SETUP
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = FALSE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.setup_detected = FALSE;
+    hs.config_valid = FALSE;
+    state_update_health(&hs);
+
+    g_assert_cmpint(state_get_current(), ==, STATE_NEEDS_SETUP);
+}
+
+static void test_readiness_needs_gateway_install(void) {
+    // No unit installed, but setup is detected → NEEDS_GATEWAY_INSTALL
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = FALSE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.setup_detected = TRUE;
+    hs.config_valid = TRUE;
+    state_update_health(&hs);
+
+    g_assert_cmpint(state_get_current(), ==, STATE_NEEDS_GATEWAY_INSTALL);
+}
+
+static void test_readiness_config_invalid_when_stopped(void) {
+    // Unit installed, stopped, config invalid → CONFIG_INVALID
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = FALSE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.config_valid = FALSE;
+    state_update_health(&hs);
+
+    g_assert_cmpint(state_get_current(), ==, STATE_CONFIG_INVALID);
+}
+
+static void test_readiness_config_invalid_when_active_unreachable(void) {
+    // Unit installed, systemd active, HTTP unreachable, config invalid → CONFIG_INVALID
+    // (config invalidity surfaces when runtime truth has not proven usability)
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.http_ok = FALSE;
+    hs.config_valid = FALSE;
+    state_update_health(&hs);
+
+    g_assert_cmpint(state_get_current(), ==, STATE_CONFIG_INVALID);
+}
+
+static void test_readiness_startup_hydration_is_starting(void) {
+    // Systemd active, no health data yet → STARTING (not RUNNING)
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    g_assert_cmpint(state_get_current(), ==, STATE_STARTING);
+}
+
+static void test_readiness_startup_hydration_to_running(void) {
+    // Hydration → STARTING, then health confirms → RUNNING
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+    g_assert_cmpint(state_get_current(), ==, STATE_STARTING);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.http_ok = TRUE;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    hs.config_valid = TRUE;
+    state_update_health(&hs);
     g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
 }
 
@@ -439,6 +540,14 @@ int main(int argc, char **argv) {
     g_test_add_func("/state/health_zero_timestamp_preserves_systemd_running", test_health_zero_timestamp_preserves_systemd_running);
     g_test_add_func("/state/activation_boundary_health_persists_through_stop", test_activation_boundary_health_persists_through_stop);
     g_test_add_func("/state/systemd_stop_does_not_regress_native_connected", test_systemd_stop_does_not_regress_native_connected);
+
+    /* Readiness decision table tests */
+    g_test_add_func("/state/readiness/needs_setup", test_readiness_needs_setup);
+    g_test_add_func("/state/readiness/needs_gateway_install", test_readiness_needs_gateway_install);
+    g_test_add_func("/state/readiness/config_invalid_when_stopped", test_readiness_config_invalid_when_stopped);
+    g_test_add_func("/state/readiness/config_invalid_when_active_unreachable", test_readiness_config_invalid_when_active_unreachable);
+    g_test_add_func("/state/readiness/startup_hydration_is_starting", test_readiness_startup_hydration_is_starting);
+    g_test_add_func("/state/readiness/startup_hydration_to_running", test_readiness_startup_hydration_to_running);
 
     return g_test_run();
 }


### PR DESCRIPTION
state.h: replace STATE_NOT_INSTALLED with STATE_NEEDS_SETUP, add STATE_NEEDS_GATEWAY_INSTALL and STATE_CONFIG_INVALID, and extend HealthState with setup_detected.

state.c: rewrite compute_state() as six labeled layers enforcing a 15-row readiness decision table with explicit three-layer precedence:
  1. Runtime truth (http_ok + ws_connected + rpc_ok + auth_ok) decides ready.
  2. Setup/config/install context explains non-ready when runtime has not proven usability.
  3. Systemd contributes lifecycle context but never proves readiness alone. Fix startup hydration: systemd active + no health data → STATE_STARTING, not STATE_RUNNING. Add STATE_CONFIG_INVALID gated on has_health_data. Add STATE_NEEDS_GATEWAY_INSTALL using setup_detected. Wire setup_detected through state_update_health(). Update state_enum_to_string() and state_get_current_string().

gateway_client.c: add detect_setup_presence() that checks whether the config file or its parent directory exists. Call it after every config load/reload. Propagate current_setup_detected in every HealthState publication (both publish_health_state() and publish_invalid_config_state()). Also enforce WS/HTTP cross-transport coherence in on_ws_status(): when WS is connected and RPC is OK, treat the endpoint as provably reachable and normalize stale http_ok=FALSE to TRUE. Trigger an immediate do_health_check() on WS connect so HTTP-specific fields refresh without waiting for the poll interval.

readiness.c/.h (new): implement readiness_evaluate(AppState, HealthState*, SystemdState*, ReadinessInfo*) producing classification, missing prerequisite, and next recommended action for all 12 AppState values. DEGRADED includes context-sensitive sub-paths based on http_ok/ws_connected/sys->active state. Presenter consumes canonical AppState — no second decision table.

diagnostics.c: restructure build_diagnostics_text() using GString to produce four sections in order: Readiness (readiness_evaluate()), Systemd Service, Gateway Connectivity, Configuration. Include setup_detected in Configuration.

tray.c: add case coverage for STATE_NEEDS_SETUP, STATE_NEEDS_GATEWAY_INSTALL, and STATE_CONFIG_INVALID in tray_update_from_state() (no-action sensitivity).

meson.build: add src/readiness.c to main executable sources and test_state sources; add test_readiness target linked against src/readiness.c.

tests/test_readiness.c (new): 17 tests covering all 12 AppState values, DEGRADED sub-paths, null-output guard, and structural assertions.

tests/test_state.c: update 8 existing tests for startup-hydration STARTING semantics and STATE_NEEDS_SETUP rename; add config_valid=TRUE where needed to prevent false STATE_CONFIG_INVALID; add 6 new readiness decision-table tests (needs_setup, needs_gateway_install, config_invalid when stopped and when active+unreachable, startup_hydration_is_starting, startup_hydration_to_running).