### PR TITLE
feat(linux): add proof-oriented runtime mode as a second semantic axis (#44)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -38,6 +38,7 @@ sources = [
   'src/gateway_ws.c',
   'src/gateway_client.c',
   'src/state.c',
+  'src/runtime_mode.c',
   'src/readiness.c',
   'src/notify.c',
   'src/diagnostics.c',
@@ -66,7 +67,7 @@ install_data('ai.openclaw.Companion.desktop',
 
 # Local Tests
 test_state_exe = executable('test_state',
-  ['tests/test_state.c', 'src/state.c', 'src/readiness.c', 'src/log.c'],
+  ['tests/test_state.c', 'src/state.c', 'src/runtime_mode.c', 'src/readiness.c', 'src/log.c'],
   dependencies : [glib_dep, gio_dep])
 test('state', test_state_exe)
 
@@ -79,6 +80,16 @@ test_readiness_exe = executable('test_readiness',
   ['tests/test_readiness.c', 'src/readiness.c'],
   dependencies : [glib_dep])
 test('readiness', test_readiness_exe)
+
+test_runtime_mode_exe = executable('test_runtime_mode',
+  ['tests/test_runtime_mode.c', 'src/state.c', 'src/runtime_mode.c', 'src/readiness.c', 'src/log.c'],
+  dependencies : [glib_dep, gio_dep])
+test('runtime_mode', test_runtime_mode_exe)
+
+test_runtime_mode_pres_exe = executable('test_runtime_mode_presentation',
+  ['tests/test_runtime_mode_presentation.c', 'src/runtime_mode.c'],
+  dependencies : [glib_dep])
+test('runtime_mode_presentation', test_runtime_mode_pres_exe)
 
 test_gateway_exe = executable('test_gateway',
   ['tests/test_gateway.c', 'src/gateway_config.c', 'src/gateway_protocol.c', 'src/log.c'],

--- a/apps/linux/src/diagnostics.c
+++ b/apps/linux/src/diagnostics.c
@@ -57,6 +57,16 @@ static gchar* build_diagnostics_text(void) {
         g_string_append_printf(out, "Next:   %s\n", ri.next_action);
     }
 
+    /* Runtime mode */
+    RuntimeMode rm = state_get_runtime_mode();
+    RuntimeModePresentation rmp;
+    runtime_mode_describe(rm, &rmp);
+    g_string_append_printf(out, "\n=== Runtime Mode ===\n");
+    g_string_append_printf(out, "Mode: %s\n", rmp.label ? rmp.label : "Unknown");
+    g_string_append_printf(out, "Detail: %s\n", rmp.explanation ? rmp.explanation : "N/A");
+    g_string_append_printf(out, "Listener Proven: %s\n",
+        health_state_listener_proven(health) ? "Yes" : "No");
+
     /* Systemd service context */
     g_string_append_printf(out, "\n=== Systemd Service ===\n");
     g_string_append_printf(out, "Unit: %s\n", sys->unit_name ? sys->unit_name : "N/A");

--- a/apps/linux/src/runtime_mode.c
+++ b/apps/linux/src/runtime_mode.c
@@ -1,0 +1,143 @@
+/*
+ * runtime_mode.c
+ *
+ * Proof-oriented runtime-mode derivation for the OpenClaw Linux Companion App.
+ *
+ * Computes a RuntimeMode classification from the available evidence
+ * (SystemdState + HealthState). This is a separate semantic dimension
+ * from AppState: AppState answers "what lifecycle/readiness class?"
+ * while RuntimeMode answers "what kind of runtime situation was observed?"
+ *
+ * These classifications describe what the app can actually infer from
+ * its evidence model. They do NOT claim lifecycle ownership ("started
+ * by us") or macOS-style attach knowledge ("adopted existing").
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "state.h"
+#include <stddef.h>
+
+gboolean health_state_listener_proven(const HealthState *hs) {
+    if (!hs) return FALSE;
+    return hs->http_probe_result == HTTP_PROBE_OK
+        || hs->http_probe_result == HTTP_PROBE_TIMED_OUT_AFTER_CONNECT
+        || hs->http_probe_result == HTTP_PROBE_INVALID_RESPONSE;
+}
+
+RuntimeMode runtime_mode_compute(const SystemdState *sys, const HealthState *health) {
+    gboolean has_health_data = (health && health->last_updated > 0);
+    gboolean expected_service_active = (sys && sys->installed && sys->active);
+
+    /*
+     * Runtime evidence: at least one actual probe or transport signal
+     * beyond config/setup checks. Health state can be populated from
+     * config parsing alone (setup_detected, config_valid) without any
+     * runtime probe — that does NOT count as runtime evidence.
+     */
+    gboolean has_runtime_evidence = has_health_data && (
+        health->http_probe_result != HTTP_PROBE_NONE ||
+        health->ws_connected ||
+        health->rpc_ok ||
+        health->auth_ok
+    );
+
+    gboolean gateway_fully_healthy = has_runtime_evidence
+        && health->http_ok
+        && health->ws_connected
+        && health->rpc_ok
+        && health->auth_ok;
+
+    gboolean listener_proven = has_runtime_evidence && health_state_listener_proven(health);
+
+    /* No runtime evidence gathered yet */
+    if (!has_runtime_evidence) {
+        if (expected_service_active) {
+            return RUNTIME_SERVICE_ACTIVE_NOT_PROVEN;
+        }
+        return RUNTIME_NONE;
+    }
+
+    /* Fully healthy endpoint */
+    if (gateway_fully_healthy) {
+        if (expected_service_active) {
+            return RUNTIME_EXPECTED_SERVICE_HEALTHY;
+        }
+        return RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE;
+    }
+
+    /* Listener proven present but not fully healthy */
+    if (listener_proven) {
+        if (health->http_probe_result == HTTP_PROBE_INVALID_RESPONSE) {
+            return RUNTIME_LISTENER_PRESENT_UNVERIFIED;
+        }
+        if (health->http_probe_result == HTTP_PROBE_TIMED_OUT_AFTER_CONNECT) {
+            return RUNTIME_LISTENER_PRESENT_UNRESPONSIVE;
+        }
+        /* HTTP_PROBE_OK but not fully healthy → partial protocol */
+        return RUNTIME_LISTENER_PRESENT_UNRESPONSIVE;
+    }
+
+    /* Service active but no listener proof */
+    if (expected_service_active) {
+        return RUNTIME_SERVICE_ACTIVE_NOT_PROVEN;
+    }
+
+    return RUNTIME_UNKNOWN;
+}
+
+void runtime_mode_describe(RuntimeMode mode, RuntimeModePresentation *out) {
+    if (!out) return;
+
+    out->label = NULL;
+    out->explanation = NULL;
+
+    switch (mode) {
+    case RUNTIME_NONE:
+        out->label = "No Runtime Detected";
+        out->explanation = "No gateway runtime evidence has been gathered.";
+        break;
+
+    case RUNTIME_EXPECTED_SERVICE_HEALTHY:
+        out->label = "Expected Service Healthy";
+        out->explanation =
+            "The expected user systemd service path is active and the "
+            "configured endpoint is healthy.";
+        break;
+
+    case RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE:
+        out->label = "Healthy (Outside Expected Service)";
+        out->explanation =
+            "A healthy gateway is reachable at the configured endpoint, "
+            "but the expected user systemd service is not the active "
+            "explanation.";
+        break;
+
+    case RUNTIME_LISTENER_PRESENT_UNRESPONSIVE:
+        out->label = "Listener Present (Unresponsive)";
+        out->explanation =
+            "A listener accepted a connection on the configured endpoint, "
+            "but health/protocol readiness was not established.";
+        break;
+
+    case RUNTIME_LISTENER_PRESENT_UNVERIFIED:
+        out->label = "Listener Present (Unverified)";
+        out->explanation =
+            "Something is listening on the configured endpoint, but it "
+            "was not validated as a healthy OpenClaw gateway.";
+        break;
+
+    case RUNTIME_SERVICE_ACTIVE_NOT_PROVEN:
+        out->label = "Service Active (Not Proven)";
+        out->explanation =
+            "The systemd service reports active, but runtime health has "
+            "not been confirmed yet.";
+        break;
+
+    case RUNTIME_UNKNOWN:
+    default:
+        out->label = "Unknown";
+        out->explanation = "Runtime state could not be classified.";
+        break;
+    }
+}

--- a/apps/linux/src/state.c
+++ b/apps/linux/src/state.c
@@ -24,11 +24,15 @@
 #include "state.h"
 
 static AppState current_state = STATE_NEEDS_SETUP;
+static RuntimeMode current_runtime_mode = RUNTIME_NONE;
 static SystemdState current_sys_state = {0};
 static HealthState current_health_state = {0};
 static guint64 current_health_generation = 0;
 static gboolean initial_hydration_done = FALSE;
 static gboolean initial_refresh_fired = FALSE;
+
+/* Defined in runtime_mode.c — internal to the state module */
+extern RuntimeMode runtime_mode_compute(const SystemdState *sys, const HealthState *health);
 
 static AppState compute_state(void) {
     gboolean has_health_data = (current_health_state.last_updated > 0);
@@ -122,6 +126,7 @@ static AppState compute_state(void) {
 
 void state_init(void) {
     current_state = STATE_NEEDS_SETUP;
+    current_runtime_mode = RUNTIME_NONE;
     initial_hydration_done = FALSE;
     initial_refresh_fired = FALSE;
 
@@ -219,6 +224,7 @@ void state_update_systemd(const SystemdState *sys_state) {
      */
 
     AppState new_state = compute_state();
+    current_runtime_mode = runtime_mode_compute(&current_sys_state, &current_health_state);
 
     gboolean should_trigger_refresh = (!initial_refresh_fired || became_active || became_inactive || unit_changed);
     if (should_trigger_refresh) {
@@ -253,7 +259,9 @@ void state_update_health(const HealthState *health_state) {
     current_health_state.auth_source = g_strdup(health_state->auth_source);
     current_health_state.last_error = g_strdup(health_state->last_error);
 
-    trigger_updates(compute_state());
+    AppState new_state = compute_state();
+    current_runtime_mode = runtime_mode_compute(&current_sys_state, &current_health_state);
+    trigger_updates(new_state);
 }
 
 AppState state_get_current(void) {
@@ -276,6 +284,10 @@ const char* state_get_current_string(void) {
         case STATE_ERROR: return "Error";
         default: return "Unknown";
     }
+}
+
+RuntimeMode state_get_runtime_mode(void) {
+    return current_runtime_mode;
 }
 
 SystemdState* state_get_systemd(void) {

--- a/apps/linux/src/state.h
+++ b/apps/linux/src/state.h
@@ -80,6 +80,31 @@ typedef struct {
     int config_issues_count;
 } HealthState;
 
+/* ---------- Runtime Mode (proof-oriented) ----------
+ *
+ * A separate semantic dimension from AppState. AppState answers "what
+ * lifecycle/readiness class are we in?" RuntimeMode answers "what kind
+ * of runtime situation was observed from the available evidence?"
+ *
+ * These names describe what the app can actually infer — they do NOT
+ * claim lifecycle ownership ("started by us") or macOS-style attach
+ * knowledge ("adopted existing").
+ */
+typedef enum {
+    RUNTIME_NONE,                             /* no runtime evidence gathered yet */
+    RUNTIME_EXPECTED_SERVICE_HEALTHY,          /* expected systemd unit active + endpoint healthy */
+    RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE,  /* endpoint healthy, expected unit not the active explanation */
+    RUNTIME_LISTENER_PRESENT_UNRESPONSIVE,     /* TCP connected (probe-proven), health/protocol failed */
+    RUNTIME_LISTENER_PRESENT_UNVERIFIED,       /* something answered, not validated as healthy OpenClaw */
+    RUNTIME_SERVICE_ACTIVE_NOT_PROVEN,         /* service manager says active, runtime proof missing */
+    RUNTIME_UNKNOWN,                           /* fallback */
+} RuntimeMode;
+
+typedef struct {
+    const char *label;       /* e.g. "Expected Service Healthy" */
+    const char *explanation; /* human-readable detail for diagnostics */
+} RuntimeModePresentation;
+
 void state_init(void);
 void health_state_clear(HealthState *hs);
 void state_update_systemd(const SystemdState *sys_state);
@@ -88,6 +113,10 @@ void state_update_health(const HealthState *health_state);
 AppState state_get_current(void);
 const char* state_get_current_string(void);
 guint64 state_get_health_generation(void);
+
+RuntimeMode state_get_runtime_mode(void);
+gboolean health_state_listener_proven(const HealthState *hs);
+void runtime_mode_describe(RuntimeMode mode, RuntimeModePresentation *out);
 
 SystemdState* state_get_systemd(void);
 HealthState* state_get_health(void);

--- a/apps/linux/tests/test_runtime_mode.c
+++ b/apps/linux/tests/test_runtime_mode.c
@@ -1,0 +1,290 @@
+/*
+ * test_runtime_mode.c
+ *
+ * Tests for the proof-oriented RuntimeMode derivation (Phase 1.5).
+ *
+ * Exercises RuntimeMode through the public state update + accessor path.
+ * Each test also asserts the AppState invariant: compute_state() output
+ * is unchanged by the RuntimeMode addition.
+ *
+ * Naming convention: no test name, comment, or assertion string claims
+ * "started by this app," "managed by us," or "adopted existing."
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include <glib.h>
+#include "../src/state.h"
+
+/* Stubs for callbacks (same as test_state.c) */
+void notify_on_transition(AppState old_state, AppState new_state) {
+    (void)old_state;
+    (void)new_state;
+}
+void tray_update_from_state(AppState state) {
+    (void)state;
+}
+void state_on_gateway_refresh_requested(void) {}
+
+/* ── Scenario A: Fresh machine, no data ── */
+
+static void test_runtime_mode_fresh_machine(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = FALSE;
+    state_update_systemd(&sys);
+
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_NONE);
+    /* AppState invariant */
+    g_assert_cmpint(state_get_current(), ==, STATE_NEEDS_SETUP);
+}
+
+/* ── Scenario B: Setup done, no unit ── */
+
+static void test_runtime_mode_setup_done_no_unit(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = FALSE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.setup_detected = TRUE;
+    hs.config_valid = TRUE;
+    state_update_health(&hs);
+
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_NONE);
+    /* AppState invariant */
+    g_assert_cmpint(state_get_current(), ==, STATE_NEEDS_GATEWAY_INSTALL);
+}
+
+/* ── Scenario C: Unit installed, stopped, no health ── */
+
+static void test_runtime_mode_unit_installed_stopped(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = FALSE;
+    state_update_systemd(&sys);
+
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_NONE);
+    /* AppState invariant */
+    g_assert_cmpint(state_get_current(), ==, STATE_STOPPED);
+}
+
+/* ── Scenario D: Unit active, no health yet ── */
+
+static void test_runtime_mode_service_active_no_health(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_SERVICE_ACTIVE_NOT_PROVEN);
+    /* AppState invariant */
+    g_assert_cmpint(state_get_current(), ==, STATE_STARTING);
+}
+
+/* ── Scenario E: Unit active, fully healthy ── */
+
+static void test_runtime_mode_expected_service_healthy(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.http_ok = TRUE;
+    hs.http_probe_result = HTTP_PROBE_OK;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    hs.config_valid = TRUE;
+    state_update_health(&hs);
+
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_EXPECTED_SERVICE_HEALTHY);
+    /* AppState invariant */
+    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+}
+
+/* ── Scenario F: Fully healthy, unit not active ── */
+
+static void test_runtime_mode_healthy_outside_service_inactive(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = FALSE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.http_ok = TRUE;
+    hs.http_probe_result = HTTP_PROBE_OK;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    hs.config_valid = TRUE;
+    state_update_health(&hs);
+
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE);
+    /* AppState invariant */
+    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+}
+
+/* ── Scenario G: Fully healthy, unit not installed ── */
+
+static void test_runtime_mode_healthy_outside_service_not_installed(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = FALSE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.http_ok = TRUE;
+    hs.http_probe_result = HTTP_PROBE_OK;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    hs.config_valid = TRUE;
+    state_update_health(&hs);
+
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE);
+    /* AppState invariant */
+    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+}
+
+/* ── Scenario H: Listener present, health times out ── */
+
+static void test_runtime_mode_listener_unresponsive(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.http_ok = FALSE;
+    hs.http_probe_result = HTTP_PROBE_TIMED_OUT_AFTER_CONNECT;
+    hs.ws_connected = FALSE;
+    hs.config_valid = TRUE;
+    state_update_health(&hs);
+
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_LISTENER_PRESENT_UNRESPONSIVE);
+    /* AppState invariant */
+    g_assert_cmpint(state_get_current(), ==, STATE_DEGRADED);
+}
+
+/* ── Scenario I: Listener present, invalid response ── */
+
+static void test_runtime_mode_listener_unverified(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.http_ok = FALSE;
+    hs.http_probe_result = HTTP_PROBE_INVALID_RESPONSE;
+    hs.ws_connected = FALSE;
+    hs.config_valid = TRUE;
+    state_update_health(&hs);
+
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_LISTENER_PRESENT_UNVERIFIED);
+    /* AppState invariant */
+    g_assert_cmpint(state_get_current(), ==, STATE_DEGRADED);
+}
+
+/* ── Scenario J: Unit active, connect refused ── */
+
+static void test_runtime_mode_service_active_connect_refused(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.http_ok = FALSE;
+    hs.http_probe_result = HTTP_PROBE_CONNECT_REFUSED;
+    hs.ws_connected = FALSE;
+    hs.config_valid = TRUE;
+    state_update_health(&hs);
+
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_SERVICE_ACTIVE_NOT_PROVEN);
+    /* Regression: systemd active does NOT prove listener presence */
+    g_assert_false(health_state_listener_proven(&hs));
+    /* AppState invariant */
+    g_assert_cmpint(state_get_current(), ==, STATE_DEGRADED);
+}
+
+/* ── Scenario K: Config invalid, no health data ── */
+
+static void test_runtime_mode_config_invalid(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = FALSE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.config_valid = FALSE;
+    state_update_health(&hs);
+
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_NONE);
+    /* AppState invariant */
+    g_assert_cmpint(state_get_current(), ==, STATE_CONFIG_INVALID);
+}
+
+/* ── Regression: state_init resets runtime mode ── */
+
+static void test_runtime_mode_reset_on_init(void) {
+    state_init();
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.http_ok = TRUE;
+    hs.http_probe_result = HTTP_PROBE_OK;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    hs.config_valid = TRUE;
+    state_update_health(&hs);
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_EXPECTED_SERVICE_HEALTHY);
+
+    state_init();
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_NONE);
+}
+
+/* ── Registration ── */
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/runtime_mode/fresh_machine", test_runtime_mode_fresh_machine);
+    g_test_add_func("/runtime_mode/setup_done_no_unit", test_runtime_mode_setup_done_no_unit);
+    g_test_add_func("/runtime_mode/unit_installed_stopped", test_runtime_mode_unit_installed_stopped);
+    g_test_add_func("/runtime_mode/service_active_no_health", test_runtime_mode_service_active_no_health);
+    g_test_add_func("/runtime_mode/expected_service_healthy", test_runtime_mode_expected_service_healthy);
+    g_test_add_func("/runtime_mode/healthy_outside_service_inactive", test_runtime_mode_healthy_outside_service_inactive);
+    g_test_add_func("/runtime_mode/healthy_outside_service_not_installed", test_runtime_mode_healthy_outside_service_not_installed);
+    g_test_add_func("/runtime_mode/listener_unresponsive", test_runtime_mode_listener_unresponsive);
+    g_test_add_func("/runtime_mode/listener_unverified", test_runtime_mode_listener_unverified);
+    g_test_add_func("/runtime_mode/service_active_connect_refused", test_runtime_mode_service_active_connect_refused);
+    g_test_add_func("/runtime_mode/config_invalid", test_runtime_mode_config_invalid);
+    g_test_add_func("/runtime_mode/reset_on_init", test_runtime_mode_reset_on_init);
+
+    return g_test_run();
+}

