### PR TITLE
fix(linux): classify HTTP probe failures in readiness and diagnostics (#42)

### DIFF
--- a/apps/linux/src/diagnostics.c
+++ b/apps/linux/src/diagnostics.c
@@ -70,7 +70,16 @@ static gchar* build_diagnostics_text(void) {
     g_string_append_printf(out, "Endpoint: %s:%d\n",
         health->endpoint_host ? health->endpoint_host : "127.0.0.1",
         health->endpoint_port);
-    g_string_append_printf(out, "HTTP Health: %s\n", health->http_ok ? "OK" : "Unreachable");
+    const char *http_probe_str;
+    switch (health->http_probe_result) {
+    case HTTP_PROBE_OK:                      http_probe_str = "OK"; break;
+    case HTTP_PROBE_CONNECT_REFUSED:         http_probe_str = "Connect Refused"; break;
+    case HTTP_PROBE_CONNECT_TIMEOUT:         http_probe_str = "Connect Timeout"; break;
+    case HTTP_PROBE_TIMED_OUT_AFTER_CONNECT: http_probe_str = "Timed Out After Connect"; break;
+    case HTTP_PROBE_INVALID_RESPONSE:        http_probe_str = "Invalid Response"; break;
+    default:                                 http_probe_str = "Unreachable"; break;
+    }
+    g_string_append_printf(out, "HTTP Health: %s\n", http_probe_str);
     g_string_append_printf(out, "WebSocket: %s\n", health->ws_connected ? "Connected" : "Disconnected");
     g_string_append_printf(out, "RPC OK: %s\n", health->rpc_ok ? "Yes" : "No");
     g_string_append_printf(out, "Auth OK: %s\n", health->auth_ok ? "Yes" : "No");

--- a/apps/linux/src/gateway_client.c
+++ b/apps/linux/src/gateway_client.c
@@ -66,7 +66,8 @@ static GatewayConfig* load_config_with_context(void) {
     return cfg;
 }
 
-static void publish_health_state(gboolean http_ok, gboolean ws_connected,
+static void publish_health_state(gboolean http_ok, HttpProbeResult http_probe_result,
+                                  gboolean ws_connected,
                                   gboolean rpc_ok, gboolean auth_ok,
                                   const gchar *gateway_version,
                                   const gchar *auth_source,
@@ -74,6 +75,7 @@ static void publish_health_state(gboolean http_ok, gboolean ws_connected,
     HealthState hs = {0};
     hs.last_updated = g_get_real_time();
     hs.http_ok = http_ok;
+    hs.http_probe_result = http_probe_result;
     hs.ws_connected = ws_connected;
     hs.rpc_ok = rpc_ok;
     hs.auth_ok = auth_ok;
@@ -143,12 +145,15 @@ static void on_ws_status(const GatewayWsStatus *status, gpointer user_data) {
      * snapshot "HTTP unreachable + WS connected + RPC OK" which the readiness
      * model would classify as DEGRADED even though the gateway is fully usable.
      */
+    HttpProbeResult probe_result = current ? current->http_probe_result : HTTP_PROBE_NONE;
     if (ws_connected && status->rpc_ok) {
         http_ok = TRUE;
+        probe_result = HTTP_PROBE_OK;
     }
 
     publish_health_state(
         http_ok,
+        probe_result,
         ws_connected,
         status->rpc_ok,
         auth_ok,
@@ -214,6 +219,7 @@ static void on_health_result(const GatewayHealthResult *result, gpointer user_da
 
     publish_health_state(
         result->ok,
+        result->probe_result,
         ws_connected,
         current ? current->rpc_ok : FALSE,
         current ? current->auth_ok : FALSE,

--- a/apps/linux/src/gateway_http.c
+++ b/apps/linux/src/gateway_http.c
@@ -13,6 +13,7 @@
 #include "log.h"
 #include <libsoup/soup.h>
 #include <json-glib/json-glib.h>
+#include <gio/gio.h>
 
 static SoupSession *http_session = NULL;
 
@@ -37,7 +38,54 @@ typedef struct {
     GatewayHealthCallback callback;
     gpointer user_data;
     SoupMessage *msg; /* retained for HTTP status inspection in callback */
+    gboolean tcp_connected; /* phase tracking: set by network-event signal */
 } HealthCheckContext;
+
+/*
+ * Phase-aware probe failure classification.
+ *
+ * libsoup3's soup_session_send_and_read_finish collapses both
+ * connect-timeout and response-timeout into the same GError code
+ * (G_IO_ERROR_TIMED_OUT or similar). To distinguish "timed out before
+ * connect" from "timed out after connect established," we rely on the
+ * tcp_connected flag set by the SoupMessage::network-event signal at
+ * G_SOCKET_CLIENT_CONNECTED.
+ */
+static HttpProbeResult classify_probe_error(const GError *error,
+                                             gboolean tcp_connected) {
+    if (!error) return HTTP_PROBE_UNKNOWN_ERROR;
+
+    if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CONNECTION_REFUSED))
+        return HTTP_PROBE_CONNECT_REFUSED;
+
+    if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_HOST_UNREACHABLE) ||
+        g_error_matches(error, G_IO_ERROR, G_IO_ERROR_NETWORK_UNREACHABLE))
+        return HTTP_PROBE_CONNECT_REFUSED;
+
+    /*
+     * Timeout disambiguation: if tcp_connected is TRUE, the TCP handshake
+     * completed before the timeout fired, proving the listener was present.
+     * Otherwise, the timeout happened during connect (no listener proof).
+     */
+    if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT) ||
+        g_error_matches(error, G_IO_ERROR, G_IO_ERROR_HOST_NOT_FOUND)) {
+        return tcp_connected ? HTTP_PROBE_TIMED_OUT_AFTER_CONNECT
+                             : HTTP_PROBE_CONNECT_TIMEOUT;
+    }
+
+    return tcp_connected ? HTTP_PROBE_TIMED_OUT_AFTER_CONNECT
+                         : HTTP_PROBE_UNKNOWN_ERROR;
+}
+
+static void on_network_event(SoupMessage *msg, GSocketClientEvent event,
+                              GIOStream *connection, gpointer user_data) {
+    (void)msg;
+    (void)connection;
+    HealthCheckContext *ctx = (HealthCheckContext *)user_data;
+    if (event == G_SOCKET_CLIENT_CONNECTED) {
+        ctx->tcp_connected = TRUE;
+    }
+}
 
 static void on_health_response(GObject *source, GAsyncResult *res, gpointer user_data) {
     HealthCheckContext *ctx = (HealthCheckContext *)user_data;
@@ -49,8 +97,10 @@ static void on_health_response(GObject *source, GAsyncResult *res, gpointer user
 
     if (!body) {
         result.ok = FALSE;
+        result.probe_result = classify_probe_error(error, ctx->tcp_connected);
         result.error = g_strdup_printf("Health check failed: %s", error ? error->message : "unknown");
-        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY, "http health error: %s", result.error);
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY, "http health error: %s (probe_result=%d tcp_connected=%d)",
+                  result.error, result.probe_result, ctx->tcp_connected);
         if (ctx->callback) ctx->callback(&result, ctx->user_data);
         g_free(result.error);
         g_object_unref(ctx->msg);
@@ -62,6 +112,7 @@ static void on_health_response(GObject *source, GAsyncResult *res, gpointer user
     guint status_code = soup_message_get_status(ctx->msg);
     if (status_code < 200 || status_code >= 300) {
         result.ok = FALSE;
+        result.probe_result = HTTP_PROBE_INVALID_RESPONSE;
         result.error = g_strdup_printf("Health check HTTP %u", status_code);
         OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY, "http health non-ok status: %u", status_code);
         g_bytes_unref(body);
@@ -85,6 +136,7 @@ static void on_health_response(GObject *source, GAsyncResult *res, gpointer user
     g_autoptr(JsonParser) parser = json_parser_new();
     if (!data || size == 0 || !json_parser_load_from_data(parser, data, size, NULL)) {
         result.ok = FALSE;
+        result.probe_result = HTTP_PROBE_INVALID_RESPONSE;
         result.error = g_strdup("Health response is not valid JSON");
         OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY, "http health non-json response");
         g_bytes_unref(body);
@@ -98,6 +150,7 @@ static void on_health_response(GObject *source, GAsyncResult *res, gpointer user
     JsonNode *root = json_parser_get_root(parser);
     if (!root || !JSON_NODE_HOLDS_OBJECT(root)) {
         result.ok = FALSE;
+        result.probe_result = HTTP_PROBE_INVALID_RESPONSE;
         result.error = g_strdup("Health response is not a JSON object");
         OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY, "http health non-object json");
         g_bytes_unref(body);
@@ -114,6 +167,7 @@ static void on_health_response(GObject *source, GAsyncResult *res, gpointer user
                       : NULL;
     if (!ok_node || json_node_get_value_type(ok_node) != G_TYPE_BOOLEAN) {
         result.ok = FALSE;
+        result.probe_result = HTTP_PROBE_INVALID_RESPONSE;
         result.error = ok_node
             ? g_strdup("Health response 'ok' field is not a boolean (wrong service?)")
             : g_strdup("Health response missing 'ok' field (wrong service?)");
@@ -128,6 +182,7 @@ static void on_health_response(GObject *source, GAsyncResult *res, gpointer user
     }
 
     result.ok = TRUE;
+    result.probe_result = HTTP_PROBE_OK;
     result.healthy = json_node_get_boolean(ok_node);
 
     if (json_object_has_member(obj, "version")) {
@@ -167,6 +222,7 @@ void gateway_http_check_health(const gchar *base_url, GatewayHealthCallback call
     ctx->user_data = user_data;
     ctx->msg = g_object_ref(msg); /* retain for status inspection in callback */
 
+    g_signal_connect(msg, "network-event", G_CALLBACK(on_network_event), ctx);
     soup_session_send_and_read_async(http_session, msg, G_PRIORITY_DEFAULT, NULL, on_health_response, ctx);
     g_object_unref(msg);
 }

--- a/apps/linux/src/gateway_http.h
+++ b/apps/linux/src/gateway_http.h
@@ -13,10 +13,12 @@
 #define OPENCLAW_LINUX_GATEWAY_HTTP_H
 
 #include <glib.h>
+#include "state.h"
 
 typedef struct {
     gboolean ok;
     gboolean healthy;
+    HttpProbeResult probe_result; /* phase-aware probe outcome */
     gchar *version;
     gchar *error;
 } GatewayHealthResult;

--- a/apps/linux/src/readiness.c
+++ b/apps/linux/src/readiness.c
@@ -93,11 +93,19 @@ void readiness_evaluate(AppState state, const HealthState *health,
         } else if (health && health->http_ok && health->ws_connected) {
             out->missing = "Connected, but RPC or auth handshake incomplete.";
         } else if (health && !health->http_ok && sys && sys->active) {
-            out->missing = "Service reports active, but gateway is not reachable via HTTP.";
+            if (health->http_probe_result == HTTP_PROBE_TIMED_OUT_AFTER_CONNECT) {
+                out->missing = "Gateway accepted a connection but did not respond in time.";
+                out->next_action = "Gateway process may be hung. Check gateway logs and restart the service.";
+            } else {
+                out->missing = "Service reports active, but gateway is not reachable via HTTP.";
+                out->next_action = "Check gateway logs and network configuration. Try restarting the service.";
+            }
         } else {
             out->missing = "Gateway connectivity is partially established.";
         }
-        out->next_action = "Check gateway logs and network configuration. Try restarting the service.";
+        if (!out->next_action) {
+            out->next_action = "Check gateway logs and network configuration. Try restarting the service.";
+        }
         break;
 
     case STATE_ERROR:

--- a/apps/linux/src/state.c
+++ b/apps/linux/src/state.c
@@ -238,6 +238,7 @@ void state_update_health(const HealthState *health_state) {
 
     current_health_state.last_updated = health_state->last_updated;
     current_health_state.http_ok = health_state->http_ok;
+    current_health_state.http_probe_result = health_state->http_probe_result;
     current_health_state.ws_connected = health_state->ws_connected;
     current_health_state.rpc_ok = health_state->rpc_ok;
     current_health_state.auth_ok = health_state->auth_ok;

--- a/apps/linux/src/state.h
+++ b/apps/linux/src/state.h
@@ -48,10 +48,21 @@ typedef struct {
     char *sub_state;
 } SystemdState;
 
+typedef enum {
+    HTTP_PROBE_NONE = 0,                /* no probe attempted yet */
+    HTTP_PROBE_OK,                      /* 2xx + valid JSON health response */
+    HTTP_PROBE_CONNECT_REFUSED,         /* TCP connect refused (nothing listening) */
+    HTTP_PROBE_CONNECT_TIMEOUT,         /* TCP connect timed out (no SYN-ACK) */
+    HTTP_PROBE_TIMED_OUT_AFTER_CONNECT, /* TCP connected, no HTTP response in time */
+    HTTP_PROBE_INVALID_RESPONSE,        /* got bytes, but not valid gateway health */
+    HTTP_PROBE_UNKNOWN_ERROR,           /* catch-all */
+} HttpProbeResult;
+
 typedef struct {
     gint64 last_updated; /* g_get_real_time() in microseconds */
 
     gboolean http_ok;       /* GET /health succeeded */
+    HttpProbeResult http_probe_result; /* phase-aware probe outcome */
     gboolean ws_connected;  /* WebSocket handshake complete */
     gboolean rpc_ok;        /* RPC channel operational */
     gboolean auth_ok;       /* Auth handshake succeeded */

--- a/apps/linux/tests/test_readiness.c
+++ b/apps/linux/tests/test_readiness.c
@@ -224,6 +224,7 @@ static void test_presenter_degraded_systemd_active_http_unreachable(void) {
     ReadinessInfo ri;
     HealthState hs = {0};
     hs.http_ok = FALSE;
+    hs.http_probe_result = HTTP_PROBE_CONNECT_REFUSED;
     SystemdState sys = {0};
     sys.active = TRUE;
 
@@ -232,6 +233,44 @@ static void test_presenter_degraded_systemd_active_http_unreachable(void) {
     g_assert_cmpstr(ri.classification, ==, "Degraded");
     g_assert_nonnull(ri.missing);
     assert_contains(ri.missing, "not reachable", "degraded_active_http.missing");
+    /* Must NOT claim listener present for connect-refused */
+    g_assert_null(strstr(ri.missing, "accepted a connection"));
+    g_assert_nonnull(ri.next_action);
+}
+
+static void test_presenter_degraded_timed_out_after_connect(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    hs.http_ok = FALSE;
+    hs.http_probe_result = HTTP_PROBE_TIMED_OUT_AFTER_CONNECT;
+    SystemdState sys = {0};
+    sys.active = TRUE;
+
+    readiness_evaluate(STATE_DEGRADED, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Degraded");
+    g_assert_nonnull(ri.missing);
+    assert_contains(ri.missing, "accepted a connection", "degraded_timeout_after_connect.missing");
+    assert_contains(ri.missing, "did not respond", "degraded_timeout_after_connect.missing2");
+    g_assert_nonnull(ri.next_action);
+    assert_contains(ri.next_action, "hung", "degraded_timeout_after_connect.next_action");
+}
+
+static void test_presenter_degraded_unknown_error_active(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    hs.http_ok = FALSE;
+    hs.http_probe_result = HTTP_PROBE_UNKNOWN_ERROR;
+    SystemdState sys = {0};
+    sys.active = TRUE;
+
+    readiness_evaluate(STATE_DEGRADED, &hs, &sys, &ri);
+
+    g_assert_cmpstr(ri.classification, ==, "Degraded");
+    g_assert_nonnull(ri.missing);
+    assert_contains(ri.missing, "not reachable", "degraded_unknown_active.missing");
+    /* Must NOT claim listener present for unknown error */
+    g_assert_null(strstr(ri.missing, "accepted a connection"));
     g_assert_nonnull(ri.next_action);
 }
 
@@ -302,6 +341,8 @@ int main(int argc, char **argv) {
     g_test_add_func("/readiness/degraded/http_ok_ws_disconnected", test_presenter_degraded_http_ok_ws_disconnected);
     g_test_add_func("/readiness/degraded/connected_rpc_incomplete", test_presenter_degraded_connected_rpc_incomplete);
     g_test_add_func("/readiness/degraded/systemd_active_http_unreachable", test_presenter_degraded_systemd_active_http_unreachable);
+    g_test_add_func("/readiness/degraded/timed_out_after_connect", test_presenter_degraded_timed_out_after_connect);
+    g_test_add_func("/readiness/degraded/unknown_error_active", test_presenter_degraded_unknown_error_active);
     g_test_add_func("/readiness/degraded/fallback", test_presenter_degraded_fallback);
 
     /* Error sub-path tests */


### PR DESCRIPTION
Add proof-oriented HTTP probe classification so the Linux companion can distinguish generic unreachable failures from timeouts that occur after TCP connect succeeds.

- add HttpProbeResult to HealthState and GatewayHealthResult
- track tcp_connected in gateway_http via SoupMessage::network-event
- classify probe failures as connect refused, connect timeout, timed out after connect, invalid response, or unknown
- thread http_probe_result through gateway_client into state
- update degraded readiness text to only claim "accepted a connection but did not respond" when that was proven
- replace binary HTTP Health OK/Unreachable with probe-result-specific diagnostics strings
- add readiness tests for timed-out-after-connect and unknown-error degraded subtypes, and guard against overclaiming listener presence
- 
Validated against the failure case where the gateway accepts TCP connections but does not answer in time; healthy-path behavior remains covered by existing readiness/state tests, though this machine was not in a healthy runtime state during manual verification.