--- a/apps/linux/tests/test_runtime_mode_presentation.c
+++ b/apps/linux/tests/test_runtime_mode_presentation.c
@@ -1,0 +1,143 @@
+/*
+ * test_runtime_mode_presentation.c
+ *
+ * Tests for RuntimeMode presentation strings and the
+ * health_state_listener_proven() helper.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include <glib.h>
+#include "../src/state.h"
+
+/* ── runtime_mode_describe: every mode produces non-NULL label + explanation ── */
+
+static void test_describe_none(void) {
+    RuntimeModePresentation p;
+    runtime_mode_describe(RUNTIME_NONE, &p);
+    g_assert_cmpstr(p.label, ==, "No Runtime Detected");
+    g_assert_nonnull(p.explanation);
+}
+
+static void test_describe_expected_service_healthy(void) {
+    RuntimeModePresentation p;
+    runtime_mode_describe(RUNTIME_EXPECTED_SERVICE_HEALTHY, &p);
+    g_assert_cmpstr(p.label, ==, "Expected Service Healthy");
+    g_assert_nonnull(p.explanation);
+}
+
+static void test_describe_healthy_outside_expected_service(void) {
+    RuntimeModePresentation p;
+    runtime_mode_describe(RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE, &p);
+    g_assert_cmpstr(p.label, ==, "Healthy (Outside Expected Service)");
+    g_assert_nonnull(p.explanation);
+}
+
+static void test_describe_listener_unresponsive(void) {
+    RuntimeModePresentation p;
+    runtime_mode_describe(RUNTIME_LISTENER_PRESENT_UNRESPONSIVE, &p);
+    g_assert_cmpstr(p.label, ==, "Listener Present (Unresponsive)");
+    g_assert_nonnull(p.explanation);
+}
+
+static void test_describe_listener_unverified(void) {
+    RuntimeModePresentation p;
+    runtime_mode_describe(RUNTIME_LISTENER_PRESENT_UNVERIFIED, &p);
+    g_assert_cmpstr(p.label, ==, "Listener Present (Unverified)");
+    g_assert_nonnull(p.explanation);
+}
+
+static void test_describe_service_active_not_proven(void) {
+    RuntimeModePresentation p;
+    runtime_mode_describe(RUNTIME_SERVICE_ACTIVE_NOT_PROVEN, &p);
+    g_assert_cmpstr(p.label, ==, "Service Active (Not Proven)");
+    g_assert_nonnull(p.explanation);
+}
+
+static void test_describe_unknown(void) {
+    RuntimeModePresentation p;
+    runtime_mode_describe(RUNTIME_UNKNOWN, &p);
+    g_assert_cmpstr(p.label, ==, "Unknown");
+    g_assert_nonnull(p.explanation);
+}
+
+static void test_describe_null_output(void) {
+    /* Must not crash when out is NULL */
+    runtime_mode_describe(RUNTIME_NONE, NULL);
+}
+
+/* ── health_state_listener_proven: per-probe-result truth table ── */
+
+static void test_listener_proven_ok(void) {
+    HealthState hs = {0};
+    hs.http_probe_result = HTTP_PROBE_OK;
+    g_assert_true(health_state_listener_proven(&hs));
+}
+
+static void test_listener_proven_timed_out_after_connect(void) {
+    HealthState hs = {0};
+    hs.http_probe_result = HTTP_PROBE_TIMED_OUT_AFTER_CONNECT;
+    g_assert_true(health_state_listener_proven(&hs));
+}
+
+static void test_listener_proven_invalid_response(void) {
+    HealthState hs = {0};
+    hs.http_probe_result = HTTP_PROBE_INVALID_RESPONSE;
+    g_assert_true(health_state_listener_proven(&hs));
+}
+
+static void test_listener_not_proven_none(void) {
+    HealthState hs = {0};
+    hs.http_probe_result = HTTP_PROBE_NONE;
+    g_assert_false(health_state_listener_proven(&hs));
+}
+
+static void test_listener_not_proven_connect_refused(void) {
+    HealthState hs = {0};
+    hs.http_probe_result = HTTP_PROBE_CONNECT_REFUSED;
+    g_assert_false(health_state_listener_proven(&hs));
+}
+
+static void test_listener_not_proven_connect_timeout(void) {
+    HealthState hs = {0};
+    hs.http_probe_result = HTTP_PROBE_CONNECT_TIMEOUT;
+    g_assert_false(health_state_listener_proven(&hs));
+}
+
+static void test_listener_not_proven_unknown_error(void) {
+    HealthState hs = {0};
+    hs.http_probe_result = HTTP_PROBE_UNKNOWN_ERROR;
+    g_assert_false(health_state_listener_proven(&hs));
+}
+
+static void test_listener_proven_null_health(void) {
+    g_assert_false(health_state_listener_proven(NULL));
+}
+
+/* ── Registration ── */
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    /* Presentation strings */
+    g_test_add_func("/runtime_mode_presentation/describe_none", test_describe_none);
+    g_test_add_func("/runtime_mode_presentation/describe_expected_service_healthy", test_describe_expected_service_healthy);
+    g_test_add_func("/runtime_mode_presentation/describe_healthy_outside_expected_service", test_describe_healthy_outside_expected_service);
+    g_test_add_func("/runtime_mode_presentation/describe_listener_unresponsive", test_describe_listener_unresponsive);
+    g_test_add_func("/runtime_mode_presentation/describe_listener_unverified", test_describe_listener_unverified);
+    g_test_add_func("/runtime_mode_presentation/describe_service_active_not_proven", test_describe_service_active_not_proven);
+    g_test_add_func("/runtime_mode_presentation/describe_unknown", test_describe_unknown);
+    g_test_add_func("/runtime_mode_presentation/describe_null_output", test_describe_null_output);
+
+    /* Listener-proven truth table */
+    g_test_add_func("/runtime_mode_presentation/listener_proven_ok", test_listener_proven_ok);
+    g_test_add_func("/runtime_mode_presentation/listener_proven_timed_out_after_connect", test_listener_proven_timed_out_after_connect);
+    g_test_add_func("/runtime_mode_presentation/listener_proven_invalid_response", test_listener_proven_invalid_response);
+    g_test_add_func("/runtime_mode_presentation/listener_not_proven_none", test_listener_not_proven_none);
+    g_test_add_func("/runtime_mode_presentation/listener_not_proven_connect_refused", test_listener_not_proven_connect_refused);
+    g_test_add_func("/runtime_mode_presentation/listener_not_proven_connect_timeout", test_listener_not_proven_connect_timeout);
+    g_test_add_func("/runtime_mode_presentation/listener_not_proven_unknown_error", test_listener_not_proven_unknown_error);
+    g_test_add_func("/runtime_mode_presentation/listener_proven_null_health", test_listener_proven_null_health);
+
+    return g_test_run();
+}

--- a/apps/linux/tests/test_state.c
+++ b/apps/linux/tests/test_state.c
@@ -16,6 +16,7 @@ void state_on_gateway_refresh_requested(void) {}
 static void test_initial_state(void) {
     state_init();
     g_assert_cmpint(state_get_current(), ==, STATE_NEEDS_SETUP);
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_NONE);
 }
 
 static void test_installed_inactive(void) {
@@ -25,6 +26,7 @@ static void test_installed_inactive(void) {
     sys.active = FALSE;
     state_update_systemd(&sys);
     g_assert_cmpint(state_get_current(), ==, STATE_STOPPED);
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_NONE);
 }
 
 static void test_active_without_fresh_health(void) {
@@ -35,6 +37,7 @@ static void test_active_without_fresh_health(void) {
     state_update_systemd(&sys);
     // Startup hydration guard: systemd active + no health data → STARTING (transitional, not RUNNING)
     g_assert_cmpint(state_get_current(), ==, STATE_STARTING);
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_SERVICE_ACTIVE_NOT_PROVEN);
 }
 
 /* ── Native gateway connectivity tests ── */
@@ -56,6 +59,7 @@ static void test_full_connectivity_running(void) {
     state_update_health(&hs);
 
     g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_EXPECTED_SERVICE_HEALTHY);
 }
 
 static void test_warning_health(void) {
@@ -135,6 +139,7 @@ static void test_precedence_systemd_inactive_native_connected(void) {
 
     // Runtime connectivity takes precedence → RUNNING
     g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE);
 }
 
 static void test_precedence_systemd_unavailable_native_connected(void) {
@@ -156,6 +161,7 @@ static void test_precedence_systemd_unavailable_native_connected(void) {
 
     // Runtime connectivity takes precedence → RUNNING
     g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE);
 }
 
 static void test_precedence_systemd_active_http_down(void) {
@@ -196,6 +202,7 @@ static void test_precedence_not_installed_native_connected(void) {
 
     // Runtime connectivity takes precedence → RUNNING
     g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE);
 }
 
 static void test_precedence_native_connected_with_warning(void) {
@@ -344,6 +351,7 @@ static void test_health_zero_timestamp_preserves_systemd_running(void) {
 
     // Systemd still active + no valid health data → startup hydration guard → STARTING
     g_assert_cmpint(state_get_current(), ==, STATE_STARTING);
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_SERVICE_ACTIVE_NOT_PROVEN);
 }
 
 static void test_activation_boundary_health_persists_through_stop(void) {
@@ -409,6 +417,7 @@ static void test_systemd_stop_does_not_regress_native_connected(void) {
     sys.active = FALSE;
     state_update_systemd(&sys);
     g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
+    g_assert_cmpint(state_get_runtime_mode(), ==, RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE);
 }
 
 /* ── Readiness decision table tests ── */


### PR DESCRIPTION
state.h: add RuntimeMode enum (RUNTIME_NONE, RUNTIME_EXPECTED_SERVICE_HEALTHY, RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE, RUNTIME_LISTENER_PRESENT_UNRESPONSIVE, RUNTIME_LISTENER_PRESENT_UNVERIFIED, RUNTIME_SERVICE_ACTIVE_NOT_PROVEN, RUNTIME_UNKNOWN) and RuntimeModePresentation struct. Declare state_get_runtime_mode(), health_state_listener_proven(), and runtime_mode_describe().

runtime_mode.c (new): implement health_state_listener_proven() returning TRUE for HTTP_PROBE_OK, HTTP_PROBE_TIMED_OUT_AFTER_CONNECT, and HTTP_PROBE_INVALID_RESPONSE and FALSE for all other probe results, including NULL input. Implement runtime_mode_compute() and gate healthy and listener-present classifications on has_runtime_evidence so config/setup-only health population does not count as runtime proof. Implement runtime_mode_describe() for all 7 modes with a NULL-output guard.

state.c: add current_runtime_mode static storage. Reset current_runtime_mode in state_init(). Recompute it alongside AppState in both state_update_systemd() and state_update_health(). Add state_get_runtime_mode() accessor. Leave compute_state() unchanged.

diagnostics.c: append a new "=== Runtime Mode ===" section after Readiness. Display runtime mode label, explanation, and "Listener Proven: Yes/No" via health_state_listener_proven().

meson.build: add src/runtime_mode.c to app sources and test_state link sources. Add test_runtime_mode and test_runtime_mode_presentation targets.

tests/test_runtime_mode.c (new): add scenario-driven runtime mode tests through the public state update path, asserting both RuntimeMode and the unchanged AppState invariant.

tests/test_runtime_mode_presentation.c (new): add coverage for all 7 runtime_mode_describe() presentation strings, the NULL-output guard, and the full health_state_listener_proven() truth table for all HttpProbeResult values and NULL input.

tests/test_state.c: add state_get_runtime_mode() regression assertions to the existing state tests touched by this feature.

This change is additive only: it does not modify AppState values, compute_state() logic, readiness structures, tray protocol, or tray behavior.