### PR TITLE
feat(linux): Phase 2A Core companion surfaces (#46)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -42,6 +42,9 @@ sources = [
   'src/readiness.c',
   'src/notify.c',
   'src/diagnostics.c',
+  'src/display_model.c',
+  'src/app_window.c',
+  'src/onboarding.c',
   'src/log.c'
 ]
 
@@ -95,3 +98,9 @@ test_gateway_exe = executable('test_gateway',
   ['tests/test_gateway.c', 'src/gateway_config.c', 'src/gateway_protocol.c', 'src/log.c'],
   dependencies : [glib_dep, gio_dep, json_glib_dep])
 test('gateway', test_gateway_exe)
+
+test_display_model_exe = executable('test_display_model',
+  ['tests/test_display_model.c', 'src/display_model.c', 'src/readiness.c',
+   'src/runtime_mode.c', 'src/gateway_config.c', 'src/log.c'],
+  dependencies : [glib_dep, gio_dep, json_glib_dep])
+test('display_model', test_display_model_exe)

--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -1,0 +1,1859 @@
+/*
+ * app_window.c
+ *
+ * Main companion window for the OpenClaw Linux Companion App.
+ *
+ * Implements the primary product surface using AdwNavigationSplitView
+ * for a sidebar+content information architecture. Each section is a
+ * distinct content page; the sidebar provides navigation.
+ *
+ * Tray-first behavior: the window is not auto-shown on every launch.
+ * It opens automatically only for first-run/recovery (onboarding), or
+ * when the user invokes "Open OpenClaw" from the tray menu.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include <gtk/gtk.h>
+#include <adwaita.h>
+#include "app_window.h"
+#include "state.h"
+#include "readiness.h"
+#include "display_model.h"
+#include "gateway_config.h"
+#include "gateway_client.h"
+#include "diagnostics.h"
+#include "onboarding.h"
+#include "log.h"
+
+/* ── Section metadata ── */
+
+typedef struct {
+    const char *id;
+    const char *title;
+    const char *icon_name;
+} SectionMeta;
+
+static const SectionMeta section_meta[SECTION_COUNT] = {
+    [SECTION_DASHBOARD]    = { "dashboard",    "Dashboard",    "computer-symbolic" },
+    [SECTION_GENERAL]      = { "general",      "General",      "preferences-system-symbolic" },
+    [SECTION_CONFIG]       = { "config",       "Config",       "document-properties-symbolic" },
+    [SECTION_ENVIRONMENT]  = { "environment",  "Environment",  "system-run-symbolic" },
+    [SECTION_DIAGNOSTICS]  = { "diagnostics",  "Diagnostics",  "utilities-system-monitor-symbolic" },
+    [SECTION_ABOUT]        = { "about",        "About",        "help-about-symbolic" },
+    [SECTION_INSTANCES]    = { "instances",    "Instances",    "network-server-symbolic" },
+    [SECTION_DEBUG]        = { "debug",        "Debug",        "emblem-system-symbolic" },
+    [SECTION_SESSIONS]     = { "sessions",     "Sessions",     "view-list-symbolic" },
+    [SECTION_CRON]         = { "cron",         "Cron",         "alarm-symbolic" },
+};
+
+/* ── Window state ── */
+
+static GtkWidget *main_window = NULL;
+static GtkWidget *content_stack = NULL;
+static GtkWidget *sidebar_list = NULL;
+static guint refresh_timer_id = 0;
+
+/* Section content widgets that need updating */
+static GtkWidget *section_pages[SECTION_COUNT] = {0};
+
+/* ── Forward declarations ── */
+
+static GtkWidget* build_placeholder_section(AppSection section);
+static GtkWidget* build_dashboard_section(void);
+static GtkWidget* build_general_section(void);
+static GtkWidget* build_config_section(void);
+static GtkWidget* build_diagnostics_section(void);
+static GtkWidget* build_environment_section(void);
+static GtkWidget* build_about_section(void);
+static GtkWidget* build_instances_section(void);
+static GtkWidget* build_debug_section(void);
+static GtkWidget* build_sessions_section(void);
+static GtkWidget* build_cron_section(void);
+static void refresh_dashboard_content(void);
+static void refresh_general_content(void);
+static void refresh_config_content(void);
+static void refresh_diagnostics_content(void);
+static void refresh_environment_content(void);
+static void refresh_instances_content(void);
+static void refresh_debug_content(void);
+static void on_sidebar_row_activated(GtkListBox *box, GtkListBoxRow *row, gpointer user_data);
+static void on_window_destroy(GtkWindow *window, gpointer user_data);
+
+/* ── Sidebar construction ── */
+
+static GtkWidget* build_sidebar_row(AppSection section) {
+    const SectionMeta *meta = &section_meta[section];
+
+    GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
+    gtk_widget_set_margin_start(box, 8);
+    gtk_widget_set_margin_end(box, 8);
+    gtk_widget_set_margin_top(box, 6);
+    gtk_widget_set_margin_bottom(box, 6);
+
+    GtkWidget *icon = gtk_image_new_from_icon_name(meta->icon_name);
+    gtk_box_append(GTK_BOX(box), icon);
+
+    GtkWidget *label = gtk_label_new(meta->title);
+    gtk_label_set_xalign(GTK_LABEL(label), 0.0);
+    gtk_widget_set_hexpand(label, TRUE);
+    gtk_box_append(GTK_BOX(box), label);
+
+    return box;
+}
+
+static GtkWidget* build_sidebar(void) {
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+    gtk_widget_set_size_request(scrolled, 200, -1);
+
+    sidebar_list = gtk_list_box_new();
+    gtk_list_box_set_selection_mode(GTK_LIST_BOX(sidebar_list), GTK_SELECTION_SINGLE);
+    gtk_widget_add_css_class(sidebar_list, "navigation-sidebar");
+
+    for (int i = 0; i < SECTION_COUNT; i++) {
+        GtkWidget *row_content = build_sidebar_row((AppSection)i);
+        gtk_list_box_append(GTK_LIST_BOX(sidebar_list), row_content);
+    }
+
+    g_signal_connect(sidebar_list, "row-activated",
+                     G_CALLBACK(on_sidebar_row_activated), NULL);
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), sidebar_list);
+    return scrolled;
+}
+
+/* ── Content stack ── */
+
+static GtkWidget* build_content_stack(void) {
+    content_stack = gtk_stack_new();
+    gtk_stack_set_transition_type(GTK_STACK(content_stack), GTK_STACK_TRANSITION_TYPE_CROSSFADE);
+    gtk_stack_set_transition_duration(GTK_STACK(content_stack), 150);
+
+    for (int i = 0; i < SECTION_COUNT; i++) {
+        GtkWidget *page;
+        if (i == SECTION_DASHBOARD) {
+            page = build_dashboard_section();
+        } else if (i == SECTION_GENERAL) {
+            page = build_general_section();
+        } else if (i == SECTION_CONFIG) {
+            page = build_config_section();
+        } else if (i == SECTION_DIAGNOSTICS) {
+            page = build_diagnostics_section();
+        } else if (i == SECTION_ENVIRONMENT) {
+            page = build_environment_section();
+        } else if (i == SECTION_ABOUT) {
+            page = build_about_section();
+        } else if (i == SECTION_INSTANCES) {
+            page = build_instances_section();
+        } else if (i == SECTION_DEBUG) {
+            page = build_debug_section();
+        } else if (i == SECTION_SESSIONS) {
+            page = build_sessions_section();
+        } else if (i == SECTION_CRON) {
+            page = build_cron_section();
+        } else {
+            page = build_placeholder_section((AppSection)i);
+        }
+        section_pages[i] = page;
+        gtk_stack_add_named(GTK_STACK(content_stack), page, section_meta[i].id);
+    }
+
+    return content_stack;
+}
+
+/* ── Sidebar row activation ── */
+
+static void on_sidebar_row_activated(GtkListBox *box, GtkListBoxRow *row, gpointer user_data) {
+    (void)box;
+    (void)user_data;
+
+    int idx = gtk_list_box_row_get_index(row);
+    if (idx >= 0 && idx < SECTION_COUNT) {
+        gtk_stack_set_visible_child_name(GTK_STACK(content_stack), section_meta[idx].id);
+    }
+}
+
+/* ── Placeholder section (Tier B / deferred) ── */
+
+static GtkWidget* build_placeholder_section(AppSection section) {
+    const SectionMeta *meta = &section_meta[section];
+
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 24);
+    gtk_widget_set_margin_bottom(page, 24);
+
+    GtkWidget *title = gtk_label_new(meta->title);
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(page), title);
+
+    GtkWidget *subtitle = gtk_label_new("This section will be available in a future update.");
+    gtk_widget_add_css_class(subtitle, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(subtitle), 0.0);
+    gtk_box_append(GTK_BOX(page), subtitle);
+
+    return page;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Dashboard section (Tier A — must feel finished)
+ *
+ * Information hierarchy:
+ *   1. Status headline + colored indicator
+ *   2. Runtime mode row
+ *   3. Readiness guidance block
+ *   4. Action bar (product actions + expected-service actions)
+ *   5. Connectivity detail group
+ *   6. Systemd context group
+ * ══════════════════════════════════════════════════════════════════ */
+
+/* Dashboard widget refs for refresh */
+static GtkWidget *dash_headline_label = NULL;
+static GtkWidget *dash_runtime_label = NULL;
+static GtkWidget *dash_runtime_detail = NULL;
+static GtkWidget *dash_guidance_label = NULL;
+static GtkWidget *dash_next_action_label = NULL;
+static GtkWidget *dash_service_notice_label = NULL;
+
+static GtkWidget *dash_btn_start = NULL;
+static GtkWidget *dash_btn_stop = NULL;
+static GtkWidget *dash_btn_restart = NULL;
+static GtkWidget *dash_btn_open_dashboard = NULL;
+
+static GtkWidget *dash_endpoint_label = NULL;
+static GtkWidget *dash_version_label = NULL;
+static GtkWidget *dash_http_label = NULL;
+static GtkWidget *dash_ws_label = NULL;
+static GtkWidget *dash_rpc_label = NULL;
+static GtkWidget *dash_auth_label = NULL;
+static GtkWidget *dash_auth_source_label = NULL;
+
+static GtkWidget *dash_unit_label = NULL;
+static GtkWidget *dash_active_state_label = NULL;
+static GtkWidget *dash_sub_state_label = NULL;
+
+/* Dashboard action callbacks */
+
+extern void systemd_start_gateway(void);
+extern void systemd_stop_gateway(void);
+extern void systemd_restart_gateway(void);
+extern void gateway_client_refresh(void);
+
+static void on_dash_start(GtkButton *btn, gpointer data) {
+    (void)btn; (void)data;
+    systemd_start_gateway();
+}
+
+static void on_dash_stop(GtkButton *btn, gpointer data) {
+    (void)btn; (void)data;
+    systemd_stop_gateway();
+}
+
+static void on_dash_restart(GtkButton *btn, gpointer data) {
+    (void)btn; (void)data;
+    systemd_restart_gateway();
+}
+
+static void on_dash_refresh(GtkButton *btn, gpointer data) {
+    (void)btn; (void)data;
+    extern void systemd_refresh(void);
+    systemd_refresh();
+    gateway_client_refresh();
+}
+
+static void on_dash_open_dashboard(GtkButton *btn, gpointer data) {
+    (void)btn; (void)data;
+
+    extern GatewayConfig* gateway_client_get_config(void);
+    GatewayConfig *cfg = gateway_client_get_config();
+    if (!cfg) return;
+
+    g_autofree gchar *url = gateway_config_dashboard_url(cfg);
+    if (url) {
+        g_app_info_launch_default_for_uri(url, NULL, NULL);
+    }
+}
+
+/* Build helpers for labeled rows */
+
+static GtkWidget* build_detail_row(const char *label_text, GtkWidget **value_out) {
+    GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 12);
+    gtk_widget_set_margin_top(row, 2);
+    gtk_widget_set_margin_bottom(row, 2);
+
+    GtkWidget *key = gtk_label_new(label_text);
+    gtk_widget_add_css_class(key, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(key), 0.0);
+    gtk_widget_set_size_request(key, 130, -1);
+    gtk_box_append(GTK_BOX(row), key);
+
+    GtkWidget *val = gtk_label_new("—");
+    gtk_label_set_xalign(GTK_LABEL(val), 0.0);
+    gtk_label_set_selectable(GTK_LABEL(val), TRUE);
+    gtk_widget_set_hexpand(val, TRUE);
+    gtk_box_append(GTK_BOX(row), val);
+
+    *value_out = val;
+    return row;
+}
+
+static GtkWidget* build_dashboard_section(void) {
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 24);
+    gtk_widget_set_margin_bottom(page, 24);
+
+    /* 1. Status headline */
+    dash_headline_label = gtk_label_new("—");
+    gtk_widget_add_css_class(dash_headline_label, "title-1");
+    gtk_label_set_xalign(GTK_LABEL(dash_headline_label), 0.0);
+    gtk_box_append(GTK_BOX(page), dash_headline_label);
+
+    /* 2. Runtime mode */
+    dash_runtime_label = gtk_label_new("—");
+    gtk_widget_add_css_class(dash_runtime_label, "title-4");
+    gtk_label_set_xalign(GTK_LABEL(dash_runtime_label), 0.0);
+    gtk_box_append(GTK_BOX(page), dash_runtime_label);
+
+    dash_runtime_detail = gtk_label_new("");
+    gtk_widget_add_css_class(dash_runtime_detail, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(dash_runtime_detail), 0.0);
+    gtk_label_set_wrap(GTK_LABEL(dash_runtime_detail), TRUE);
+    gtk_box_append(GTK_BOX(page), dash_runtime_detail);
+
+    /* 3. Readiness guidance */
+    dash_guidance_label = gtk_label_new("");
+    gtk_label_set_xalign(GTK_LABEL(dash_guidance_label), 0.0);
+    gtk_label_set_wrap(GTK_LABEL(dash_guidance_label), TRUE);
+    gtk_box_append(GTK_BOX(page), dash_guidance_label);
+
+    dash_next_action_label = gtk_label_new("");
+    gtk_widget_add_css_class(dash_next_action_label, "accent");
+    gtk_label_set_xalign(GTK_LABEL(dash_next_action_label), 0.0);
+    gtk_label_set_wrap(GTK_LABEL(dash_next_action_label), TRUE);
+    gtk_box_append(GTK_BOX(page), dash_next_action_label);
+
+    /* Service context notice (visible when actions need qualification) */
+    dash_service_notice_label = gtk_label_new("");
+    gtk_widget_add_css_class(dash_service_notice_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(dash_service_notice_label), 0.0);
+    gtk_label_set_wrap(GTK_LABEL(dash_service_notice_label), TRUE);
+    gtk_widget_set_visible(dash_service_notice_label, FALSE);
+    gtk_box_append(GTK_BOX(page), dash_service_notice_label);
+
+    /* 4. Action bar */
+    GtkWidget *sep1 = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_top(sep1, 8);
+    gtk_widget_set_margin_bottom(sep1, 4);
+    gtk_box_append(GTK_BOX(page), sep1);
+
+    /* Product actions row */
+    GtkWidget *product_actions = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_margin_top(product_actions, 4);
+
+    dash_btn_open_dashboard = gtk_button_new_with_label("Open Dashboard");
+    gtk_widget_add_css_class(dash_btn_open_dashboard, "suggested-action");
+    g_signal_connect(dash_btn_open_dashboard, "clicked", G_CALLBACK(on_dash_open_dashboard), NULL);
+    gtk_box_append(GTK_BOX(product_actions), dash_btn_open_dashboard);
+
+    GtkWidget *refresh_btn = gtk_button_new_with_label("Refresh");
+    g_signal_connect(refresh_btn, "clicked", G_CALLBACK(on_dash_refresh), NULL);
+    gtk_box_append(GTK_BOX(product_actions), refresh_btn);
+
+    gtk_box_append(GTK_BOX(page), product_actions);
+
+    /* Expected service actions row */
+    GtkWidget *svc_label = gtk_label_new("Expected Service");
+    gtk_widget_add_css_class(svc_label, "heading");
+    gtk_label_set_xalign(GTK_LABEL(svc_label), 0.0);
+    gtk_widget_set_margin_top(svc_label, 12);
+    gtk_box_append(GTK_BOX(page), svc_label);
+
+    GtkWidget *service_actions = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_margin_top(service_actions, 4);
+
+    dash_btn_start = gtk_button_new_with_label("Start");
+    g_signal_connect(dash_btn_start, "clicked", G_CALLBACK(on_dash_start), NULL);
+    gtk_box_append(GTK_BOX(service_actions), dash_btn_start);
+
+    dash_btn_stop = gtk_button_new_with_label("Stop");
+    g_signal_connect(dash_btn_stop, "clicked", G_CALLBACK(on_dash_stop), NULL);
+    gtk_box_append(GTK_BOX(service_actions), dash_btn_stop);
+
+    dash_btn_restart = gtk_button_new_with_label("Restart");
+    g_signal_connect(dash_btn_restart, "clicked", G_CALLBACK(on_dash_restart), NULL);
+    gtk_box_append(GTK_BOX(service_actions), dash_btn_restart);
+
+    gtk_box_append(GTK_BOX(page), service_actions);
+
+    /* 5. Connectivity detail group */
+    GtkWidget *sep2 = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_top(sep2, 12);
+    gtk_widget_set_margin_bottom(sep2, 4);
+    gtk_box_append(GTK_BOX(page), sep2);
+
+    GtkWidget *conn_label = gtk_label_new("Connectivity");
+    gtk_widget_add_css_class(conn_label, "heading");
+    gtk_label_set_xalign(GTK_LABEL(conn_label), 0.0);
+    gtk_box_append(GTK_BOX(page), conn_label);
+
+    gtk_box_append(GTK_BOX(page), build_detail_row("Endpoint", &dash_endpoint_label));
+    gtk_box_append(GTK_BOX(page), build_detail_row("Gateway Version", &dash_version_label));
+    gtk_box_append(GTK_BOX(page), build_detail_row("HTTP Health", &dash_http_label));
+    gtk_box_append(GTK_BOX(page), build_detail_row("WebSocket", &dash_ws_label));
+    gtk_box_append(GTK_BOX(page), build_detail_row("RPC", &dash_rpc_label));
+    gtk_box_append(GTK_BOX(page), build_detail_row("Auth", &dash_auth_label));
+    gtk_box_append(GTK_BOX(page), build_detail_row("Auth Source", &dash_auth_source_label));
+
+    /* 6. Systemd context group */
+    GtkWidget *sep3 = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_top(sep3, 12);
+    gtk_widget_set_margin_bottom(sep3, 4);
+    gtk_box_append(GTK_BOX(page), sep3);
+
+    GtkWidget *sys_label = gtk_label_new("Systemd Service");
+    gtk_widget_add_css_class(sys_label, "heading");
+    gtk_label_set_xalign(GTK_LABEL(sys_label), 0.0);
+    gtk_box_append(GTK_BOX(page), sys_label);
+
+    gtk_box_append(GTK_BOX(page), build_detail_row("Unit", &dash_unit_label));
+    gtk_box_append(GTK_BOX(page), build_detail_row("Active State", &dash_active_state_label));
+    gtk_box_append(GTK_BOX(page), build_detail_row("Sub State", &dash_sub_state_label));
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
+    return scrolled;
+}
+
+/* ── Dashboard refresh ── */
+
+static void refresh_dashboard_content(void) {
+    if (!main_window) return;
+
+    AppState current = state_get_current();
+    RuntimeMode rm = state_get_runtime_mode();
+    SystemdState *sys = state_get_systemd();
+    HealthState *health = state_get_health();
+
+    ReadinessInfo ri;
+    readiness_evaluate(current, health, sys, &ri);
+
+    DashboardDisplayModel dm;
+    dashboard_display_model_build(current, rm, &ri, health, sys, &dm);
+
+    /* Headline */
+    gtk_label_set_text(GTK_LABEL(dash_headline_label), dm.headline ? dm.headline : "—");
+
+    /* Runtime mode */
+    gtk_label_set_text(GTK_LABEL(dash_runtime_label), dm.runtime_label ? dm.runtime_label : "—");
+    gtk_label_set_text(GTK_LABEL(dash_runtime_detail), dm.runtime_detail ? dm.runtime_detail : "");
+
+    /* Guidance */
+    gtk_label_set_text(GTK_LABEL(dash_guidance_label), dm.guidance_text ? dm.guidance_text : "");
+    gtk_widget_set_visible(dash_guidance_label, dm.guidance_text != NULL);
+    gtk_label_set_text(GTK_LABEL(dash_next_action_label), dm.next_action ? dm.next_action : "");
+    gtk_widget_set_visible(dash_next_action_label, dm.next_action != NULL);
+
+    /* Service context notice */
+    if (dm.service_context_notice) {
+        gtk_label_set_text(GTK_LABEL(dash_service_notice_label), dm.service_context_notice);
+        gtk_widget_set_visible(dash_service_notice_label, TRUE);
+    } else {
+        gtk_widget_set_visible(dash_service_notice_label, FALSE);
+    }
+
+    /* Action sensitivities */
+    gtk_widget_set_sensitive(dash_btn_start, dm.can_start);
+    gtk_widget_set_sensitive(dash_btn_stop, dm.can_stop);
+    gtk_widget_set_sensitive(dash_btn_restart, dm.can_restart);
+    gtk_widget_set_sensitive(dash_btn_open_dashboard, dm.can_open_dashboard);
+
+    /* Connectivity */
+    if (health && health->endpoint_host) {
+        g_autofree gchar *ep = g_strdup_printf("%s:%d",
+            health->endpoint_host, health->endpoint_port);
+        gtk_label_set_text(GTK_LABEL(dash_endpoint_label), ep);
+    } else {
+        gtk_label_set_text(GTK_LABEL(dash_endpoint_label), "—");
+    }
+
+    gtk_label_set_text(GTK_LABEL(dash_version_label),
+        dm.gateway_version ? dm.gateway_version : "—");
+    gtk_label_set_text(GTK_LABEL(dash_http_label),
+        dm.http_probe_label ? dm.http_probe_label : "—");
+    gtk_label_set_text(GTK_LABEL(dash_ws_label),
+        dm.ws_connected ? "Connected" : "Disconnected");
+    gtk_label_set_text(GTK_LABEL(dash_rpc_label),
+        dm.rpc_ok ? "OK" : "Not established");
+    gtk_label_set_text(GTK_LABEL(dash_auth_label),
+        dm.auth_ok ? "OK" : "Not established");
+    gtk_label_set_text(GTK_LABEL(dash_auth_source_label),
+        dm.auth_source ? dm.auth_source : "—");
+
+    /* Systemd */
+    gtk_label_set_text(GTK_LABEL(dash_unit_label),
+        dm.unit_name ? dm.unit_name : "—");
+    gtk_label_set_text(GTK_LABEL(dash_active_state_label),
+        dm.active_state ? dm.active_state : "—");
+    gtk_label_set_text(GTK_LABEL(dash_sub_state_label),
+        dm.sub_state ? dm.sub_state : "—");
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * General section (Tier A — must feel finished)
+ *
+ * Product job: full gateway/service/context information surface,
+ * expected-service controls, and companion preferences.
+ *
+ * Explicitly separates "Product/navigation actions" from
+ * "Expected service actions" to avoid control overclaim.
+ * ══════════════════════════════════════════════════════════════════ */
+
+/* General widget refs — status */
+static GtkWidget *gen_status_label = NULL;
+static GtkWidget *gen_runtime_label = NULL;
+static GtkWidget *gen_service_notice_label = NULL;
+
+/* General widget refs — gateway info */
+static GtkWidget *gen_endpoint_label = NULL;
+static GtkWidget *gen_version_label = NULL;
+static GtkWidget *gen_auth_mode_label = NULL;
+static GtkWidget *gen_auth_source_label = NULL;
+
+/* General widget refs — service info */
+static GtkWidget *gen_unit_label = NULL;
+static GtkWidget *gen_active_state_label = NULL;
+static GtkWidget *gen_sub_state_label = NULL;
+
+/* General widget refs — paths */
+static GtkWidget *gen_config_path_label = NULL;
+static GtkWidget *gen_state_dir_label = NULL;
+static GtkWidget *gen_profile_label = NULL;
+
+/* General widget refs — buttons */
+static GtkWidget *gen_btn_start = NULL;
+static GtkWidget *gen_btn_stop = NULL;
+static GtkWidget *gen_btn_restart = NULL;
+static GtkWidget *gen_btn_open_dashboard = NULL;
+
+static void on_gen_start(GtkButton *b, gpointer d) { (void)b; (void)d; systemd_start_gateway(); }
+static void on_gen_stop(GtkButton *b, gpointer d) { (void)b; (void)d; systemd_stop_gateway(); }
+static void on_gen_restart(GtkButton *b, gpointer d) { (void)b; (void)d; systemd_restart_gateway(); }
+
+static void on_gen_open_dashboard(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    GatewayConfig *cfg = gateway_client_get_config();
+    if (!cfg) return;
+    g_autofree gchar *url = gateway_config_dashboard_url(cfg);
+    if (url) g_app_info_launch_default_for_uri(url, NULL, NULL);
+}
+
+static void on_gen_rerun_onboarding(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    onboarding_show();
+}
+
+static void on_gen_quit(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    GApplication *app = g_application_get_default();
+    if (app) g_application_quit(app);
+}
+
+static void on_gen_reveal_config(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    GatewayConfig *cfg = gateway_client_get_config();
+    if (cfg && cfg->config_path) {
+        g_autofree gchar *dir = g_path_get_dirname(cfg->config_path);
+        g_autofree gchar *uri = g_filename_to_uri(dir, NULL, NULL);
+        if (uri) g_app_info_launch_default_for_uri(uri, NULL, NULL);
+    }
+}
+
+static void on_gen_reveal_state_dir(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    g_autofree gchar *profile = NULL;
+    g_autofree gchar *state_dir = NULL;
+    g_autofree gchar *config_path = NULL;
+    systemd_get_runtime_context(&profile, &state_dir, &config_path);
+    if (state_dir) {
+        g_autofree gchar *uri = g_filename_to_uri(state_dir, NULL, NULL);
+        if (uri) g_app_info_launch_default_for_uri(uri, NULL, NULL);
+    }
+}
+
+/* Helper: create a row with a bold label and a value label */
+static GtkWidget* gen_info_row(const char *heading, GtkWidget **out_value) {
+    GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_margin_top(row, 2);
+
+    GtkWidget *h = gtk_label_new(heading);
+    gtk_widget_add_css_class(h, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(h), 0.0);
+    gtk_widget_set_size_request(h, 120, -1);
+    gtk_box_append(GTK_BOX(row), h);
+
+    GtkWidget *v = gtk_label_new("—");
+    gtk_label_set_xalign(GTK_LABEL(v), 0.0);
+    gtk_label_set_selectable(GTK_LABEL(v), TRUE);
+    gtk_label_set_wrap(GTK_LABEL(v), TRUE);
+    gtk_widget_set_hexpand(v, TRUE);
+    gtk_box_append(GTK_BOX(row), v);
+
+    *out_value = v;
+    return row;
+}
+
+static GtkWidget* build_general_section(void) {
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 4);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 24);
+    gtk_widget_set_margin_bottom(page, 24);
+
+    GtkWidget *title = gtk_label_new("General");
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(page), title);
+
+    /* ── Status summary ── */
+    gen_status_label = gtk_label_new("—");
+    gtk_widget_add_css_class(gen_status_label, "title-3");
+    gtk_label_set_xalign(GTK_LABEL(gen_status_label), 0.0);
+    gtk_widget_set_margin_top(gen_status_label, 4);
+    gtk_box_append(GTK_BOX(page), gen_status_label);
+
+    gen_runtime_label = gtk_label_new("—");
+    gtk_widget_add_css_class(gen_runtime_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(gen_runtime_label), 0.0);
+    gtk_box_append(GTK_BOX(page), gen_runtime_label);
+
+    gen_service_notice_label = gtk_label_new("");
+    gtk_widget_add_css_class(gen_service_notice_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(gen_service_notice_label), 0.0);
+    gtk_label_set_wrap(GTK_LABEL(gen_service_notice_label), TRUE);
+    gtk_widget_set_visible(gen_service_notice_label, FALSE);
+    gtk_box_append(GTK_BOX(page), gen_service_notice_label);
+
+    /* ── Product actions ── */
+    GtkWidget *sep1 = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_top(sep1, 8);
+    gtk_box_append(GTK_BOX(page), sep1);
+
+    GtkWidget *nav_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_margin_top(nav_row, 8);
+
+    gen_btn_open_dashboard = gtk_button_new_with_label("Open Dashboard");
+    gtk_widget_add_css_class(gen_btn_open_dashboard, "suggested-action");
+    g_signal_connect(gen_btn_open_dashboard, "clicked", G_CALLBACK(on_gen_open_dashboard), NULL);
+    gtk_box_append(GTK_BOX(nav_row), gen_btn_open_dashboard);
+
+    gtk_box_append(GTK_BOX(page), nav_row);
+
+    /* ── Gateway information ── */
+    GtkWidget *gw_heading = gtk_label_new("Gateway");
+    gtk_widget_add_css_class(gw_heading, "heading");
+    gtk_label_set_xalign(GTK_LABEL(gw_heading), 0.0);
+    gtk_widget_set_margin_top(gw_heading, 12);
+    gtk_box_append(GTK_BOX(page), gw_heading);
+
+    gtk_box_append(GTK_BOX(page), gen_info_row("Endpoint", &gen_endpoint_label));
+    gtk_box_append(GTK_BOX(page), gen_info_row("Version", &gen_version_label));
+    gtk_box_append(GTK_BOX(page), gen_info_row("Auth Mode", &gen_auth_mode_label));
+    gtk_box_append(GTK_BOX(page), gen_info_row("Auth Source", &gen_auth_source_label));
+
+    /* ── Expected service ── */
+    GtkWidget *svc_heading = gtk_label_new("Expected Service");
+    gtk_widget_add_css_class(svc_heading, "heading");
+    gtk_label_set_xalign(GTK_LABEL(svc_heading), 0.0);
+    gtk_widget_set_margin_top(svc_heading, 12);
+    gtk_box_append(GTK_BOX(page), svc_heading);
+
+    gtk_box_append(GTK_BOX(page), gen_info_row("Unit", &gen_unit_label));
+    gtk_box_append(GTK_BOX(page), gen_info_row("Active State", &gen_active_state_label));
+    gtk_box_append(GTK_BOX(page), gen_info_row("Sub State", &gen_sub_state_label));
+
+    GtkWidget *svc_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_margin_top(svc_row, 6);
+
+    gen_btn_start = gtk_button_new_with_label("Start");
+    g_signal_connect(gen_btn_start, "clicked", G_CALLBACK(on_gen_start), NULL);
+    gtk_box_append(GTK_BOX(svc_row), gen_btn_start);
+
+    gen_btn_stop = gtk_button_new_with_label("Stop");
+    g_signal_connect(gen_btn_stop, "clicked", G_CALLBACK(on_gen_stop), NULL);
+    gtk_box_append(GTK_BOX(svc_row), gen_btn_stop);
+
+    gen_btn_restart = gtk_button_new_with_label("Restart");
+    g_signal_connect(gen_btn_restart, "clicked", G_CALLBACK(on_gen_restart), NULL);
+    gtk_box_append(GTK_BOX(svc_row), gen_btn_restart);
+
+    gtk_box_append(GTK_BOX(page), svc_row);
+
+    /* ── Paths & profile ── */
+    GtkWidget *paths_heading = gtk_label_new("Paths");
+    gtk_widget_add_css_class(paths_heading, "heading");
+    gtk_label_set_xalign(GTK_LABEL(paths_heading), 0.0);
+    gtk_widget_set_margin_top(paths_heading, 12);
+    gtk_box_append(GTK_BOX(page), paths_heading);
+
+    gtk_box_append(GTK_BOX(page), gen_info_row("Config File", &gen_config_path_label));
+    gtk_widget_add_css_class(gen_config_path_label, "monospace");
+
+    GtkWidget *reveal_config_btn = gtk_button_new_with_label("Reveal Config Folder");
+    gtk_widget_set_halign(reveal_config_btn, GTK_ALIGN_START);
+    gtk_widget_set_margin_top(reveal_config_btn, 2);
+    g_signal_connect(reveal_config_btn, "clicked", G_CALLBACK(on_gen_reveal_config), NULL);
+    gtk_box_append(GTK_BOX(page), reveal_config_btn);
+
+    gtk_box_append(GTK_BOX(page), gen_info_row("State Dir", &gen_state_dir_label));
+    gtk_widget_add_css_class(gen_state_dir_label, "monospace");
+
+    GtkWidget *reveal_state_btn = gtk_button_new_with_label("Reveal State Folder");
+    gtk_widget_set_halign(reveal_state_btn, GTK_ALIGN_START);
+    gtk_widget_set_margin_top(reveal_state_btn, 2);
+    g_signal_connect(reveal_state_btn, "clicked", G_CALLBACK(on_gen_reveal_state_dir), NULL);
+    gtk_box_append(GTK_BOX(page), reveal_state_btn);
+
+    gtk_box_append(GTK_BOX(page), gen_info_row("Profile", &gen_profile_label));
+
+    /* ── Companion ── */
+    GtkWidget *sep2 = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_top(sep2, 12);
+    gtk_box_append(GTK_BOX(page), sep2);
+
+    GtkWidget *companion_label = gtk_label_new("Companion");
+    gtk_widget_add_css_class(companion_label, "heading");
+    gtk_label_set_xalign(GTK_LABEL(companion_label), 0.0);
+    gtk_widget_set_margin_top(companion_label, 8);
+    gtk_box_append(GTK_BOX(page), companion_label);
+
+    GtkWidget *onboard_btn = gtk_button_new_with_label("Re-run Onboarding");
+    gtk_widget_set_halign(onboard_btn, GTK_ALIGN_START);
+    gtk_widget_set_margin_top(onboard_btn, 4);
+    g_signal_connect(onboard_btn, "clicked", G_CALLBACK(on_gen_rerun_onboarding), NULL);
+    gtk_box_append(GTK_BOX(page), onboard_btn);
+
+    GtkWidget *quit_btn = gtk_button_new_with_label("Quit OpenClaw Companion");
+    gtk_widget_add_css_class(quit_btn, "destructive-action");
+    gtk_widget_set_halign(quit_btn, GTK_ALIGN_START);
+    gtk_widget_set_margin_top(quit_btn, 8);
+    g_signal_connect(quit_btn, "clicked", G_CALLBACK(on_gen_quit), NULL);
+    gtk_box_append(GTK_BOX(page), quit_btn);
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
+    return scrolled;
+}
+
+static void refresh_general_content(void) {
+    if (!gen_status_label) return;
+
+    AppState current = state_get_current();
+    RuntimeMode rm = state_get_runtime_mode();
+    HealthState *health = state_get_health();
+    SystemdState *sys = state_get_systemd();
+
+    ReadinessInfo ri;
+    readiness_evaluate(current, health, sys, &ri);
+
+    DashboardDisplayModel dm;
+    dashboard_display_model_build(current, rm, &ri, health, sys, &dm);
+
+    /* Status headline + runtime */
+    gtk_label_set_text(GTK_LABEL(gen_status_label), dm.headline ? dm.headline : "—");
+    gtk_label_set_text(GTK_LABEL(gen_runtime_label), dm.runtime_label ? dm.runtime_label : "—");
+
+    if (dm.service_context_notice) {
+        gtk_label_set_text(GTK_LABEL(gen_service_notice_label), dm.service_context_notice);
+        gtk_widget_set_visible(gen_service_notice_label, TRUE);
+    } else {
+        gtk_widget_set_visible(gen_service_notice_label, FALSE);
+    }
+
+    /* Gateway info */
+    GatewayConfig *cfg = gateway_client_get_config();
+    if (cfg) {
+        g_autofree gchar *ep = g_strdup_printf("%s:%d", cfg->host ? cfg->host : "127.0.0.1", cfg->port);
+        gtk_label_set_text(GTK_LABEL(gen_endpoint_label), ep);
+    } else {
+        gtk_label_set_text(GTK_LABEL(gen_endpoint_label), "—");
+    }
+    gtk_label_set_text(GTK_LABEL(gen_version_label),
+        dm.gateway_version ? dm.gateway_version : "—");
+    gtk_label_set_text(GTK_LABEL(gen_auth_mode_label),
+        (cfg && cfg->auth_mode) ? cfg->auth_mode : "—");
+    gtk_label_set_text(GTK_LABEL(gen_auth_source_label),
+        dm.auth_source ? dm.auth_source : "—");
+
+    /* Service info */
+    gtk_label_set_text(GTK_LABEL(gen_unit_label),
+        dm.unit_name ? dm.unit_name : "—");
+    gtk_label_set_text(GTK_LABEL(gen_active_state_label),
+        dm.active_state ? dm.active_state : "—");
+    gtk_label_set_text(GTK_LABEL(gen_sub_state_label),
+        dm.sub_state ? dm.sub_state : "—");
+
+    /* Paths & profile */
+    g_autofree gchar *profile = NULL;
+    g_autofree gchar *state_dir = NULL;
+    g_autofree gchar *config_path = NULL;
+    systemd_get_runtime_context(&profile, &state_dir, &config_path);
+
+    gtk_label_set_text(GTK_LABEL(gen_config_path_label),
+        config_path ? config_path : "—");
+    gtk_label_set_text(GTK_LABEL(gen_state_dir_label),
+        state_dir ? state_dir : "—");
+    gtk_label_set_text(GTK_LABEL(gen_profile_label),
+        profile ? profile : "default");
+
+    /* Button sensitivity */
+    gtk_widget_set_sensitive(gen_btn_start, dm.can_start);
+    gtk_widget_set_sensitive(gen_btn_stop, dm.can_stop);
+    gtk_widget_set_sensitive(gen_btn_restart, dm.can_restart);
+    gtk_widget_set_sensitive(gen_btn_open_dashboard, dm.can_open_dashboard);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Config section (Tier A — must feel finished)
+ *
+ * Validity-first hierarchy:
+ *   1. Validity status
+ *   2. Issues count
+ *   3. Warning / error text
+ *   4. File path + last modified
+ *   5. Raw JSON read-only view
+ *   6. Copy-to-clipboard action
+ * ══════════════════════════════════════════════════════════════════ */
+
+/* Config widget refs */
+static GtkWidget *cfg_status_label = NULL;
+static GtkWidget *cfg_path_label = NULL;
+static GtkWidget *cfg_modified_label = NULL;
+static GtkWidget *cfg_warning_label = NULL;
+static GtkWidget *cfg_issues_label = NULL;
+static GtkWidget *cfg_json_view = NULL;
+static GtkWidget *cfg_copy_btn = NULL;
+static guint cfg_copy_reset_id = 0;
+
+static void on_cfg_open_file(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    GatewayConfig *cfg = gateway_client_get_config();
+    if (cfg && cfg->config_path) {
+        g_autofree gchar *uri = g_filename_to_uri(cfg->config_path, NULL, NULL);
+        if (uri) g_app_info_launch_default_for_uri(uri, NULL, NULL);
+    }
+}
+
+static void on_cfg_open_folder(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    GatewayConfig *cfg = gateway_client_get_config();
+    if (cfg && cfg->config_path) {
+        g_autofree gchar *dir = g_path_get_dirname(cfg->config_path);
+        g_autofree gchar *uri = g_filename_to_uri(dir, NULL, NULL);
+        if (uri) g_app_info_launch_default_for_uri(uri, NULL, NULL);
+    }
+}
+
+static gboolean reset_cfg_copy_label(gpointer data) {
+    (void)data;
+    if (cfg_copy_btn)
+        gtk_button_set_label(GTK_BUTTON(cfg_copy_btn), "Copy Config JSON");
+    cfg_copy_reset_id = 0;
+    return G_SOURCE_REMOVE;
+}
+
+static void on_cfg_copy_json(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    GatewayConfig *cfg = gateway_client_get_config();
+    if (!cfg || !cfg->config_path) return;
+    g_autofree gchar *contents = NULL;
+    if (!g_file_get_contents(cfg->config_path, &contents, NULL, NULL)) return;
+
+    GdkClipboard *cb = gdk_display_get_clipboard(gdk_display_get_default());
+    gdk_clipboard_set_text(cb, contents);
+    if (cfg_copy_btn) {
+        gtk_button_set_label(GTK_BUTTON(cfg_copy_btn), "Copied!");
+        if (cfg_copy_reset_id > 0) g_source_remove(cfg_copy_reset_id);
+        cfg_copy_reset_id = g_timeout_add(2000, reset_cfg_copy_label, NULL);
+    }
+}
+
+static gchar* cfg_get_modified_text(const char *path) {
+    if (!path) return g_strdup("—");
+    g_autoptr(GFile) file = g_file_new_for_path(path);
+    g_autoptr(GFileInfo) info = g_file_query_info(file,
+        G_FILE_ATTRIBUTE_TIME_MODIFIED, G_FILE_QUERY_INFO_NONE, NULL, NULL);
+    if (!info) return g_strdup("—");
+
+    g_autoptr(GDateTime) dt = g_file_info_get_modification_date_time(info);
+    if (!dt) return g_strdup("—");
+
+    g_autoptr(GDateTime) local = g_date_time_to_local(dt);
+    return g_date_time_format(local, "%Y-%m-%d %H:%M:%S");
+}
+
+static GtkWidget* build_config_section(void) {
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 24);
+    gtk_widget_set_margin_bottom(page, 24);
+
+    GtkWidget *title = gtk_label_new("Config");
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(page), title);
+
+    /* 1. Validity status */
+    cfg_status_label = gtk_label_new("—");
+    gtk_widget_add_css_class(cfg_status_label, "title-3");
+    gtk_label_set_xalign(GTK_LABEL(cfg_status_label), 0.0);
+    gtk_widget_set_margin_top(cfg_status_label, 4);
+    gtk_box_append(GTK_BOX(page), cfg_status_label);
+
+    /* 2. Issues count */
+    cfg_issues_label = gtk_label_new("");
+    gtk_widget_add_css_class(cfg_issues_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(cfg_issues_label), 0.0);
+    gtk_widget_set_visible(cfg_issues_label, FALSE);
+    gtk_box_append(GTK_BOX(page), cfg_issues_label);
+
+    /* 3. Warning / error text */
+    cfg_warning_label = gtk_label_new("");
+    gtk_label_set_wrap(GTK_LABEL(cfg_warning_label), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(cfg_warning_label), 0.0);
+    gtk_widget_set_visible(cfg_warning_label, FALSE);
+    gtk_box_append(GTK_BOX(page), cfg_warning_label);
+
+    /* 4. File path + last modified */
+    GtkWidget *sep1 = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_top(sep1, 8);
+    gtk_box_append(GTK_BOX(page), sep1);
+
+    GtkWidget *path_heading = gtk_label_new("Config File");
+    gtk_widget_add_css_class(path_heading, "heading");
+    gtk_label_set_xalign(GTK_LABEL(path_heading), 0.0);
+    gtk_widget_set_margin_top(path_heading, 8);
+    gtk_box_append(GTK_BOX(page), path_heading);
+
+    cfg_path_label = gtk_label_new("—");
+    gtk_label_set_selectable(GTK_LABEL(cfg_path_label), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(cfg_path_label), 0.0);
+    gtk_label_set_wrap(GTK_LABEL(cfg_path_label), TRUE);
+    gtk_widget_add_css_class(cfg_path_label, "monospace");
+    gtk_box_append(GTK_BOX(page), cfg_path_label);
+
+    cfg_modified_label = gtk_label_new("Last modified: —");
+    gtk_widget_add_css_class(cfg_modified_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(cfg_modified_label), 0.0);
+    gtk_box_append(GTK_BOX(page), cfg_modified_label);
+
+    /* File actions */
+    GtkWidget *file_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_margin_top(file_row, 6);
+
+    GtkWidget *open_file_btn = gtk_button_new_with_label("Open Config File");
+    g_signal_connect(open_file_btn, "clicked", G_CALLBACK(on_cfg_open_file), NULL);
+    gtk_box_append(GTK_BOX(file_row), open_file_btn);
+
+    GtkWidget *open_folder_btn = gtk_button_new_with_label("Reveal Folder");
+    g_signal_connect(open_folder_btn, "clicked", G_CALLBACK(on_cfg_open_folder), NULL);
+    gtk_box_append(GTK_BOX(file_row), open_folder_btn);
+
+    gtk_box_append(GTK_BOX(page), file_row);
+
+    /* 5. Raw JSON read-only view */
+    GtkWidget *json_heading = gtk_label_new("Raw Config");
+    gtk_widget_add_css_class(json_heading, "heading");
+    gtk_label_set_xalign(GTK_LABEL(json_heading), 0.0);
+    gtk_widget_set_margin_top(json_heading, 12);
+    gtk_box_append(GTK_BOX(page), json_heading);
+
+    GtkTextBuffer *json_buf = gtk_text_buffer_new(NULL);
+    cfg_json_view = gtk_text_view_new_with_buffer(json_buf);
+    gtk_text_view_set_editable(GTK_TEXT_VIEW(cfg_json_view), FALSE);
+    gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(cfg_json_view), FALSE);
+    gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(cfg_json_view), GTK_WRAP_WORD_CHAR);
+    gtk_text_view_set_monospace(GTK_TEXT_VIEW(cfg_json_view), TRUE);
+    gtk_widget_set_vexpand(cfg_json_view, TRUE);
+
+    GtkWidget *json_scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(json_scrolled), cfg_json_view);
+    gtk_widget_set_vexpand(json_scrolled, TRUE);
+    gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(json_scrolled), 200);
+    gtk_box_append(GTK_BOX(page), json_scrolled);
+
+    /* 6. Copy action */
+    GtkWidget *copy_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_margin_top(copy_row, 6);
+
+    cfg_copy_btn = gtk_button_new_with_label("Copy Config JSON");
+    g_signal_connect(cfg_copy_btn, "clicked", G_CALLBACK(on_cfg_copy_json), NULL);
+    gtk_box_append(GTK_BOX(copy_row), cfg_copy_btn);
+
+    gtk_box_append(GTK_BOX(page), copy_row);
+
+    return page;
+}
+
+static void refresh_config_content(void) {
+    if (!cfg_status_label) return;
+
+    HealthState *health = state_get_health();
+    GatewayConfig *cfg = gateway_client_get_config();
+    const char *path = cfg ? cfg->config_path : NULL;
+
+    ConfigDisplayModel cm;
+    config_display_model_build(health, path, &cm);
+
+    /* 1. Validity */
+    gtk_label_set_text(GTK_LABEL(cfg_status_label),
+        cm.is_valid ? "Configuration Valid" : "Configuration Invalid");
+
+    /* 2. Issues */
+    if (cm.issues_count > 0) {
+        g_autofree gchar *issues_text = g_strdup_printf("%d issue(s) detected", cm.issues_count);
+        gtk_label_set_text(GTK_LABEL(cfg_issues_label), issues_text);
+        gtk_widget_set_visible(cfg_issues_label, TRUE);
+    } else {
+        gtk_widget_set_visible(cfg_issues_label, FALSE);
+    }
+
+    /* 3. Warning / error */
+    if (cm.warning_text) {
+        gtk_label_set_text(GTK_LABEL(cfg_warning_label), cm.warning_text);
+        gtk_widget_set_visible(cfg_warning_label, TRUE);
+    } else {
+        gtk_widget_set_visible(cfg_warning_label, FALSE);
+    }
+
+    /* 4. Path + last modified */
+    gtk_label_set_text(GTK_LABEL(cfg_path_label), cm.config_path ? cm.config_path : "—");
+    g_autofree gchar *mod_text = cfg_get_modified_text(path);
+    g_autofree gchar *mod_label = g_strdup_printf("Last modified: %s", mod_text);
+    gtk_label_set_text(GTK_LABEL(cfg_modified_label), mod_label);
+
+    /* 5. Raw JSON */
+    if (cfg_json_view && path) {
+        g_autofree gchar *contents = NULL;
+        if (g_file_get_contents(path, &contents, NULL, NULL)) {
+            GtkTextBuffer *buf = gtk_text_view_get_buffer(GTK_TEXT_VIEW(cfg_json_view));
+            gtk_text_buffer_set_text(buf, contents, -1);
+        }
+    }
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Diagnostics section (integrated)
+ *
+ * Reuses the canonical build_diagnostics_text() from diagnostics.c.
+ * Provides an inline text view + copy button.
+ * ══════════════════════════════════════════════════════════════════ */
+
+static GtkWidget *diag_text_view = NULL;
+static GtkWidget *diag_copy_btn = NULL;
+static guint diag_copy_reset_id = 0;
+
+static gboolean reset_diag_copy_label(gpointer data) {
+    (void)data;
+    if (diag_copy_btn)
+        gtk_button_set_label(GTK_BUTTON(diag_copy_btn), "Copy Diagnostics");
+    diag_copy_reset_id = 0;
+    return G_SOURCE_REMOVE;
+}
+
+static void on_diag_copy(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    g_autofree gchar *text = build_diagnostics_text();
+    GdkClipboard *cb = gdk_display_get_clipboard(gdk_display_get_default());
+    gdk_clipboard_set_text(cb, text);
+    if (diag_copy_btn) {
+        gtk_button_set_label(GTK_BUTTON(diag_copy_btn), "Copied!");
+        if (diag_copy_reset_id > 0) g_source_remove(diag_copy_reset_id);
+        diag_copy_reset_id = g_timeout_add(2000, reset_diag_copy_label, NULL);
+    }
+}
+
+static GtkWidget* build_diagnostics_section(void) {
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 24);
+    gtk_widget_set_margin_bottom(page, 24);
+
+    GtkWidget *title = gtk_label_new("Diagnostics");
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(page), title);
+
+    GtkWidget *subtitle = gtk_label_new(
+        "Full connectivity snapshot. Copy and share for troubleshooting.");
+    gtk_widget_add_css_class(subtitle, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(subtitle), 0.0);
+    gtk_box_append(GTK_BOX(page), subtitle);
+
+    g_autofree gchar *initial = build_diagnostics_text();
+    GtkTextBuffer *buf = gtk_text_buffer_new(NULL);
+    gtk_text_buffer_set_text(buf, initial, -1);
+
+    diag_text_view = gtk_text_view_new_with_buffer(buf);
+    gtk_text_view_set_editable(GTK_TEXT_VIEW(diag_text_view), FALSE);
+    gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(diag_text_view), FALSE);
+    gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(diag_text_view), GTK_WRAP_WORD_CHAR);
+    gtk_text_view_set_monospace(GTK_TEXT_VIEW(diag_text_view), TRUE);
+    gtk_widget_set_vexpand(diag_text_view, TRUE);
+
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), diag_text_view);
+    gtk_widget_set_vexpand(scrolled, TRUE);
+    gtk_box_append(GTK_BOX(page), scrolled);
+
+    GtkWidget *btn_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_margin_top(btn_row, 8);
+
+    diag_copy_btn = gtk_button_new_with_label("Copy Diagnostics");
+    g_signal_connect(diag_copy_btn, "clicked", G_CALLBACK(on_diag_copy), NULL);
+    gtk_box_append(GTK_BOX(btn_row), diag_copy_btn);
+
+    gtk_box_append(GTK_BOX(page), btn_row);
+    return page;
+}
+
+static void refresh_diagnostics_content(void) {
+    if (!diag_text_view) return;
+    g_autofree gchar *text = build_diagnostics_text();
+    GtkTextBuffer *buf = gtk_text_view_get_buffer(GTK_TEXT_VIEW(diag_text_view));
+    gtk_text_buffer_set_text(buf, text, -1);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Environment section
+ *
+ * Shows environment checks from the display model.
+ * ══════════════════════════════════════════════════════════════════ */
+
+static GtkWidget *env_checks_box = NULL;
+
+extern void systemd_get_runtime_context(gchar **out_profile, gchar **out_state_dir, gchar **out_config_path);
+
+static void populate_env_checks(GtkWidget *container) {
+    /* Clear previous children */
+    GtkWidget *child;
+    while ((child = gtk_widget_get_first_child(container)) != NULL) {
+        gtk_box_remove(GTK_BOX(container), child);
+    }
+
+    SystemdState *sys = state_get_systemd();
+    g_autofree gchar *config_path = NULL;
+    g_autofree gchar *state_dir = NULL;
+    g_autofree gchar *profile = NULL;
+    systemd_get_runtime_context(&profile, &state_dir, &config_path);
+
+    EnvironmentCheckResult ecr;
+    environment_check_build(sys, config_path, state_dir, &ecr);
+
+    for (int i = 0; i < ecr.count; i++) {
+        GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+        gtk_widget_set_margin_top(row, 4);
+
+        const char *icon = ecr.rows[i].passed ? "\u2705" : "\u274C";
+        GtkWidget *icon_label = gtk_label_new(icon);
+        gtk_box_append(GTK_BOX(row), icon_label);
+
+        g_autofree gchar *text = g_strdup_printf("%s: %s",
+            ecr.rows[i].label,
+            ecr.rows[i].detail ? ecr.rows[i].detail : "");
+        GtkWidget *detail = gtk_label_new(text);
+        gtk_label_set_wrap(GTK_LABEL(detail), TRUE);
+        gtk_label_set_xalign(GTK_LABEL(detail), 0.0);
+        gtk_widget_set_hexpand(detail, TRUE);
+        gtk_box_append(GTK_BOX(row), detail);
+
+        gtk_box_append(GTK_BOX(container), row);
+    }
+}
+
+static GtkWidget* build_environment_section(void) {
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 24);
+    gtk_widget_set_margin_bottom(page, 24);
+
+    GtkWidget *title = gtk_label_new("Environment");
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(page), title);
+
+    GtkWidget *subtitle = gtk_label_new(
+        "Prerequisites and runtime environment checks.");
+    gtk_widget_add_css_class(subtitle, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(subtitle), 0.0);
+    gtk_box_append(GTK_BOX(page), subtitle);
+
+    GtkWidget *sep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_top(sep, 8);
+    gtk_box_append(GTK_BOX(page), sep);
+
+    env_checks_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 4);
+    gtk_widget_set_margin_top(env_checks_box, 8);
+    populate_env_checks(env_checks_box);
+    gtk_box_append(GTK_BOX(page), env_checks_box);
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
+    return scrolled;
+}
+
+static void refresh_environment_content(void) {
+    if (!env_checks_box) return;
+    populate_env_checks(env_checks_box);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * About section
+ * ══════════════════════════════════════════════════════════════════ */
+
+static GtkWidget* build_about_section(void) {
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 40);
+    gtk_widget_set_margin_bottom(page, 24);
+    gtk_widget_set_halign(page, GTK_ALIGN_CENTER);
+
+    GtkWidget *title = gtk_label_new("OpenClaw");
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_box_append(GTK_BOX(page), title);
+
+    GtkWidget *subtitle = gtk_label_new("Linux Companion App");
+    gtk_widget_add_css_class(subtitle, "title-3");
+    gtk_box_append(GTK_BOX(page), subtitle);
+
+    HealthState *health = state_get_health();
+    const char *ver = (health && health->gateway_version) ? health->gateway_version : "Unknown";
+    g_autofree gchar *ver_text = g_strdup_printf("Gateway Version: %s", ver);
+    GtkWidget *version = gtk_label_new(ver_text);
+    gtk_widget_add_css_class(version, "dim-label");
+    gtk_widget_set_margin_top(version, 16);
+    gtk_box_append(GTK_BOX(page), version);
+
+    GtkWidget *docs_link = gtk_label_new(NULL);
+    gtk_label_set_markup(GTK_LABEL(docs_link),
+        "<a href=\"https://docs.openclaw.ai\">Documentation</a>");
+    gtk_widget_set_margin_top(docs_link, 12);
+    gtk_box_append(GTK_BOX(page), docs_link);
+
+    GtkWidget *gh_link = gtk_label_new(NULL);
+    gtk_label_set_markup(GTK_LABEL(gh_link),
+        "<a href=\"https://github.com/openclaw/openclaw\">GitHub</a>");
+    gtk_box_append(GTK_BOX(page), gh_link);
+
+    GtkWidget *copyright = gtk_label_new("Copyright \u00A9 2025 OpenClaw Contributors");
+    gtk_widget_add_css_class(copyright, "dim-label");
+    gtk_widget_set_margin_top(copyright, 24);
+    gtk_box_append(GTK_BOX(page), copyright);
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
+    return scrolled;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Instances section (Tier B — local instance card)
+ *
+ * Shows the local machine instance card. No RPC needed; all data
+ * is already available from state, health, systemd, and config.
+ * ══════════════════════════════════════════════════════════════════ */
+
+static GtkWidget *inst_hostname_label = NULL;
+static GtkWidget *inst_platform_label = NULL;
+static GtkWidget *inst_version_label = NULL;
+static GtkWidget *inst_runtime_label = NULL;
+static GtkWidget *inst_endpoint_label = NULL;
+static GtkWidget *inst_unit_label = NULL;
+static GtkWidget *inst_state_label = NULL;
+
+static GtkWidget* inst_card_row(const char *heading, GtkWidget **out_value) {
+    GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_margin_top(row, 2);
+
+    GtkWidget *h = gtk_label_new(heading);
+    gtk_widget_add_css_class(h, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(h), 0.0);
+    gtk_widget_set_size_request(h, 120, -1);
+    gtk_box_append(GTK_BOX(row), h);
+
+    GtkWidget *v = gtk_label_new("—");
+    gtk_label_set_xalign(GTK_LABEL(v), 0.0);
+    gtk_label_set_selectable(GTK_LABEL(v), TRUE);
+    gtk_widget_set_hexpand(v, TRUE);
+    gtk_box_append(GTK_BOX(row), v);
+
+    *out_value = v;
+    return row;
+}
+
+static GtkWidget* build_instances_section(void) {
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 4);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 24);
+    gtk_widget_set_margin_bottom(page, 24);
+
+    GtkWidget *title = gtk_label_new("Instances");
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(page), title);
+
+    GtkWidget *subtitle = gtk_label_new("Local gateway instance.");
+    gtk_widget_add_css_class(subtitle, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(subtitle), 0.0);
+    gtk_box_append(GTK_BOX(page), subtitle);
+
+    /* Local instance card */
+    GtkWidget *card_frame = gtk_frame_new(NULL);
+    gtk_widget_set_margin_top(card_frame, 12);
+
+    GtkWidget *card = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
+    gtk_widget_set_margin_start(card, 16);
+    gtk_widget_set_margin_end(card, 16);
+    gtk_widget_set_margin_top(card, 12);
+    gtk_widget_set_margin_bottom(card, 12);
+
+    GtkWidget *card_title = gtk_label_new("Local Instance");
+    gtk_widget_add_css_class(card_title, "heading");
+    gtk_label_set_xalign(GTK_LABEL(card_title), 0.0);
+    gtk_box_append(GTK_BOX(card), card_title);
+
+    GtkWidget *sep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_top(sep, 4);
+    gtk_widget_set_margin_bottom(sep, 4);
+    gtk_box_append(GTK_BOX(card), sep);
+
+    gtk_box_append(GTK_BOX(card), inst_card_row("Hostname", &inst_hostname_label));
+    gtk_box_append(GTK_BOX(card), inst_card_row("Platform", &inst_platform_label));
+    gtk_box_append(GTK_BOX(card), inst_card_row("Version", &inst_version_label));
+    gtk_box_append(GTK_BOX(card), inst_card_row("Runtime", &inst_runtime_label));
+    gtk_box_append(GTK_BOX(card), inst_card_row("Endpoint", &inst_endpoint_label));
+    gtk_box_append(GTK_BOX(card), inst_card_row("Unit", &inst_unit_label));
+    gtk_box_append(GTK_BOX(card), inst_card_row("Service State", &inst_state_label));
+
+    gtk_frame_set_child(GTK_FRAME(card_frame), card);
+    gtk_box_append(GTK_BOX(page), card_frame);
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
+    return scrolled;
+}
+
+static void refresh_instances_content(void) {
+    if (!inst_hostname_label) return;
+
+    AppState current = state_get_current();
+    RuntimeMode rm = state_get_runtime_mode();
+    HealthState *health = state_get_health();
+    SystemdState *sys = state_get_systemd();
+
+    ReadinessInfo ri;
+    readiness_evaluate(current, health, sys, &ri);
+
+    DashboardDisplayModel dm;
+    dashboard_display_model_build(current, rm, &ri, health, sys, &dm);
+
+    g_autofree gchar *hostname = g_strdup(g_get_host_name());
+    gtk_label_set_text(GTK_LABEL(inst_hostname_label), hostname ? hostname : "—");
+    gtk_label_set_text(GTK_LABEL(inst_platform_label), "Linux");
+    gtk_label_set_text(GTK_LABEL(inst_version_label),
+        dm.gateway_version ? dm.gateway_version : "—");
+    gtk_label_set_text(GTK_LABEL(inst_runtime_label),
+        dm.runtime_label ? dm.runtime_label : "—");
+
+    GatewayConfig *cfg = gateway_client_get_config();
+    if (cfg) {
+        g_autofree gchar *ep = g_strdup_printf("%s:%d", cfg->host ? cfg->host : "127.0.0.1", cfg->port);
+        gtk_label_set_text(GTK_LABEL(inst_endpoint_label), ep);
+    } else {
+        gtk_label_set_text(GTK_LABEL(inst_endpoint_label), "—");
+    }
+
+    gtk_label_set_text(GTK_LABEL(inst_unit_label),
+        dm.unit_name ? dm.unit_name : "—");
+
+    if (dm.active_state && dm.sub_state) {
+        g_autofree gchar *state_text = g_strdup_printf("%s (%s)", dm.active_state, dm.sub_state);
+        gtk_label_set_text(GTK_LABEL(inst_state_label), state_text);
+    } else {
+        gtk_label_set_text(GTK_LABEL(inst_state_label),
+            dm.active_state ? dm.active_state : "—");
+    }
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Debug section (Tier B — reduced debug, conditional on need)
+ *
+ * Service state/PID, config folder reveal, journal command,
+ * trigger health refresh, restart gateway, restart onboarding,
+ * copy diagnostics dump.
+ * ══════════════════════════════════════════════════════════════════ */
+
+static GtkWidget *dbg_state_label = NULL;
+static GtkWidget *dbg_unit_label = NULL;
+static GtkWidget *dbg_journal_label = NULL;
+
+static void on_dbg_refresh_health(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    gateway_client_refresh();
+}
+
+static void on_dbg_restart_gw(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    systemd_restart_gateway();
+}
+
+static void on_dbg_rerun_onboarding(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    onboarding_show();
+}
+
+static void on_dbg_reveal_config(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    GatewayConfig *cfg = gateway_client_get_config();
+    if (cfg && cfg->config_path) {
+        g_autofree gchar *dir = g_path_get_dirname(cfg->config_path);
+        g_autofree gchar *uri = g_filename_to_uri(dir, NULL, NULL);
+        if (uri) g_app_info_launch_default_for_uri(uri, NULL, NULL);
+    }
+}
+
+static void on_dbg_copy_diagnostics(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    g_autofree gchar *text = build_diagnostics_text();
+    GdkClipboard *cb = gdk_display_get_clipboard(gdk_display_get_default());
+    gdk_clipboard_set_text(cb, text);
+}
+
+static void on_dbg_copy_journal_cmd(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    const gchar *unit = systemd_get_canonical_unit_name();
+    g_autofree gchar *cmd = g_strdup_printf("journalctl --user -u %s -f",
+        unit ? unit : "openclaw-gateway.service");
+    GdkClipboard *cb = gdk_display_get_clipboard(gdk_display_get_default());
+    gdk_clipboard_set_text(cb, cmd);
+}
+
+static GtkWidget* build_debug_section(void) {
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 24);
+    gtk_widget_set_margin_bottom(page, 24);
+
+    GtkWidget *title = gtk_label_new("Debug");
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(page), title);
+
+    GtkWidget *subtitle = gtk_label_new("Advanced debugging tools.");
+    gtk_widget_add_css_class(subtitle, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(subtitle), 0.0);
+    gtk_box_append(GTK_BOX(page), subtitle);
+
+    /* Service state */
+    GtkWidget *state_heading = gtk_label_new("Gateway Service");
+    gtk_widget_add_css_class(state_heading, "heading");
+    gtk_label_set_xalign(GTK_LABEL(state_heading), 0.0);
+    gtk_widget_set_margin_top(state_heading, 12);
+    gtk_box_append(GTK_BOX(page), state_heading);
+
+    gtk_box_append(GTK_BOX(page), inst_card_row("Unit", &dbg_unit_label));
+    gtk_box_append(GTK_BOX(page), inst_card_row("State", &dbg_state_label));
+
+    /* Journal command */
+    GtkWidget *journal_heading = gtk_label_new("Journal");
+    gtk_widget_add_css_class(journal_heading, "heading");
+    gtk_label_set_xalign(GTK_LABEL(journal_heading), 0.0);
+    gtk_widget_set_margin_top(journal_heading, 12);
+    gtk_box_append(GTK_BOX(page), journal_heading);
+
+    dbg_journal_label = gtk_label_new("—");
+    gtk_widget_add_css_class(dbg_journal_label, "monospace");
+    gtk_label_set_selectable(GTK_LABEL(dbg_journal_label), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(dbg_journal_label), 0.0);
+    gtk_label_set_wrap(GTK_LABEL(dbg_journal_label), TRUE);
+    gtk_box_append(GTK_BOX(page), dbg_journal_label);
+
+    GtkWidget *copy_journal_btn = gtk_button_new_with_label("Copy Journal Command");
+    gtk_widget_set_halign(copy_journal_btn, GTK_ALIGN_START);
+    gtk_widget_set_margin_top(copy_journal_btn, 4);
+    g_signal_connect(copy_journal_btn, "clicked", G_CALLBACK(on_dbg_copy_journal_cmd), NULL);
+    gtk_box_append(GTK_BOX(page), copy_journal_btn);
+
+    /* Actions */
+    GtkWidget *actions_heading = gtk_label_new("Actions");
+    gtk_widget_add_css_class(actions_heading, "heading");
+    gtk_label_set_xalign(GTK_LABEL(actions_heading), 0.0);
+    gtk_widget_set_margin_top(actions_heading, 12);
+    gtk_box_append(GTK_BOX(page), actions_heading);
+
+    GtkWidget *row1 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_margin_top(row1, 4);
+
+    GtkWidget *refresh_btn = gtk_button_new_with_label("Trigger Health Refresh");
+    g_signal_connect(refresh_btn, "clicked", G_CALLBACK(on_dbg_refresh_health), NULL);
+    gtk_box_append(GTK_BOX(row1), refresh_btn);
+
+    GtkWidget *restart_btn = gtk_button_new_with_label("Restart Gateway");
+    g_signal_connect(restart_btn, "clicked", G_CALLBACK(on_dbg_restart_gw), NULL);
+    gtk_box_append(GTK_BOX(row1), restart_btn);
+    gtk_box_append(GTK_BOX(page), row1);
+
+    GtkWidget *row2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_margin_top(row2, 4);
+
+    GtkWidget *reveal_btn = gtk_button_new_with_label("Reveal Config Folder");
+    g_signal_connect(reveal_btn, "clicked", G_CALLBACK(on_dbg_reveal_config), NULL);
+    gtk_box_append(GTK_BOX(row2), reveal_btn);
+
+    GtkWidget *copy_diag_btn = gtk_button_new_with_label("Copy Diagnostics Dump");
+    g_signal_connect(copy_diag_btn, "clicked", G_CALLBACK(on_dbg_copy_diagnostics), NULL);
+    gtk_box_append(GTK_BOX(row2), copy_diag_btn);
+    gtk_box_append(GTK_BOX(page), row2);
+
+    GtkWidget *onboard_btn = gtk_button_new_with_label("Restart Onboarding");
+    gtk_widget_set_halign(onboard_btn, GTK_ALIGN_START);
+    gtk_widget_set_margin_top(onboard_btn, 4);
+    g_signal_connect(onboard_btn, "clicked", G_CALLBACK(on_dbg_rerun_onboarding), NULL);
+    gtk_box_append(GTK_BOX(page), onboard_btn);
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
+    return scrolled;
+}
+
+static void refresh_debug_content(void) {
+    if (!dbg_state_label) return;
+
+    SystemdState *sys = state_get_systemd();
+    if (sys->active_state && sys->sub_state) {
+        g_autofree gchar *state_text = g_strdup_printf("%s (%s)", sys->active_state, sys->sub_state);
+        gtk_label_set_text(GTK_LABEL(dbg_state_label), state_text);
+    } else {
+        gtk_label_set_text(GTK_LABEL(dbg_state_label),
+            sys->active_state ? sys->active_state : "—");
+    }
+
+    gtk_label_set_text(GTK_LABEL(dbg_unit_label),
+        sys->unit_name ? sys->unit_name : "—");
+
+    const gchar *unit = systemd_get_canonical_unit_name();
+    g_autofree gchar *cmd = g_strdup_printf("journalctl --user -u %s -f",
+        unit ? unit : "openclaw-gateway.service");
+    gtk_label_set_text(GTK_LABEL(dbg_journal_label), cmd);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Sessions section (Tier B — entry point)
+ *
+ * Header, short description, "Open in Dashboard" action.
+ * Full session management lives in the dashboard web UI.
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void on_open_dashboard_for_section(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    GatewayConfig *cfg = gateway_client_get_config();
+    if (!cfg) return;
+    g_autofree gchar *url = gateway_config_dashboard_url(cfg);
+    if (url) g_app_info_launch_default_for_uri(url, NULL, NULL);
+}
+
+static GtkWidget* build_sessions_section(void) {
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 24);
+    gtk_widget_set_margin_bottom(page, 24);
+
+    GtkWidget *title = gtk_label_new("Sessions");
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(page), title);
+
+    GtkWidget *desc = gtk_label_new(
+        "Sessions represent active messaging conversations between "
+        "users and the AI agent. Each channel connection maintains "
+        "its own session with message history and context.");
+    gtk_label_set_wrap(GTK_LABEL(desc), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(desc), 0.0);
+    gtk_box_append(GTK_BOX(page), desc);
+
+    GtkWidget *info = gtk_label_new(
+        "View and manage sessions in the gateway dashboard.");
+    gtk_widget_add_css_class(info, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(info), 0.0);
+    gtk_box_append(GTK_BOX(page), info);
+
+    GtkWidget *btn = gtk_button_new_with_label("Open in Dashboard");
+    gtk_widget_add_css_class(btn, "suggested-action");
+    gtk_widget_set_halign(btn, GTK_ALIGN_START);
+    gtk_widget_set_margin_top(btn, 8);
+    g_signal_connect(btn, "clicked", G_CALLBACK(on_open_dashboard_for_section), NULL);
+    gtk_box_append(GTK_BOX(page), btn);
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
+    return scrolled;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Cron section (Tier B — entry point)
+ *
+ * Header, short description, "Open in Dashboard" action.
+ * Full cron management lives in the dashboard web UI.
+ * ══════════════════════════════════════════════════════════════════ */
+
+static GtkWidget* build_cron_section(void) {
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 24);
+    gtk_widget_set_margin_bottom(page, 24);
+
+    GtkWidget *title = gtk_label_new("Cron");
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(page), title);
+
+    GtkWidget *desc = gtk_label_new(
+        "Cron jobs allow the AI agent to perform scheduled tasks "
+        "automatically. Configure recurring actions, periodic checks, "
+        "and timed workflows.");
+    gtk_label_set_wrap(GTK_LABEL(desc), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(desc), 0.0);
+    gtk_box_append(GTK_BOX(page), desc);
+
+    GtkWidget *info = gtk_label_new(
+        "View and manage cron jobs in the gateway dashboard.");
+    gtk_widget_add_css_class(info, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(info), 0.0);
+    gtk_box_append(GTK_BOX(page), info);
+
+    GtkWidget *btn = gtk_button_new_with_label("Open in Dashboard");
+    gtk_widget_add_css_class(btn, "suggested-action");
+    gtk_widget_set_halign(btn, GTK_ALIGN_START);
+    gtk_widget_set_margin_top(btn, 8);
+    g_signal_connect(btn, "clicked", G_CALLBACK(on_open_dashboard_for_section), NULL);
+    gtk_box_append(GTK_BOX(page), btn);
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
+    return scrolled;
+}
+
+/* ── Auto-refresh timer ── */
+
+static gboolean on_refresh_tick(gpointer user_data) {
+    (void)user_data;
+    if (main_window) {
+        refresh_dashboard_content();
+        refresh_general_content();
+        refresh_config_content();
+        refresh_diagnostics_content();
+        refresh_environment_content();
+        refresh_instances_content();
+        refresh_debug_content();
+        return G_SOURCE_CONTINUE;
+    }
+    refresh_timer_id = 0;
+    return G_SOURCE_REMOVE;
+}
+
+/* ── Window lifecycle ── */
+
+static void on_window_destroy(GtkWindow *window, gpointer user_data) {
+    (void)window;
+    (void)user_data;
+
+    if (refresh_timer_id > 0) {
+        g_source_remove(refresh_timer_id);
+        refresh_timer_id = 0;
+    }
+
+    main_window = NULL;
+    content_stack = NULL;
+    sidebar_list = NULL;
+
+    dash_headline_label = NULL;
+    dash_runtime_label = NULL;
+    dash_runtime_detail = NULL;
+    dash_guidance_label = NULL;
+    dash_next_action_label = NULL;
+    dash_service_notice_label = NULL;
+    dash_btn_start = NULL;
+    dash_btn_stop = NULL;
+    dash_btn_restart = NULL;
+    dash_btn_open_dashboard = NULL;
+    dash_endpoint_label = NULL;
+    dash_version_label = NULL;
+    dash_http_label = NULL;
+    dash_ws_label = NULL;
+    dash_rpc_label = NULL;
+    dash_auth_label = NULL;
+    dash_auth_source_label = NULL;
+    dash_unit_label = NULL;
+    dash_active_state_label = NULL;
+    dash_sub_state_label = NULL;
+
+    gen_status_label = NULL;
+    gen_runtime_label = NULL;
+    gen_service_notice_label = NULL;
+    gen_endpoint_label = NULL;
+    gen_version_label = NULL;
+    gen_auth_mode_label = NULL;
+    gen_auth_source_label = NULL;
+    gen_unit_label = NULL;
+    gen_active_state_label = NULL;
+    gen_sub_state_label = NULL;
+    gen_config_path_label = NULL;
+    gen_state_dir_label = NULL;
+    gen_profile_label = NULL;
+    gen_btn_start = NULL;
+    gen_btn_stop = NULL;
+    gen_btn_restart = NULL;
+    gen_btn_open_dashboard = NULL;
+
+    cfg_status_label = NULL;
+    cfg_path_label = NULL;
+    cfg_modified_label = NULL;
+    cfg_warning_label = NULL;
+    cfg_issues_label = NULL;
+    cfg_json_view = NULL;
+    if (cfg_copy_reset_id > 0) {
+        g_source_remove(cfg_copy_reset_id);
+        cfg_copy_reset_id = 0;
+    }
+    cfg_copy_btn = NULL;
+
+    if (diag_copy_reset_id > 0) {
+        g_source_remove(diag_copy_reset_id);
+        diag_copy_reset_id = 0;
+    }
+    diag_text_view = NULL;
+    diag_copy_btn = NULL;
+
+    env_checks_box = NULL;
+
+    inst_hostname_label = NULL;
+    inst_platform_label = NULL;
+    inst_version_label = NULL;
+    inst_runtime_label = NULL;
+    inst_endpoint_label = NULL;
+    inst_unit_label = NULL;
+    inst_state_label = NULL;
+
+    dbg_state_label = NULL;
+    dbg_unit_label = NULL;
+    dbg_journal_label = NULL;
+
+    memset(section_pages, 0, sizeof(section_pages));
+}
+
+/* ── Public API ── */
+
+void app_window_show(void) {
+    if (main_window) {
+        gtk_window_present(GTK_WINDOW(main_window));
+        return;
+    }
+
+    GApplication *app = g_application_get_default();
+    if (!app) return;
+
+    main_window = adw_application_window_new(GTK_APPLICATION(app));
+    gtk_window_set_title(GTK_WINDOW(main_window), "OpenClaw");
+    gtk_window_set_default_size(GTK_WINDOW(main_window), 820, 600);
+
+    /* Build split layout */
+    AdwNavigationSplitView *split = ADW_NAVIGATION_SPLIT_VIEW(adw_navigation_split_view_new());
+
+    /* Sidebar pane */
+    GtkWidget *sidebar_content = build_sidebar();
+    AdwNavigationPage *sidebar_page = adw_navigation_page_new(sidebar_content, "OpenClaw");
+    adw_navigation_split_view_set_sidebar(split, sidebar_page);
+
+    /* Content pane */
+    GtkWidget *stack = build_content_stack();
+    AdwNavigationPage *content_page = adw_navigation_page_new(stack, "Dashboard");
+    adw_navigation_split_view_set_content(split, content_page);
+
+    adw_application_window_set_content(ADW_APPLICATION_WINDOW(main_window), GTK_WIDGET(split));
+
+    /* Select dashboard row by default */
+    GtkListBoxRow *first = gtk_list_box_get_row_at_index(GTK_LIST_BOX(sidebar_list), 0);
+    if (first) {
+        gtk_list_box_select_row(GTK_LIST_BOX(sidebar_list), first);
+    }
+
+    g_signal_connect(main_window, "destroy", G_CALLBACK(on_window_destroy), NULL);
+
+    /* Initial content fill for ALL sections + start auto-refresh */
+    refresh_dashboard_content();
+    refresh_general_content();
+    refresh_config_content();
+    refresh_diagnostics_content();
+    refresh_environment_content();
+    refresh_instances_content();
+    refresh_debug_content();
+    refresh_timer_id = g_timeout_add_seconds(1, on_refresh_tick, NULL);
+
+    gtk_window_present(GTK_WINDOW(main_window));
+}
+
+void app_window_navigate_to(AppSection section) {
+    if (section < 0 || section >= SECTION_COUNT) return;
+
+    app_window_show();
+
+    if (content_stack) {
+        gtk_stack_set_visible_child_name(GTK_STACK(content_stack), section_meta[section].id);
+    }
+    if (sidebar_list) {
+        GtkListBoxRow *row = gtk_list_box_get_row_at_index(GTK_LIST_BOX(sidebar_list), section);
+        if (row) {
+            gtk_list_box_select_row(GTK_LIST_BOX(sidebar_list), row);
+        }
+    }
+}
+
+gboolean app_window_is_visible(void) {
+    return main_window != NULL;
+}

--- a/apps/linux/src/app_window.h
+++ b/apps/linux/src/app_window.h
@@ -1,0 +1,37 @@
+/*
+ * app_window.h
+ *
+ * Main companion window for the OpenClaw Linux Companion App.
+ *
+ * Provides the primary product surface: a sidebar+content split layout
+ * with section-based navigation. The window is tray-first by default —
+ * it opens automatically only for first-run/recovery UX, or when the
+ * user explicitly invokes "Open OpenClaw" from the tray.
+ *
+ * Container: AdwNavigationSplitView (libadwaita >= 1.4).
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+typedef enum {
+    SECTION_DASHBOARD,
+    SECTION_GENERAL,
+    SECTION_CONFIG,
+    SECTION_ENVIRONMENT,
+    SECTION_DIAGNOSTICS,
+    SECTION_ABOUT,
+    SECTION_INSTANCES,
+    SECTION_DEBUG,
+    SECTION_SESSIONS,
+    SECTION_CRON,
+    SECTION_COUNT,
+} AppSection;
+
+void app_window_show(void);
+void app_window_navigate_to(AppSection section);
+gboolean app_window_is_visible(void);
+

--- a/apps/linux/src/diagnostics.c
+++ b/apps/linux/src/diagnostics.c
@@ -35,7 +35,7 @@ static gchar* format_age(gint64 timestamp_us) {
     return g_strdup_printf("%ld hours ago", diff_sec / 3600);
 }
 
-static gchar* build_diagnostics_text(void) {
+gchar* build_diagnostics_text(void) {
     AppState current = state_get_current();
     SystemdState *sys = state_get_systemd();
     HealthState *health = state_get_health();

--- a/apps/linux/src/diagnostics.h
+++ b/apps/linux/src/diagnostics.h
@@ -1,0 +1,14 @@
+/*
+ * diagnostics.h
+ *
+ * Diagnostics window and debug payload generation.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#pragma once
+
+#include <glib.h>
+
+void diagnostics_show_window(void);
+gchar* build_diagnostics_text(void);

--- a/apps/linux/src/display_model.c
+++ b/apps/linux/src/display_model.c
@@ -1,0 +1,341 @@
+/*
+ * display_model.c
+ *
+ * Pure display-model helpers for the OpenClaw Linux Companion App.
+ *
+ * Transforms backend state into UI-ready data structures with no GTK
+ * dependency. All functions are deterministic pure-logic mappers
+ * suitable for automated testing.
+ *
+ * Control Semantics:
+ *   Service control actions (start/stop/restart) target the expected
+ *   user systemd service unit. The display model makes this explicit
+ *   via service_context_notice when the observed runtime is not
+ *   explained by the expected service path.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "display_model.h"
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+
+/* ── HTTP probe labels ── */
+
+const char* http_probe_result_label(HttpProbeResult probe) {
+    switch (probe) {
+    case HTTP_PROBE_NONE:                   return "No probe yet";
+    case HTTP_PROBE_OK:                     return "OK";
+    case HTTP_PROBE_CONNECT_REFUSED:        return "Connection refused";
+    case HTTP_PROBE_CONNECT_TIMEOUT:        return "Connection timed out";
+    case HTTP_PROBE_TIMED_OUT_AFTER_CONNECT: return "Timed out after connect";
+    case HTTP_PROBE_INVALID_RESPONSE:       return "Invalid response";
+    case HTTP_PROBE_UNKNOWN_ERROR:          return "Unknown error";
+    default:                                return "Unknown";
+    }
+}
+
+/* ── Status color mapping ── */
+
+static StatusColor color_for_state(AppState state) {
+    switch (state) {
+    case STATE_RUNNING:
+        return STATUS_COLOR_GREEN;
+    case STATE_RUNNING_WITH_WARNING:
+    case STATE_DEGRADED:
+    case STATE_STARTING:
+    case STATE_STOPPING:
+        return STATUS_COLOR_ORANGE;
+    case STATE_ERROR:
+    case STATE_CONFIG_INVALID:
+        return STATUS_COLOR_RED;
+    default:
+        return STATUS_COLOR_GRAY;
+    }
+}
+
+/* ── Service context notice constants ── */
+
+static const char *NOTICE_EXTERNAL_GATEWAY =
+    "Service controls target the expected systemd unit, not "
+    "the runtime currently serving this endpoint.";
+
+static const char *NOTICE_LISTENER_NOT_PROVEN_SERVICE =
+    "Service controls target the expected systemd unit. The "
+    "companion cannot confirm that the listener on this port "
+    "corresponds to the expected service.";
+
+/* ── Dashboard display model ── */
+
+void dashboard_display_model_build(
+    AppState state,
+    RuntimeMode runtime_mode,
+    const ReadinessInfo *readiness,
+    const HealthState *health,
+    const SystemdState *sys,
+    DashboardDisplayModel *out)
+{
+    if (!out) return;
+    memset(out, 0, sizeof(*out));
+
+    /* Headline + color from readiness classification */
+    out->headline = readiness ? readiness->classification : "Unknown";
+    out->headline_color = color_for_state(state);
+
+    /* Runtime mode presentation */
+    RuntimeModePresentation rmp;
+    runtime_mode_describe(runtime_mode, &rmp);
+    out->runtime_label = rmp.label;
+    out->runtime_detail = rmp.explanation;
+
+    /* Readiness guidance */
+    if (readiness) {
+        out->guidance_text = readiness->missing;
+        out->next_action = readiness->next_action;
+    }
+
+    /*
+     * Service control actions — target the expected systemd unit.
+     *
+     * Enabled based on whether the expected service is installed and
+     * the current lifecycle allows the action. These do NOT claim
+     * control over an external/manual runtime.
+     */
+    gboolean service_installed = sys && sys->installed;
+    gboolean service_active = sys && sys->active;
+    gboolean service_activating = sys && sys->activating;
+    gboolean service_deactivating = sys && sys->deactivating;
+    gboolean in_transition = service_activating || service_deactivating;
+
+    out->can_start = service_installed && !service_active && !in_transition;
+    out->can_stop = service_installed && service_active && !in_transition;
+    out->can_restart = service_installed && service_active && !in_transition;
+
+    /* Dashboard browser action — available when config is valid */
+    out->can_open_dashboard = (health && health->config_valid);
+
+    /*
+     * Service context notice: qualify service actions when the
+     * observed runtime is not explained by the expected service.
+     */
+    switch (runtime_mode) {
+    case RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE:
+        out->service_context_notice = NOTICE_EXTERNAL_GATEWAY;
+        break;
+    case RUNTIME_LISTENER_PRESENT_UNRESPONSIVE:
+    case RUNTIME_LISTENER_PRESENT_UNVERIFIED:
+        out->service_context_notice = NOTICE_LISTENER_NOT_PROVEN_SERVICE;
+        break;
+    default:
+        out->service_context_notice = NULL;
+        break;
+    }
+
+    /* Connectivity detail */
+    if (health) {
+        out->endpoint_display = health->endpoint_host; /* "host" — port added by UI */
+        out->gateway_version = health->gateway_version;
+        out->http_probe_label = http_probe_result_label(health->http_probe_result);
+        out->ws_connected = health->ws_connected;
+        out->rpc_ok = health->rpc_ok;
+        out->auth_ok = health->auth_ok;
+        out->auth_source = health->auth_source;
+    }
+
+    /* Systemd context */
+    if (sys) {
+        out->unit_name = sys->unit_name;
+        out->active_state = sys->active_state;
+        out->sub_state = sys->sub_state;
+    }
+}
+
+/* ── Tray display model ── */
+
+/* Tray status label prefix by AppState */
+static const char* tray_status_prefix(AppState state) {
+    switch (state) {
+    case STATE_RUNNING:                return "\u25CF Running";
+    case STATE_RUNNING_WITH_WARNING:   return "\u25C9 Running (Warning)";
+    case STATE_DEGRADED:               return "\u25C9 Degraded";
+    case STATE_ERROR:                  return "\u25CF Error";
+    case STATE_STOPPED:                return "\u25CB Stopped";
+    case STATE_STARTING:               return "\u25CC Starting\u2026";
+    case STATE_STOPPING:               return "\u25CC Stopping\u2026";
+    case STATE_NEEDS_SETUP:            return "\u25CB Setup Required";
+    case STATE_NEEDS_GATEWAY_INSTALL:  return "\u25CB Gateway Not Installed";
+    case STATE_CONFIG_INVALID:         return "\u25CF Config Invalid";
+    case STATE_USER_SYSTEMD_UNAVAILABLE: return "\u25CB Systemd Unavailable";
+    case STATE_SYSTEM_UNSUPPORTED:     return "\u25CB System Unsupported";
+    default:                           return "\u25CB Unknown";
+    }
+}
+
+void tray_display_model_build(
+    AppState state,
+    RuntimeMode runtime_mode,
+    const HealthState *health,
+    TrayDisplayModel *out)
+{
+    if (!out) return;
+    memset(out, 0, sizeof(*out));
+
+    out->status_label = tray_status_prefix(state);
+
+    RuntimeModePresentation rmp;
+    runtime_mode_describe(runtime_mode, &rmp);
+    out->runtime_label = rmp.label;
+
+    /* Action sensitivities mirror dashboard logic but simplified */
+    gboolean can_act = (state != STATE_STARTING && state != STATE_STOPPING);
+    gboolean is_stoppable = (state == STATE_RUNNING ||
+                             state == STATE_RUNNING_WITH_WARNING ||
+                             state == STATE_DEGRADED);
+    gboolean is_startable = (state == STATE_STOPPED ||
+                             state == STATE_ERROR);
+
+    out->start_sensitive = is_startable && can_act;
+    out->stop_sensitive = is_stoppable && can_act;
+    out->restart_sensitive = is_stoppable && can_act;
+    out->refresh_sensitive = TRUE;
+    out->open_dashboard_sensitive = (health && health->config_valid);
+}
+
+/* ── Config display model ── */
+
+void config_display_model_build(
+    const HealthState *health,
+    const char *config_path,
+    ConfigDisplayModel *out)
+{
+    if (!out) return;
+    memset(out, 0, sizeof(*out));
+
+    out->config_path = config_path;
+
+    if (!health) {
+        out->is_valid = FALSE;
+        out->warning_text = "Health state not available.";
+        return;
+    }
+
+    out->is_valid = health->config_valid;
+    out->issues_count = health->config_issues_count;
+
+    if (!health->config_valid) {
+        out->warning_text = health->last_error
+            ? health->last_error
+            : "Configuration could not be loaded or is invalid.";
+    } else if (health->config_issues_count > 0) {
+        out->warning_text = "Configuration loaded with warnings.";
+    }
+}
+
+/* ── Environment check ── */
+
+void environment_check_build(
+    const SystemdState *sys,
+    const char *config_path,
+    const char *state_dir,
+    EnvironmentCheckResult *out)
+{
+    if (!out) return;
+    memset(out, 0, sizeof(*out));
+    int i = 0;
+
+    /* 1. User systemd session */
+    out->rows[i].label = "User systemd session";
+    if (sys && !sys->systemd_unavailable) {
+        out->rows[i].passed = TRUE;
+        out->rows[i].detail = "Available";
+    } else {
+        out->rows[i].passed = FALSE;
+        out->rows[i].detail = "Cannot connect to user systemd session bus.";
+    }
+    i++;
+
+    /* 2. D-Bus session bus — if systemd works, D-Bus works */
+    out->rows[i].label = "D-Bus session bus";
+    out->rows[i].passed = (sys && !sys->systemd_unavailable);
+    out->rows[i].detail = out->rows[i].passed ? "Reachable" : "Not reachable";
+    i++;
+
+    /* 3. Config file readable */
+    out->rows[i].label = "Config file";
+    if (config_path && config_path[0] != '\0') {
+        out->rows[i].passed = (access(config_path, R_OK) == 0);
+        out->rows[i].detail = config_path;
+    } else {
+        out->rows[i].passed = FALSE;
+        out->rows[i].detail = "No config path resolved.";
+    }
+    i++;
+
+    /* 4. State directory writable */
+    out->rows[i].label = "State directory";
+    if (state_dir && state_dir[0] != '\0') {
+        out->rows[i].passed = (access(state_dir, W_OK) == 0);
+        out->rows[i].detail = state_dir;
+    } else {
+        out->rows[i].passed = FALSE;
+        out->rows[i].detail = "No state directory resolved.";
+    }
+    i++;
+
+    /* 5. Expected systemd unit present */
+    out->rows[i].label = "Expected systemd unit";
+    if (sys && sys->installed) {
+        out->rows[i].passed = TRUE;
+        out->rows[i].detail = sys->unit_name ? sys->unit_name : "Installed";
+    } else if (sys && sys->systemd_unavailable) {
+        out->rows[i].passed = FALSE;
+        out->rows[i].detail = "Systemd unavailable";
+    } else {
+        out->rows[i].passed = FALSE;
+        out->rows[i].detail = "Not installed";
+    }
+    i++;
+
+    out->count = i;
+}
+
+/* ── Onboarding routing ── */
+
+OnboardingRoute onboarding_routing_decide(
+    AppState state,
+    int seen_version,
+    int current_version)
+{
+    /* Already completed current or newer version */
+    if (seen_version >= current_version) {
+        return ONBOARDING_SKIP;
+    }
+
+    /* First run or outdated version — decide flow shape */
+    switch (state) {
+    case STATE_RUNNING:
+    case STATE_RUNNING_WITH_WARNING:
+        /* Gateway already healthy: shortened flow */
+        return ONBOARDING_SHOW_SHORTENED;
+
+    case STATE_NEEDS_SETUP:
+    case STATE_NEEDS_GATEWAY_INSTALL:
+    case STATE_CONFIG_INVALID:
+    case STATE_ERROR:
+    case STATE_STOPPED:
+    case STATE_DEGRADED:
+    case STATE_USER_SYSTEMD_UNAVAILABLE:
+    case STATE_SYSTEM_UNSUPPORTED:
+        /* Needs guidance: full flow */
+        return ONBOARDING_SHOW_FULL;
+
+    case STATE_STARTING:
+    case STATE_STOPPING:
+        /* Transitional: show shortened, gateway may become healthy */
+        return ONBOARDING_SHOW_SHORTENED;
+
+    default:
+        return ONBOARDING_SHOW_FULL;
+    }
+}

--- a/apps/linux/src/display_model.h
+++ b/apps/linux/src/display_model.h
@@ -1,0 +1,160 @@
+/*
+ * display_model.h
+ *
+ * Pure display-model helpers for the OpenClaw Linux Companion App.
+ *
+ * Transforms backend state (AppState, RuntimeMode, ReadinessInfo,
+ * HealthState, SystemdState) into UI-ready data structures. These
+ * helpers have no GTK dependency and are designed for deterministic
+ * automated testing.
+ *
+ * Control Semantics:
+ *   Service control actions (start/stop/restart) target the expected
+ *   user systemd service unit. They do NOT universally control
+ *   whatever runtime is currently serving the endpoint. The display
+ *   model reflects this by gating action visibility/sensitivity on
+ *   the expected service relationship, and by providing explicit
+ *   service-context guidance when RuntimeMode indicates a runtime
+ *   not explained by the expected service.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#pragma once
+
+#include "state.h"
+#include "readiness.h"
+#include <glib.h>
+
+/* ── Dashboard display model ── */
+
+typedef enum {
+    STATUS_COLOR_GREEN,
+    STATUS_COLOR_ORANGE,
+    STATUS_COLOR_RED,
+    STATUS_COLOR_GRAY,
+} StatusColor;
+
+typedef struct {
+    const char *headline;          /* e.g. "Running", "Setup Required" */
+    StatusColor headline_color;
+
+    const char *runtime_label;     /* RuntimeModePresentation.label */
+    const char *runtime_detail;    /* RuntimeModePresentation.explanation */
+
+    const char *guidance_text;     /* ReadinessInfo.missing */
+    const char *next_action;       /* ReadinessInfo.next_action */
+
+    /*
+     * Service control actions target the expected user systemd unit.
+     * These flags indicate whether each action should be enabled.
+     * When runtime_mode is RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE,
+     * actions may still be enabled (to control the expected service)
+     * but service_context_notice will explain the disconnect.
+     */
+    gboolean can_start;
+    gboolean can_stop;
+    gboolean can_restart;
+    gboolean can_open_dashboard;
+
+    /*
+     * Non-NULL when service actions need contextual qualification.
+     * e.g. "Service controls target the expected systemd unit, not
+     * necessarily the runtime currently serving this endpoint."
+     */
+    const char *service_context_notice;
+
+    /* Connectivity detail */
+    const char *endpoint_display;  /* "host:port" or NULL */
+    const char *gateway_version;
+    const char *http_probe_label;
+    gboolean ws_connected;
+    gboolean rpc_ok;
+    gboolean auth_ok;
+    const char *auth_source;
+
+    /* Systemd context */
+    const char *unit_name;
+    const char *active_state;
+    const char *sub_state;
+} DashboardDisplayModel;
+
+void dashboard_display_model_build(
+    AppState state,
+    RuntimeMode runtime_mode,
+    const ReadinessInfo *readiness,
+    const HealthState *health,
+    const SystemdState *sys,
+    DashboardDisplayModel *out);
+
+/* ── Tray display model ── */
+
+typedef struct {
+    const char *status_label;      /* e.g. "● Running" */
+    const char *runtime_label;     /* RuntimeMode label */
+
+    gboolean start_sensitive;
+    gboolean stop_sensitive;
+    gboolean restart_sensitive;
+    gboolean refresh_sensitive;
+    gboolean open_dashboard_sensitive;
+} TrayDisplayModel;
+
+void tray_display_model_build(
+    AppState state,
+    RuntimeMode runtime_mode,
+    const HealthState *health,
+    TrayDisplayModel *out);
+
+/* ── Config display model ── */
+
+typedef struct {
+    gboolean is_valid;
+    int issues_count;
+    const char *warning_text;      /* NULL if no issues */
+    const char *config_path;
+} ConfigDisplayModel;
+
+void config_display_model_build(
+    const HealthState *health,
+    const char *config_path,
+    ConfigDisplayModel *out);
+
+/* ── Environment check row ── */
+
+typedef struct {
+    const char *label;
+    gboolean passed;
+    const char *detail;            /* path or explanation */
+} EnvironmentCheckRow;
+
+#define ENV_CHECK_MAX_ROWS 6
+
+typedef struct {
+    EnvironmentCheckRow rows[ENV_CHECK_MAX_ROWS];
+    int count;
+} EnvironmentCheckResult;
+
+void environment_check_build(
+    const SystemdState *sys,
+    const char *config_path,
+    const char *state_dir,
+    EnvironmentCheckResult *out);
+
+/* ── Onboarding routing ── */
+
+typedef enum {
+    ONBOARDING_SHOW_FULL,       /* first run or recovery: full guidance */
+    ONBOARDING_SHOW_SHORTENED,  /* first run but already healthy: welcome + what's next */
+    ONBOARDING_SKIP,            /* already completed */
+} OnboardingRoute;
+
+OnboardingRoute onboarding_routing_decide(
+    AppState state,
+    int seen_version,
+    int current_version);
+
+/* ── HTTP probe label ── */
+
+const char* http_probe_result_label(HttpProbeResult probe);
+

--- a/apps/linux/src/gateway_client.c
+++ b/apps/linux/src/gateway_client.c
@@ -377,3 +377,7 @@ void gateway_client_shutdown(void) {
 gboolean gateway_client_is_connected(void) {
     return gateway_ws_get_state() == GATEWAY_WS_CONNECTED;
 }
+
+GatewayConfig* gateway_client_get_config(void) {
+    return current_config;
+}

--- a/apps/linux/src/gateway_client.h
+++ b/apps/linux/src/gateway_client.h
@@ -22,4 +22,7 @@ void gateway_client_refresh(void);
 void gateway_client_shutdown(void);
 gboolean gateway_client_is_connected(void);
 
+#include "gateway_config.h"
+GatewayConfig* gateway_client_get_config(void);
+
 #endif /* OPENCLAW_LINUX_GATEWAY_CLIENT_H */

--- a/apps/linux/src/gateway_config.c
+++ b/apps/linux/src/gateway_config.c
@@ -321,11 +321,23 @@ GatewayConfig* gateway_config_load(const GatewayConfigContext *ctx) {
     resolve_auth(auth_obj, config);
     if (!validate_auth(config)) return config;
 
+    /* Resolve controlUi.basePath */
+    if (gateway_obj && json_object_has_member(gateway_obj, "controlUi")) {
+        JsonObject *cui_obj = json_object_get_object_member(gateway_obj, "controlUi");
+        if (cui_obj && json_object_has_member(cui_obj, "basePath")) {
+            const gchar *bp = json_object_get_string_member(cui_obj, "basePath");
+            if (bp && bp[0] != '\0') {
+                config->control_ui_base_path = g_strdup(bp);
+            }
+        }
+    }
+
     config->valid = TRUE;
     config->error_code = GW_CFG_OK;
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
-              "gateway_config_load valid host=%s port=%d auth_mode=%s has_token=%d",
-              config->host, config->port, config->auth_mode, config->token != NULL);
+              "gateway_config_load valid host=%s port=%d auth_mode=%s has_token=%d basePath=%s",
+              config->host, config->port, config->auth_mode, config->token != NULL,
+              config->control_ui_base_path ? config->control_ui_base_path : "(default)");
     return config;
 }
 
@@ -336,6 +348,7 @@ void gateway_config_free(GatewayConfig *config) {
     g_free(config->auth_mode);
     g_free(config->token);
     g_free(config->password);
+    g_free(config->control_ui_base_path);
     g_free(config->config_path);
     g_free(config->error);
     g_free(config);
@@ -391,5 +404,57 @@ gboolean gateway_config_equivalent(const GatewayConfig *a, const GatewayConfig *
     g_autofree gchar *b_ws = gateway_config_ws_url(b);
     if (g_strcmp0(a_ws, b_ws) != 0) return FALSE;
 
+    /* controlUi.basePath */
+    if (g_strcmp0(a->control_ui_base_path, b->control_ui_base_path) != 0) return FALSE;
+
     return TRUE;
+}
+
+/*
+ * Build the dashboard (Control UI) URL from the configured gateway endpoint.
+ *
+ * Uses the configured endpoint as the source of truth — not transient
+ * health-state values. The URL pattern matches the CLI (dashboard.ts)
+ * and macOS (GatewayEndpointStore.dashboardURL):
+ *   http://{host}:{port}{basePath}#token={token}
+ *
+ * Token is embedded as a URL fragment (not query param) to avoid leaking
+ * via server logs. SecretRef-managed tokens are never embedded.
+ */
+gchar* gateway_config_dashboard_url(const GatewayConfig *config) {
+    if (!config || !config->valid) return NULL;
+
+    /* Normalize basePath: ensure leading slash, trailing slash */
+    const gchar *raw_path = config->control_ui_base_path;
+    g_autofree gchar *normalized = NULL;
+    if (!raw_path || raw_path[0] == '\0') {
+        normalized = g_strdup("/");
+    } else {
+        gboolean has_leading = (raw_path[0] == '/');
+        gsize len = strlen(raw_path);
+        gboolean has_trailing = (len > 0 && raw_path[len - 1] == '/');
+
+        if (has_leading && has_trailing) {
+            normalized = g_strdup(raw_path);
+        } else if (has_leading && !has_trailing) {
+            normalized = g_strdup_printf("%s/", raw_path);
+        } else if (!has_leading && has_trailing) {
+            normalized = g_strdup_printf("/%s", raw_path);
+        } else {
+            normalized = g_strdup_printf("/%s/", raw_path);
+        }
+    }
+
+    /* Build base URL */
+    g_autofree gchar *base = g_strdup_printf("http://%s:%d%s",
+        config->host, config->port,
+        g_strcmp0(normalized, "/") == 0 ? "/" : normalized);
+
+    /* Append token fragment if available and not a SecretRef */
+    if (config->token && config->token[0] != '\0' && !config->token_is_secret_ref) {
+        g_autofree gchar *escaped = g_uri_escape_string(config->token, NULL, FALSE);
+        return g_strdup_printf("%s#token=%s", base, escaped);
+    }
+
+    return g_strdup(base);
 }

--- a/apps/linux/src/gateway_config.h
+++ b/apps/linux/src/gateway_config.h
@@ -51,6 +51,7 @@ typedef struct {
     gchar *password;       /* resolved auth password (config + env override) */
     gboolean token_is_secret_ref;
     gboolean password_is_secret_ref;
+    gchar *control_ui_base_path; /* gateway.controlUi.basePath (NULL => "/") */
     gchar *config_path;    /* resolved config file path */
     gboolean valid;        /* whether config was loaded successfully */
     GatewayConfigError error_code; /* stable error discriminator */
@@ -63,5 +64,6 @@ gboolean gateway_config_is_local(const GatewayConfig *config);
 gchar* gateway_config_http_url(const GatewayConfig *config);
 gchar* gateway_config_ws_url(const GatewayConfig *config);
 gboolean gateway_config_equivalent(const GatewayConfig *a, const GatewayConfig *b);
+gchar* gateway_config_dashboard_url(const GatewayConfig *config);
 
 #endif /* OPENCLAW_LINUX_GATEWAY_CONFIG_H */

--- a/apps/linux/src/main.c
+++ b/apps/linux/src/main.c
@@ -18,6 +18,7 @@
 
 #include "log.h"
 #include "gateway_client.h"
+#include "onboarding.h"
 
 extern void tray_init(void);
 extern void systemd_init(void);
@@ -27,6 +28,12 @@ extern void notify_init(void);
 
 void state_on_gateway_refresh_requested(void) {
     gateway_client_refresh();
+}
+
+static gboolean onboarding_check_timeout_cb(gpointer user_data) {
+    (void)user_data;
+    onboarding_check_and_show();
+    return G_SOURCE_REMOVE;
 }
 
 static void on_activate(GtkApplication *app, gpointer user_data) {
@@ -60,6 +67,12 @@ static void on_activate(GtkApplication *app, gpointer user_data) {
     // The gateway client manages its own internal timers for health polling
     // and WebSocket reconnection with exponential backoff.
     gateway_client_init();
+
+    // 6. Schedule onboarding check after a short delay so the initial
+    // health probe has time to complete and state is meaningful.
+    // Tray-first: after onboarding is completed, steady-state launches
+    // do NOT auto-open the main window.
+    g_timeout_add_seconds(2, onboarding_check_timeout_cb, NULL);
 }
 
 int main(int argc, char **argv) {

--- a/apps/linux/src/onboarding.c
+++ b/apps/linux/src/onboarding.c
@@ -1,0 +1,433 @@
+/*
+ * onboarding.c
+ *
+ * State-aware onboarding flow for the OpenClaw Linux Companion App.
+ *
+ * Implements a guided first-run and recovery flow using AdwCarousel
+ * for page navigation. The flow adapts to the detected gateway state:
+ *   - Shortened when gateway is already healthy on first run
+ *   - Full guidance when setup/install/config issues are detected
+ *   - Re-openable from the app at any time
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include <gtk/gtk.h>
+#include <adwaita.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <string.h>
+#include <glib/gstdio.h>
+
+#include "onboarding.h"
+#include "display_model.h"
+#include "gateway_config.h"
+#include "state.h"
+#include "readiness.h"
+#include "app_window.h"
+#include "log.h"
+
+/* ── Version marker persistence ── */
+
+static gchar* get_marker_path(void) {
+    const gchar *state_dir = g_get_user_state_dir(); /* XDG_STATE_HOME or ~/.local/state */
+    return g_build_filename(state_dir, "openclaw-companion", "onboarding_version", NULL);
+}
+
+int onboarding_get_seen_version(void) {
+    g_autofree gchar *path = get_marker_path();
+    g_autofree gchar *contents = NULL;
+    if (!g_file_get_contents(path, &contents, NULL, NULL)) {
+        return 0;
+    }
+    g_strstrip(contents);
+    gint64 v = g_ascii_strtoll(contents, NULL, 10);
+    return (int)v;
+}
+
+static void write_seen_version(int version) {
+    g_autofree gchar *path = get_marker_path();
+    g_autofree gchar *dir = g_path_get_dirname(path);
+
+    g_mkdir_with_parents(dir, 0755);
+
+    g_autofree gchar *text = g_strdup_printf("%d\n", version);
+    g_autoptr(GError) err = NULL;
+    if (!g_file_set_contents(path, text, -1, &err)) {
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_STATE, "Failed to write onboarding marker: %s",
+                    err->message);
+    }
+}
+
+void onboarding_reset(void) {
+    g_autofree gchar *path = get_marker_path();
+    g_unlink(path);
+}
+
+/* ── Onboarding window ── */
+
+static GtkWidget *onboard_window = NULL;
+
+static void on_onboard_destroy(GtkWindow *window, gpointer data) {
+    (void)window; (void)data;
+    onboard_window = NULL;
+}
+
+static void on_finish_clicked(GtkButton *btn, gpointer data) {
+    (void)btn; (void)data;
+    write_seen_version(ONBOARDING_CURRENT_VERSION);
+    if (onboard_window) {
+        gtk_window_destroy(GTK_WINDOW(onboard_window));
+    }
+    app_window_show();
+}
+
+static void on_open_dashboard_clicked(GtkButton *btn, gpointer data) {
+    (void)btn; (void)data;
+    extern GatewayConfig* gateway_client_get_config(void); /* gateway_client.h */
+    GatewayConfig *cfg = gateway_client_get_config();
+    if (cfg) {
+        g_autofree gchar *url = gateway_config_dashboard_url(cfg);
+        if (url) {
+            g_app_info_launch_default_for_uri(url, NULL, NULL);
+        }
+    }
+}
+
+/* ── Page builders ── */
+
+static GtkWidget* build_welcome_page(void) {
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 16);
+    gtk_widget_set_margin_start(page, 40);
+    gtk_widget_set_margin_end(page, 40);
+    gtk_widget_set_margin_top(page, 40);
+    gtk_widget_set_margin_bottom(page, 40);
+    gtk_widget_set_valign(page, GTK_ALIGN_CENTER);
+
+    GtkWidget *title = gtk_label_new("Welcome to OpenClaw");
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_box_append(GTK_BOX(page), title);
+
+    GtkWidget *subtitle = gtk_label_new(
+        "The Linux companion for your OpenClaw gateway.");
+    gtk_widget_add_css_class(subtitle, "title-3");
+    gtk_label_set_xalign(GTK_LABEL(subtitle), 0.5);
+    gtk_box_append(GTK_BOX(page), subtitle);
+
+    GtkWidget *security = gtk_label_new(
+        "OpenClaw connects to an AI agent gateway that can trigger "
+        "powerful actions on your system. The companion app helps you "
+        "monitor, manage, and stay informed about your gateway's status.");
+    gtk_label_set_wrap(GTK_LABEL(security), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(security), 0.0);
+    gtk_widget_set_margin_top(security, 16);
+    gtk_box_append(GTK_BOX(page), security);
+
+    return page;
+}
+
+static GtkWidget* build_gateway_page(void) {
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+    gtk_widget_set_margin_start(page, 40);
+    gtk_widget_set_margin_end(page, 40);
+    gtk_widget_set_margin_top(page, 40);
+    gtk_widget_set_margin_bottom(page, 40);
+    gtk_widget_set_valign(page, GTK_ALIGN_CENTER);
+
+    GtkWidget *title = gtk_label_new("Gateway & Service");
+    gtk_widget_add_css_class(title, "title-2");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(page), title);
+
+    AppState current = state_get_current();
+    RuntimeMode rm = state_get_runtime_mode();
+    SystemdState *sys = state_get_systemd();
+    HealthState *health = state_get_health();
+
+    ReadinessInfo ri;
+    readiness_evaluate(current, health, sys, &ri);
+
+    /* State-aware content */
+    if (current == STATE_RUNNING || current == STATE_RUNNING_WITH_WARNING) {
+        if (rm == RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE) {
+            GtkWidget *status = gtk_label_new(
+                "A healthy gateway was found at the configured endpoint, "
+                "but it is not running via the expected systemd service.");
+            gtk_label_set_wrap(GTK_LABEL(status), TRUE);
+            gtk_label_set_xalign(GTK_LABEL(status), 0.0);
+            gtk_widget_add_css_class(status, "accent");
+            gtk_box_append(GTK_BOX(page), status);
+
+            GtkWidget *detail = gtk_label_new(
+                "This is normal if you run the gateway manually or via another "
+                "service manager. The companion will monitor the endpoint and "
+                "report its status, but service controls will target the "
+                "expected systemd unit.");
+            gtk_label_set_wrap(GTK_LABEL(detail), TRUE);
+            gtk_label_set_xalign(GTK_LABEL(detail), 0.0);
+            gtk_box_append(GTK_BOX(page), detail);
+        } else {
+            GtkWidget *status = gtk_label_new("Your gateway is running and healthy.");
+            gtk_widget_add_css_class(status, "accent");
+            gtk_label_set_xalign(GTK_LABEL(status), 0.0);
+            gtk_box_append(GTK_BOX(page), status);
+        }
+    } else if (current == STATE_NEEDS_SETUP) {
+        GtkWidget *msg = gtk_label_new(
+            "No OpenClaw configuration was detected. Run the following "
+            "command to initialize the OpenClaw environment:");
+        gtk_label_set_wrap(GTK_LABEL(msg), TRUE);
+        gtk_label_set_xalign(GTK_LABEL(msg), 0.0);
+        gtk_box_append(GTK_BOX(page), msg);
+
+        GtkWidget *cmd = gtk_label_new("openclaw setup");
+        gtk_widget_add_css_class(cmd, "monospace");
+        gtk_label_set_selectable(GTK_LABEL(cmd), TRUE);
+        gtk_label_set_xalign(GTK_LABEL(cmd), 0.0);
+        gtk_widget_set_margin_top(cmd, 8);
+        gtk_box_append(GTK_BOX(page), cmd);
+    } else if (current == STATE_NEEDS_GATEWAY_INSTALL) {
+        GtkWidget *msg = gtk_label_new(
+            "OpenClaw is configured, but no gateway service is installed. "
+            "Run the following command:");
+        gtk_label_set_wrap(GTK_LABEL(msg), TRUE);
+        gtk_label_set_xalign(GTK_LABEL(msg), 0.0);
+        gtk_box_append(GTK_BOX(page), msg);
+
+        GtkWidget *cmd = gtk_label_new("openclaw gateway install");
+        gtk_widget_add_css_class(cmd, "monospace");
+        gtk_label_set_selectable(GTK_LABEL(cmd), TRUE);
+        gtk_label_set_xalign(GTK_LABEL(cmd), 0.0);
+        gtk_widget_set_margin_top(cmd, 8);
+        gtk_box_append(GTK_BOX(page), cmd);
+    } else {
+        /* Generic: show readiness info */
+        if (ri.classification) {
+            g_autofree gchar *text = g_strdup_printf("Current status: %s", ri.classification);
+            GtkWidget *status = gtk_label_new(text);
+            gtk_label_set_xalign(GTK_LABEL(status), 0.0);
+            gtk_box_append(GTK_BOX(page), status);
+        }
+        if (ri.missing) {
+            GtkWidget *missing = gtk_label_new(ri.missing);
+            gtk_label_set_wrap(GTK_LABEL(missing), TRUE);
+            gtk_label_set_xalign(GTK_LABEL(missing), 0.0);
+            gtk_box_append(GTK_BOX(page), missing);
+        }
+        if (ri.next_action) {
+            GtkWidget *action = gtk_label_new(ri.next_action);
+            gtk_widget_add_css_class(action, "accent");
+            gtk_label_set_wrap(GTK_LABEL(action), TRUE);
+            gtk_label_set_xalign(GTK_LABEL(action), 0.0);
+            gtk_widget_set_margin_top(action, 8);
+            gtk_box_append(GTK_BOX(page), action);
+        }
+    }
+
+    /* Systemd context if available */
+    if (sys && sys->unit_name) {
+        g_autofree gchar *unit_text = g_strdup_printf("Service unit: %s", sys->unit_name);
+        GtkWidget *unit = gtk_label_new(unit_text);
+        gtk_widget_add_css_class(unit, "dim-label");
+        gtk_label_set_xalign(GTK_LABEL(unit), 0.0);
+        gtk_widget_set_margin_top(unit, 12);
+        gtk_box_append(GTK_BOX(page), unit);
+    }
+
+    return page;
+}
+
+static GtkWidget* build_environment_page(void) {
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+    gtk_widget_set_margin_start(page, 40);
+    gtk_widget_set_margin_end(page, 40);
+    gtk_widget_set_margin_top(page, 40);
+    gtk_widget_set_margin_bottom(page, 40);
+    gtk_widget_set_valign(page, GTK_ALIGN_CENTER);
+
+    GtkWidget *title = gtk_label_new("Environment Check");
+    gtk_widget_add_css_class(title, "title-2");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(page), title);
+
+    /* Build environment checks */
+    SystemdState *sys = state_get_systemd();
+    gchar *config_path = NULL;
+    gchar *state_dir = NULL;
+    gchar *profile = NULL;
+    extern void systemd_get_runtime_context(gchar **out_profile, gchar **out_state_dir, gchar **out_config_path);
+    systemd_get_runtime_context(&profile, &state_dir, &config_path);
+
+    EnvironmentCheckResult ecr;
+    environment_check_build(sys, config_path, state_dir, &ecr);
+
+    for (int i = 0; i < ecr.count; i++) {
+        GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+        gtk_widget_set_margin_top(row, 4);
+
+        const char *icon = ecr.rows[i].passed ? "\u2705" : "\u274C";
+        GtkWidget *icon_label = gtk_label_new(icon);
+        gtk_box_append(GTK_BOX(row), icon_label);
+
+        g_autofree gchar *text = g_strdup_printf("%s: %s",
+            ecr.rows[i].label, ecr.rows[i].detail ? ecr.rows[i].detail : "");
+        GtkWidget *detail = gtk_label_new(text);
+        gtk_label_set_wrap(GTK_LABEL(detail), TRUE);
+        gtk_label_set_xalign(GTK_LABEL(detail), 0.0);
+        gtk_widget_set_hexpand(detail, TRUE);
+        gtk_box_append(GTK_BOX(row), detail);
+
+        gtk_box_append(GTK_BOX(page), row);
+    }
+
+    g_free(config_path);
+    g_free(state_dir);
+    g_free(profile);
+
+    return page;
+}
+
+static GtkWidget* build_whats_next_page(void) {
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 16);
+    gtk_widget_set_margin_start(page, 40);
+    gtk_widget_set_margin_end(page, 40);
+    gtk_widget_set_margin_top(page, 40);
+    gtk_widget_set_margin_bottom(page, 40);
+    gtk_widget_set_valign(page, GTK_ALIGN_CENTER);
+
+    GtkWidget *title = gtk_label_new("What's Next");
+    gtk_widget_add_css_class(title, "title-2");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.5);
+    gtk_box_append(GTK_BOX(page), title);
+
+    AppState current = state_get_current();
+    ReadinessInfo ri;
+    readiness_evaluate(current, state_get_health(), state_get_systemd(), &ri);
+
+    if (current == STATE_RUNNING || current == STATE_RUNNING_WITH_WARNING) {
+        GtkWidget *msg = gtk_label_new(
+            "Your gateway is running. Open the Dashboard to start interacting "
+            "with your AI agent, or explore the companion app to monitor and "
+            "manage your gateway.");
+        gtk_label_set_wrap(GTK_LABEL(msg), TRUE);
+        gtk_label_set_xalign(GTK_LABEL(msg), 0.0);
+        gtk_box_append(GTK_BOX(page), msg);
+
+        GtkWidget *btn_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+        gtk_widget_set_halign(btn_row, GTK_ALIGN_CENTER);
+        gtk_widget_set_margin_top(btn_row, 12);
+
+        GtkWidget *dash_btn = gtk_button_new_with_label("Open Dashboard");
+        gtk_widget_add_css_class(dash_btn, "suggested-action");
+        g_signal_connect(dash_btn, "clicked", G_CALLBACK(on_open_dashboard_clicked), NULL);
+        gtk_box_append(GTK_BOX(btn_row), dash_btn);
+
+        gtk_box_append(GTK_BOX(page), btn_row);
+    } else if (ri.next_action) {
+        GtkWidget *guidance = gtk_label_new(ri.next_action);
+        gtk_widget_add_css_class(guidance, "accent");
+        gtk_label_set_wrap(GTK_LABEL(guidance), TRUE);
+        gtk_label_set_xalign(GTK_LABEL(guidance), 0.0);
+        gtk_box_append(GTK_BOX(page), guidance);
+    }
+
+    /* Documentation links */
+    GtkWidget *links_label = gtk_label_new("Documentation:");
+    gtk_widget_add_css_class(links_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(links_label), 0.0);
+    gtk_widget_set_margin_top(links_label, 20);
+    gtk_box_append(GTK_BOX(page), links_label);
+
+    GtkWidget *docs_link = gtk_label_new(NULL);
+    gtk_label_set_markup(GTK_LABEL(docs_link),
+        "<a href=\"https://docs.openclaw.ai\">docs.openclaw.ai</a>");
+    gtk_label_set_xalign(GTK_LABEL(docs_link), 0.0);
+    gtk_box_append(GTK_BOX(page), docs_link);
+
+    /* Get Started button */
+    GtkWidget *finish_btn = gtk_button_new_with_label("Get Started");
+    gtk_widget_add_css_class(finish_btn, "pill");
+    gtk_widget_add_css_class(finish_btn, "suggested-action");
+    gtk_widget_set_halign(finish_btn, GTK_ALIGN_CENTER);
+    gtk_widget_set_margin_top(finish_btn, 24);
+    g_signal_connect(finish_btn, "clicked", G_CALLBACK(on_finish_clicked), NULL);
+    gtk_box_append(GTK_BOX(page), finish_btn);
+
+    return page;
+}
+
+/* ── Flow construction ── */
+
+void onboarding_show(void) {
+    if (onboard_window) {
+        gtk_window_present(GTK_WINDOW(onboard_window));
+        return;
+    }
+
+    GApplication *app = g_application_get_default();
+    if (!app) return;
+
+    AppState current = state_get_current();
+    OnboardingRoute route = onboarding_routing_decide(
+        current, onboarding_get_seen_version(), ONBOARDING_CURRENT_VERSION);
+
+    onboard_window = adw_window_new();
+    gtk_window_set_application(GTK_WINDOW(onboard_window), GTK_APPLICATION(app));
+    gtk_window_set_title(GTK_WINDOW(onboard_window), "OpenClaw Setup");
+    gtk_window_set_default_size(GTK_WINDOW(onboard_window), 560, 480);
+    gtk_window_set_modal(GTK_WINDOW(onboard_window), TRUE);
+
+    GtkWidget *carousel = adw_carousel_new();
+    adw_carousel_set_allow_long_swipes(ADW_CAROUSEL(carousel), TRUE);
+
+    /* Page 1: Welcome + Security (always shown) */
+    GtkWidget *welcome = build_welcome_page();
+    adw_carousel_append(ADW_CAROUSEL(carousel), welcome);
+
+    if (route == ONBOARDING_SHOW_FULL) {
+        /* Full flow: Gateway & Service + Environment Check */
+        GtkWidget *gateway = build_gateway_page();
+        adw_carousel_append(ADW_CAROUSEL(carousel), gateway);
+
+        GtkWidget *env = build_environment_page();
+        adw_carousel_append(ADW_CAROUSEL(carousel), env);
+    }
+
+    /* Final page: What's Next (always shown) */
+    GtkWidget *whats_next = build_whats_next_page();
+    adw_carousel_append(ADW_CAROUSEL(carousel), whats_next);
+
+    /* Carousel indicator dots */
+    GtkWidget *indicator_dots = adw_carousel_indicator_dots_new();
+    adw_carousel_indicator_dots_set_carousel(ADW_CAROUSEL_INDICATOR_DOTS(indicator_dots),
+                                              ADW_CAROUSEL(carousel));
+
+    GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    gtk_widget_set_vexpand(carousel, TRUE);
+    gtk_box_append(GTK_BOX(vbox), carousel);
+    gtk_widget_set_margin_bottom(indicator_dots, 12);
+    gtk_widget_set_halign(indicator_dots, GTK_ALIGN_CENTER);
+    gtk_box_append(GTK_BOX(vbox), indicator_dots);
+
+    adw_window_set_content(ADW_WINDOW(onboard_window), vbox);
+    g_signal_connect(onboard_window, "destroy", G_CALLBACK(on_onboard_destroy), NULL);
+
+    gtk_window_present(GTK_WINDOW(onboard_window));
+}
+
+void onboarding_check_and_show(void) {
+    AppState current = state_get_current();
+    OnboardingRoute route = onboarding_routing_decide(
+        current, onboarding_get_seen_version(), ONBOARDING_CURRENT_VERSION);
+
+    if (route == ONBOARDING_SKIP) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "onboarding: skip (seen=%d current=%d)",
+                     onboarding_get_seen_version(), ONBOARDING_CURRENT_VERSION);
+        return;
+    }
+
+    OC_LOG_INFO(OPENCLAW_LOG_CAT_STATE, "onboarding: showing %s flow",
+                route == ONBOARDING_SHOW_FULL ? "full" : "shortened");
+    onboarding_show();
+}

--- a/apps/linux/src/onboarding.h
+++ b/apps/linux/src/onboarding.h
@@ -1,0 +1,33 @@
+/*
+ * onboarding.h
+ *
+ * State-aware onboarding flow for the OpenClaw Linux Companion App.
+ *
+ * A guided first-run and recovery flow that adapts to the detected
+ * gateway state. Capable of short-circuiting when the gateway is
+ * already healthy. Re-openable later from the app.
+ *
+ * Lifecycle:
+ *   - Auto-appears on first launch or when onboarding version bumps
+ *   - Shortened flow when gateway is already healthy on first run
+ *   - Full guidance when setup/install/config issues detected
+ *   - Dismissed by completing the flow; writes version marker
+ *   - Re-openable from General or Environment sections
+ *
+ * Tray-first behavior: after onboarding is completed, the app remains
+ * tray-first. The main window does not auto-open on every launch.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#pragma once
+
+#include <glib.h>
+
+#define ONBOARDING_CURRENT_VERSION 1
+
+void onboarding_check_and_show(void);
+void onboarding_show(void);
+void onboarding_reset(void);
+int onboarding_get_seen_version(void);
+

--- a/apps/linux/src/tray.c
+++ b/apps/linux/src/tray.c
@@ -17,6 +17,10 @@
 #include <string.h>
 #include "state.h"
 #include "log.h"
+#include "app_window.h"
+#include "gateway_client.h"
+#include "gateway_config.h"
+#include "display_model.h"
 
 static GSubprocess *helper_process = NULL;
 static GOutputStream *helper_stdin = NULL;
@@ -67,7 +71,19 @@ static void handle_helper_action(const gchar *action) {
         gateway_client_refresh();
     } else if (g_strcmp0(action, "DIAGNOSTICS") == 0) {
         gateway_client_refresh();
-        diagnostics_show_window();
+        app_window_navigate_to(SECTION_DIAGNOSTICS);
+    } else if (g_strcmp0(action, "OPEN_MAIN") == 0) {
+        app_window_show();
+    } else if (g_strcmp0(action, "OPEN_DASHBOARD") == 0) {
+        GatewayConfig *cfg = gateway_client_get_config();
+        if (cfg) {
+            g_autofree gchar *url = gateway_config_dashboard_url(cfg);
+            if (url) {
+                g_app_info_launch_default_for_uri(url, NULL, NULL);
+            }
+        }
+    } else if (g_strcmp0(action, "OPEN_SETTINGS") == 0) {
+        app_window_navigate_to(SECTION_GENERAL);
     } else if (g_strcmp0(action, "QUIT") == 0) {
         GApplication *app = g_application_get_default();
         if (app) g_application_quit(app);
@@ -288,5 +304,31 @@ void tray_update_from_state(AppState state) {
     send_to_helper(cmd_start);
     send_to_helper(cmd_stop);
     send_to_helper(cmd_restart);
+
+    /* Send runtime mode label */
+    RuntimeMode rm = state_get_runtime_mode();
+    TrayDisplayModel tdm;
+    HealthState *health = state_get_health();
+    tray_display_model_build(state, rm, health, &tdm);
+    if (tdm.runtime_label) {
+        g_autofree gchar *cmd_runtime = g_strdup_printf("RUNTIME:%s\n", tdm.runtime_label);
+        send_to_helper(cmd_runtime);
+    }
+
+    /* Send dashboard URL availability */
+    GatewayConfig *cfg = gateway_client_get_config();
+    if (cfg) {
+        g_autofree gchar *url = gateway_config_dashboard_url(cfg);
+        if (url) {
+            g_autofree gchar *cmd_url = g_strdup_printf("DASHBOARD_URL:%s\n", url);
+            send_to_helper(cmd_url);
+        }
+    }
+
+    /* Send Open Dashboard sensitivity */
+    g_autofree gchar *cmd_dash = g_strdup_printf("SENSITIVE:OPEN_DASHBOARD:%d\n",
+        tdm.open_dashboard_sensitive ? 1 : 0);
+    send_to_helper(cmd_dash);
+
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state exit");
 }

--- a/apps/linux/src/tray_helper.c
+++ b/apps/linux/src/tray_helper.c
@@ -17,21 +17,37 @@
 #include <gio/gio.h>
 
 static AppIndicator *indicator = NULL;
+
+/* Status context (disabled labels) */
 static GtkWidget *status_item = NULL;
+static GtkWidget *runtime_item = NULL;
+
+/* Navigation actions */
+static GtkWidget *open_main_item = NULL;
+static GtkWidget *open_dashboard_item = NULL;
+
+/* Expected service actions */
 static GtkWidget *start_item = NULL;
 static GtkWidget *stop_item = NULL;
 static GtkWidget *restart_item = NULL;
+
+/* App navigation */
+static GtkWidget *diagnostics_item = NULL;
+static GtkWidget *settings_item = NULL;
 
 static void send_action(const char *action) {
     g_print("ACTION:%s\n", action);
     fflush(stdout);
 }
 
+static void on_open_main(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("OPEN_MAIN"); }
+static void on_open_dashboard(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("OPEN_DASHBOARD"); }
 static void on_start_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("START"); }
 static void on_stop_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("STOP"); }
 static void on_restart_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("RESTART"); }
 static void on_refresh_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("REFRESH"); }
 static void on_diagnostics_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("DIAGNOSTICS"); }
+static void on_settings_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("OPEN_SETTINGS"); }
 static void on_quit_clicked(GtkMenuItem *item, gpointer data) { 
     (void)item; (void)data;
     send_action("QUIT"); 
@@ -54,9 +70,12 @@ static gboolean handle_stdin(GIOChannel *source, GIOCondition condition, gpointe
         if (g_str_has_prefix(line, "STATE:")) {
             const char *state_str = line + 6;
             if (status_item) {
-                gchar *label = g_strdup_printf("Status: %s", state_str);
-                gtk_menu_item_set_label(GTK_MENU_ITEM(status_item), label);
-                g_free(label);
+                gtk_menu_item_set_label(GTK_MENU_ITEM(status_item), state_str);
+            }
+        } else if (g_str_has_prefix(line, "RUNTIME:")) {
+            const char *runtime_str = line + 8;
+            if (runtime_item) {
+                gtk_menu_item_set_label(GTK_MENU_ITEM(runtime_item), runtime_str);
             }
         } else if (g_str_has_prefix(line, "SENSITIVE:")) {
             gchar **parts = g_strsplit(line, ":", 3);
@@ -70,6 +89,8 @@ static gboolean handle_stdin(GIOChannel *source, GIOCondition condition, gpointe
                     gtk_widget_set_sensitive(stop_item, is_sensitive);
                 } else if (g_strcmp0(action, "RESTART") == 0 && restart_item) {
                     gtk_widget_set_sensitive(restart_item, is_sensitive);
+                } else if (g_strcmp0(action, "OPEN_DASHBOARD") == 0 && open_dashboard_item) {
+                    gtk_widget_set_sensitive(open_dashboard_item, is_sensitive);
                 }
             }
             g_strfreev(parts);
@@ -90,7 +111,7 @@ int main(int argc, char **argv) {
     gtk_init(&argc, &argv);
 
     indicator = app_indicator_new("openclaw-companion",
-                                  "openclaw-icon", // fallback/placeholder
+                                  "openclaw-icon",
                                   APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
     
     app_indicator_set_status(indicator, APP_INDICATOR_STATUS_ACTIVE);
@@ -98,12 +119,30 @@ int main(int argc, char **argv) {
 
     GtkWidget *menu = gtk_menu_new();
 
-    status_item = gtk_menu_item_new_with_label("Status: Unknown");
-    gtk_widget_set_sensitive(status_item, FALSE); 
+    /* ── Status context (disabled) ── */
+    status_item = gtk_menu_item_new_with_label("Unknown");
+    gtk_widget_set_sensitive(status_item, FALSE);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), status_item);
-    
+
+    runtime_item = gtk_menu_item_new_with_label("No Runtime Detected");
+    gtk_widget_set_sensitive(runtime_item, FALSE);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), runtime_item);
+
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 
+    /* ── Navigation actions ── */
+    open_main_item = gtk_menu_item_new_with_label("Open OpenClaw");
+    g_signal_connect(open_main_item, "activate", G_CALLBACK(on_open_main), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), open_main_item);
+
+    open_dashboard_item = gtk_menu_item_new_with_label("Open Dashboard");
+    g_signal_connect(open_dashboard_item, "activate", G_CALLBACK(on_open_dashboard), NULL);
+    gtk_widget_set_sensitive(open_dashboard_item, FALSE);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), open_dashboard_item);
+
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+
+    /* ── Expected service actions ── */
     start_item = gtk_menu_item_new_with_label("Start Gateway");
     g_signal_connect(start_item, "activate", G_CALLBACK(on_start_clicked), NULL);
     gtk_widget_set_sensitive(start_item, FALSE);
@@ -125,18 +164,27 @@ int main(int argc, char **argv) {
 
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 
-    GtkWidget *diag_item = gtk_menu_item_new_with_label("Diagnostics / Settings");
-    g_signal_connect(diag_item, "activate", G_CALLBACK(on_diagnostics_clicked), NULL);
-    gtk_menu_shell_append(GTK_MENU_SHELL(menu), diag_item);
+    /* ── App navigation ── */
+    diagnostics_item = gtk_menu_item_new_with_label("Diagnostics");
+    g_signal_connect(diagnostics_item, "activate", G_CALLBACK(on_diagnostics_clicked), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), diagnostics_item);
+
+    settings_item = gtk_menu_item_new_with_label("Settings");
+    g_signal_connect(settings_item, "activate", G_CALLBACK(on_settings_clicked), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), settings_item);
 
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 
+    /* ── Quit ── */
     GtkWidget *quit_item = gtk_menu_item_new_with_label("Quit");
     g_signal_connect(quit_item, "activate", G_CALLBACK(on_quit_clicked), NULL);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), quit_item);
 
     gtk_widget_show_all(menu);
     app_indicator_set_menu(indicator, GTK_MENU(menu));
+
+    /* Middle-click → Open OpenClaw (KDE/XFCE) */
+    app_indicator_set_secondary_activate_target(indicator, open_main_item);
 
     GIOChannel *stdin_ch = g_io_channel_unix_new(fileno(stdin));
     g_io_add_watch(stdin_ch, G_IO_IN | G_IO_HUP | G_IO_ERR, handle_stdin, NULL);

--- a/apps/linux/tests/test_display_model.c
+++ b/apps/linux/tests/test_display_model.c
@@ -1,0 +1,637 @@
+/*
+ * test_display_model.c
+ *
+ * Tests for the pure display-model helpers (display_model.h).
+ *
+ * These test the deterministic logic layer that transforms backend
+ * state into UI-ready data. No GTK dependency.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include <glib.h>
+#include <string.h>
+#include "../src/display_model.h"
+#include "../src/gateway_config.h"
+
+/* ── Helper ── */
+static void assert_contains(const char *haystack, const char *needle, const char *ctx) {
+    if (!haystack || !needle) {
+        g_test_message("assert_contains(%s): haystack=%p needle=%p", ctx,
+                       (const void *)haystack, (const void *)needle);
+        g_assert_not_reached();
+    }
+    if (!strstr(haystack, needle)) {
+        g_test_message("assert_contains(%s): '%s' not in '%s'", ctx, needle, haystack);
+        g_assert_not_reached();
+    }
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Dashboard display model tests
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_dashboard_running_expected_service(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    hs.http_ok = TRUE; hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE; hs.auth_ok = TRUE;
+    hs.config_valid = TRUE;
+    hs.endpoint_host = "127.0.0.1"; hs.endpoint_port = 18789;
+    hs.gateway_version = "1.2.3";
+
+    SystemdState sys = {0};
+    sys.installed = TRUE; sys.active = TRUE;
+    sys.unit_name = "openclaw-gateway.service";
+    sys.active_state = "active"; sys.sub_state = "running";
+
+    readiness_evaluate(STATE_RUNNING, &hs, &sys, &ri);
+
+    DashboardDisplayModel dm;
+    dashboard_display_model_build(STATE_RUNNING, RUNTIME_EXPECTED_SERVICE_HEALTHY,
+                                  &ri, &hs, &sys, &dm);
+
+    g_assert_cmpstr(dm.headline, ==, "Fully Ready");
+    g_assert_cmpint(dm.headline_color, ==, STATUS_COLOR_GREEN);
+    g_assert_nonnull(dm.runtime_label);
+    assert_contains(dm.runtime_label, "Expected Service", "running.runtime_label");
+    g_assert_null(dm.guidance_text);
+    g_assert_null(dm.next_action);
+
+    /* Service actions available */
+    g_assert_false(dm.can_start);
+    g_assert_true(dm.can_stop);
+    g_assert_true(dm.can_restart);
+    g_assert_true(dm.can_open_dashboard);
+
+    /* No service context notice when expected service is the explanation */
+    g_assert_null(dm.service_context_notice);
+
+    /* Connectivity */
+    g_assert_cmpstr(dm.gateway_version, ==, "1.2.3");
+    g_assert_true(dm.ws_connected);
+    g_assert_true(dm.rpc_ok);
+    g_assert_true(dm.auth_ok);
+
+    /* Systemd */
+    g_assert_cmpstr(dm.unit_name, ==, "openclaw-gateway.service");
+    g_assert_cmpstr(dm.active_state, ==, "active");
+}
+
+static void test_dashboard_healthy_outside_expected_service(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    hs.http_ok = TRUE; hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE; hs.auth_ok = TRUE;
+    hs.config_valid = TRUE;
+
+    SystemdState sys = {0};
+    sys.installed = TRUE; sys.active = FALSE;
+
+    readiness_evaluate(STATE_RUNNING, &hs, &sys, &ri);
+
+    DashboardDisplayModel dm;
+    dashboard_display_model_build(STATE_RUNNING, RUNTIME_HEALTHY_OUTSIDE_EXPECTED_SERVICE,
+                                  &ri, &hs, &sys, &dm);
+
+    g_assert_cmpstr(dm.headline, ==, "Fully Ready");
+    g_assert_cmpint(dm.headline_color, ==, STATUS_COLOR_GREEN);
+
+    /* Service context notice must be present */
+    g_assert_nonnull(dm.service_context_notice);
+    assert_contains(dm.service_context_notice, "expected systemd unit",
+                    "external.service_context_notice");
+
+    /* Start should be available (expected service is stopped) */
+    g_assert_true(dm.can_start);
+    /* Stop/restart should not be available (expected service not active) */
+    g_assert_false(dm.can_stop);
+    g_assert_false(dm.can_restart);
+}
+
+static void test_dashboard_listener_unresponsive(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    hs.http_ok = FALSE;
+    hs.http_probe_result = HTTP_PROBE_TIMED_OUT_AFTER_CONNECT;
+    hs.config_valid = TRUE;
+    hs.last_updated = 1;
+
+    SystemdState sys = {0};
+    sys.installed = TRUE; sys.active = TRUE;
+
+    readiness_evaluate(STATE_DEGRADED, &hs, &sys, &ri);
+
+    DashboardDisplayModel dm;
+    dashboard_display_model_build(STATE_DEGRADED, RUNTIME_LISTENER_PRESENT_UNRESPONSIVE,
+                                  &ri, &hs, &sys, &dm);
+
+    g_assert_cmpstr(dm.headline, ==, "Degraded");
+    g_assert_cmpint(dm.headline_color, ==, STATUS_COLOR_ORANGE);
+
+    /* Service context notice for listener-present states */
+    g_assert_nonnull(dm.service_context_notice);
+    assert_contains(dm.service_context_notice, "expected systemd unit",
+                    "listener.service_context_notice");
+
+    /* Restart available (expected service is active) */
+    g_assert_true(dm.can_restart);
+}
+
+static void test_dashboard_listener_unverified(void) {
+    HealthState hs = {0};
+    hs.http_ok = FALSE;
+    hs.http_probe_result = HTTP_PROBE_INVALID_RESPONSE;
+    hs.config_valid = TRUE;
+    hs.last_updated = 1;
+
+    SystemdState sys = {0};
+    sys.installed = TRUE; sys.active = TRUE;
+
+    ReadinessInfo ri;
+    readiness_evaluate(STATE_DEGRADED, &hs, &sys, &ri);
+
+    DashboardDisplayModel dm;
+    dashboard_display_model_build(STATE_DEGRADED, RUNTIME_LISTENER_PRESENT_UNVERIFIED,
+                                  &ri, &hs, &sys, &dm);
+
+    g_assert_nonnull(dm.service_context_notice);
+    assert_contains(dm.service_context_notice, "cannot confirm",
+                    "unverified.service_context_notice");
+}
+
+static void test_dashboard_stopped(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    SystemdState sys = {0};
+    sys.installed = TRUE; sys.active = FALSE;
+
+    readiness_evaluate(STATE_STOPPED, &hs, &sys, &ri);
+
+    DashboardDisplayModel dm;
+    dashboard_display_model_build(STATE_STOPPED, RUNTIME_NONE,
+                                  &ri, &hs, &sys, &dm);
+
+    g_assert_cmpstr(dm.headline, ==, "Stopped");
+    g_assert_cmpint(dm.headline_color, ==, STATUS_COLOR_GRAY);
+    g_assert_true(dm.can_start);
+    g_assert_false(dm.can_stop);
+    g_assert_false(dm.can_restart);
+    g_assert_null(dm.service_context_notice);
+}
+
+static void test_dashboard_needs_setup(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    SystemdState sys = {0};
+
+    readiness_evaluate(STATE_NEEDS_SETUP, &hs, &sys, &ri);
+
+    DashboardDisplayModel dm;
+    dashboard_display_model_build(STATE_NEEDS_SETUP, RUNTIME_NONE,
+                                  &ri, &hs, &sys, &dm);
+
+    g_assert_cmpstr(dm.headline, ==, "Setup Required");
+    g_assert_cmpint(dm.headline_color, ==, STATUS_COLOR_GRAY);
+    g_assert_false(dm.can_start);
+    g_assert_false(dm.can_stop);
+    g_assert_false(dm.can_restart);
+    g_assert_nonnull(dm.next_action);
+    assert_contains(dm.next_action, "openclaw setup", "setup.next_action");
+}
+
+static void test_dashboard_starting(void) {
+    ReadinessInfo ri;
+    HealthState hs = {0};
+    SystemdState sys = {0};
+    sys.installed = TRUE; sys.activating = TRUE;
+
+    readiness_evaluate(STATE_STARTING, &hs, &sys, &ri);
+
+    DashboardDisplayModel dm;
+    dashboard_display_model_build(STATE_STARTING, RUNTIME_SERVICE_ACTIVE_NOT_PROVEN,
+                                  &ri, &hs, &sys, &dm);
+
+    g_assert_cmpstr(dm.headline, ==, "Starting");
+    g_assert_cmpint(dm.headline_color, ==, STATUS_COLOR_ORANGE);
+    /* All actions disabled during transition */
+    g_assert_false(dm.can_start);
+    g_assert_false(dm.can_stop);
+    g_assert_false(dm.can_restart);
+}
+
+static void test_dashboard_null_output(void) {
+    dashboard_display_model_build(STATE_RUNNING, RUNTIME_NONE, NULL, NULL, NULL, NULL);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Tray display model tests
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_tray_running(void) {
+    HealthState hs = {0};
+    hs.config_valid = TRUE;
+    TrayDisplayModel tm;
+    tray_display_model_build(STATE_RUNNING, RUNTIME_EXPECTED_SERVICE_HEALTHY, &hs, &tm);
+
+    assert_contains(tm.status_label, "Running", "tray_running.label");
+    g_assert_nonnull(tm.runtime_label);
+    g_assert_false(tm.start_sensitive);
+    g_assert_true(tm.stop_sensitive);
+    g_assert_true(tm.restart_sensitive);
+    g_assert_true(tm.open_dashboard_sensitive);
+}
+
+static void test_tray_stopped(void) {
+    HealthState hs = {0};
+    TrayDisplayModel tm;
+    tray_display_model_build(STATE_STOPPED, RUNTIME_NONE, &hs, &tm);
+
+    assert_contains(tm.status_label, "Stopped", "tray_stopped.label");
+    g_assert_true(tm.start_sensitive);
+    g_assert_false(tm.stop_sensitive);
+    g_assert_false(tm.restart_sensitive);
+    g_assert_false(tm.open_dashboard_sensitive);
+}
+
+static void test_tray_starting(void) {
+    HealthState hs = {0};
+    TrayDisplayModel tm;
+    tray_display_model_build(STATE_STARTING, RUNTIME_NONE, &hs, &tm);
+
+    assert_contains(tm.status_label, "Starting", "tray_starting.label");
+    /* Transition: all service actions disabled */
+    g_assert_false(tm.start_sensitive);
+    g_assert_false(tm.stop_sensitive);
+    g_assert_false(tm.restart_sensitive);
+}
+
+static void test_tray_needs_setup(void) {
+    HealthState hs = {0};
+    TrayDisplayModel tm;
+    tray_display_model_build(STATE_NEEDS_SETUP, RUNTIME_NONE, &hs, &tm);
+
+    assert_contains(tm.status_label, "Setup Required", "tray_setup.label");
+    g_assert_false(tm.start_sensitive);
+}
+
+static void test_tray_null_output(void) {
+    tray_display_model_build(STATE_RUNNING, RUNTIME_NONE, NULL, NULL);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Config display model tests
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_config_valid(void) {
+    HealthState hs = {0};
+    hs.config_valid = TRUE;
+    hs.config_issues_count = 0;
+
+    ConfigDisplayModel cm;
+    config_display_model_build(&hs, "/home/user/.openclaw/openclaw.json", &cm);
+
+    g_assert_true(cm.is_valid);
+    g_assert_cmpint(cm.issues_count, ==, 0);
+    g_assert_null(cm.warning_text);
+    g_assert_cmpstr(cm.config_path, ==, "/home/user/.openclaw/openclaw.json");
+}
+
+static void test_config_valid_with_warnings(void) {
+    HealthState hs = {0};
+    hs.config_valid = TRUE;
+    hs.config_issues_count = 3;
+
+    ConfigDisplayModel cm;
+    config_display_model_build(&hs, "/path", &cm);
+
+    g_assert_true(cm.is_valid);
+    g_assert_cmpint(cm.issues_count, ==, 3);
+    g_assert_nonnull(cm.warning_text);
+    assert_contains(cm.warning_text, "warnings", "config_warn.text");
+}
+
+static void test_config_invalid(void) {
+    HealthState hs = {0};
+    hs.config_valid = FALSE;
+    hs.last_error = "parse error at line 5";
+
+    ConfigDisplayModel cm;
+    config_display_model_build(&hs, "/path", &cm);
+
+    g_assert_false(cm.is_valid);
+    g_assert_nonnull(cm.warning_text);
+    assert_contains(cm.warning_text, "parse error", "config_invalid.text");
+}
+
+static void test_config_no_health(void) {
+    ConfigDisplayModel cm;
+    config_display_model_build(NULL, "/path", &cm);
+
+    g_assert_false(cm.is_valid);
+    g_assert_nonnull(cm.warning_text);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Environment check tests
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_env_all_ok(void) {
+    SystemdState sys = {0};
+    sys.systemd_unavailable = FALSE;
+    sys.installed = TRUE;
+    sys.unit_name = "openclaw-gateway.service";
+
+    EnvironmentCheckResult ecr;
+    /* Use /tmp as a writable dir and /dev/null as a readable file */
+    environment_check_build(&sys, "/dev/null", "/tmp", &ecr);
+
+    g_assert_cmpint(ecr.count, >=, 5);
+    /* systemd session */
+    g_assert_true(ecr.rows[0].passed);
+    /* D-Bus */
+    g_assert_true(ecr.rows[1].passed);
+    /* Config file readable */
+    g_assert_true(ecr.rows[2].passed);
+    /* State dir writable */
+    g_assert_true(ecr.rows[3].passed);
+    /* Unit present */
+    g_assert_true(ecr.rows[4].passed);
+}
+
+static void test_env_systemd_unavailable(void) {
+    SystemdState sys = {0};
+    sys.systemd_unavailable = TRUE;
+
+    EnvironmentCheckResult ecr;
+    environment_check_build(&sys, "/dev/null", "/tmp", &ecr);
+
+    g_assert_false(ecr.rows[0].passed); /* systemd */
+    g_assert_false(ecr.rows[1].passed); /* D-Bus */
+}
+
+static void test_env_no_config_path(void) {
+    SystemdState sys = {0};
+    EnvironmentCheckResult ecr;
+    environment_check_build(&sys, NULL, NULL, &ecr);
+
+    g_assert_false(ecr.rows[2].passed); /* config */
+    g_assert_false(ecr.rows[3].passed); /* state dir */
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Onboarding routing tests
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_onboarding_first_run_healthy(void) {
+    OnboardingRoute r = onboarding_routing_decide(STATE_RUNNING, 0, 1);
+    g_assert_cmpint(r, ==, ONBOARDING_SHOW_SHORTENED);
+}
+
+static void test_onboarding_first_run_needs_setup(void) {
+    OnboardingRoute r = onboarding_routing_decide(STATE_NEEDS_SETUP, 0, 1);
+    g_assert_cmpint(r, ==, ONBOARDING_SHOW_FULL);
+}
+
+static void test_onboarding_first_run_needs_install(void) {
+    OnboardingRoute r = onboarding_routing_decide(STATE_NEEDS_GATEWAY_INSTALL, 0, 1);
+    g_assert_cmpint(r, ==, ONBOARDING_SHOW_FULL);
+}
+
+static void test_onboarding_first_run_stopped(void) {
+    OnboardingRoute r = onboarding_routing_decide(STATE_STOPPED, 0, 1);
+    g_assert_cmpint(r, ==, ONBOARDING_SHOW_FULL);
+}
+
+static void test_onboarding_first_run_starting(void) {
+    OnboardingRoute r = onboarding_routing_decide(STATE_STARTING, 0, 1);
+    g_assert_cmpint(r, ==, ONBOARDING_SHOW_SHORTENED);
+}
+
+static void test_onboarding_already_seen(void) {
+    OnboardingRoute r = onboarding_routing_decide(STATE_NEEDS_SETUP, 1, 1);
+    g_assert_cmpint(r, ==, ONBOARDING_SKIP);
+}
+
+static void test_onboarding_newer_version(void) {
+    OnboardingRoute r = onboarding_routing_decide(STATE_RUNNING, 1, 2);
+    g_assert_cmpint(r, ==, ONBOARDING_SHOW_SHORTENED);
+}
+
+static void test_onboarding_future_seen(void) {
+    /* seen_version > current_version → skip */
+    OnboardingRoute r = onboarding_routing_decide(STATE_RUNNING, 5, 2);
+    g_assert_cmpint(r, ==, ONBOARDING_SKIP);
+}
+
+static void test_onboarding_error_state(void) {
+    OnboardingRoute r = onboarding_routing_decide(STATE_ERROR, 0, 1);
+    g_assert_cmpint(r, ==, ONBOARDING_SHOW_FULL);
+}
+
+static void test_onboarding_degraded(void) {
+    OnboardingRoute r = onboarding_routing_decide(STATE_DEGRADED, 0, 1);
+    g_assert_cmpint(r, ==, ONBOARDING_SHOW_FULL);
+}
+
+static void test_onboarding_config_invalid(void) {
+    OnboardingRoute r = onboarding_routing_decide(STATE_CONFIG_INVALID, 0, 1);
+    g_assert_cmpint(r, ==, ONBOARDING_SHOW_FULL);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * HTTP probe label tests
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_probe_labels(void) {
+    g_assert_cmpstr(http_probe_result_label(HTTP_PROBE_NONE), ==, "No probe yet");
+    g_assert_cmpstr(http_probe_result_label(HTTP_PROBE_OK), ==, "OK");
+    g_assert_cmpstr(http_probe_result_label(HTTP_PROBE_CONNECT_REFUSED), ==, "Connection refused");
+    g_assert_cmpstr(http_probe_result_label(HTTP_PROBE_CONNECT_TIMEOUT), ==, "Connection timed out");
+    g_assert_cmpstr(http_probe_result_label(HTTP_PROBE_TIMED_OUT_AFTER_CONNECT), ==, "Timed out after connect");
+    g_assert_cmpstr(http_probe_result_label(HTTP_PROBE_INVALID_RESPONSE), ==, "Invalid response");
+    g_assert_cmpstr(http_probe_result_label(HTTP_PROBE_UNKNOWN_ERROR), ==, "Unknown error");
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Dashboard URL builder tests
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_dashboard_url_default(void) {
+    GatewayConfig cfg = {0};
+    cfg.valid = TRUE;
+    cfg.host = "127.0.0.1";
+    cfg.port = 18789;
+    cfg.control_ui_base_path = NULL;
+    cfg.token = NULL;
+
+    g_autofree gchar *url = gateway_config_dashboard_url(&cfg);
+    g_assert_cmpstr(url, ==, "http://127.0.0.1:18789/");
+}
+
+static void test_dashboard_url_with_base_path(void) {
+    GatewayConfig cfg = {0};
+    cfg.valid = TRUE;
+    cfg.host = "127.0.0.1";
+    cfg.port = 18789;
+    cfg.control_ui_base_path = "/my-path";
+    cfg.token = NULL;
+
+    g_autofree gchar *url = gateway_config_dashboard_url(&cfg);
+    g_assert_cmpstr(url, ==, "http://127.0.0.1:18789/my-path/");
+}
+
+static void test_dashboard_url_with_token(void) {
+    GatewayConfig cfg = {0};
+    cfg.valid = TRUE;
+    cfg.host = "127.0.0.1";
+    cfg.port = 18789;
+    cfg.control_ui_base_path = NULL;
+    cfg.token = "mytoken123";
+    cfg.token_is_secret_ref = FALSE;
+
+    g_autofree gchar *url = gateway_config_dashboard_url(&cfg);
+    g_assert_nonnull(url);
+    assert_contains(url, "http://127.0.0.1:18789/", "url_token.base");
+    assert_contains(url, "#token=mytoken123", "url_token.fragment");
+}
+
+static void test_dashboard_url_secret_ref_no_token(void) {
+    GatewayConfig cfg = {0};
+    cfg.valid = TRUE;
+    cfg.host = "127.0.0.1";
+    cfg.port = 18789;
+    cfg.token = "managed-token";
+    cfg.token_is_secret_ref = TRUE;
+
+    g_autofree gchar *url = gateway_config_dashboard_url(&cfg);
+    g_assert_nonnull(url);
+    /* SecretRef token must NOT be embedded */
+    g_assert_null(strstr(url, "token="));
+}
+
+static void test_dashboard_url_invalid_config(void) {
+    GatewayConfig cfg = {0};
+    cfg.valid = FALSE;
+
+    g_autofree gchar *url = gateway_config_dashboard_url(&cfg);
+    g_assert_null(url);
+}
+
+static void test_dashboard_url_null_config(void) {
+    g_autofree gchar *url = gateway_config_dashboard_url(NULL);
+    g_assert_null(url);
+}
+
+static void test_dashboard_url_base_path_no_leading_slash(void) {
+    GatewayConfig cfg = {0};
+    cfg.valid = TRUE;
+    cfg.host = "127.0.0.1";
+    cfg.port = 18789;
+    cfg.control_ui_base_path = "dashboard";
+
+    g_autofree gchar *url = gateway_config_dashboard_url(&cfg);
+    g_assert_cmpstr(url, ==, "http://127.0.0.1:18789/dashboard/");
+}
+
+static void test_dashboard_url_base_path_trailing_slash(void) {
+    GatewayConfig cfg = {0};
+    cfg.valid = TRUE;
+    cfg.host = "127.0.0.1";
+    cfg.port = 18789;
+    cfg.control_ui_base_path = "/ui/";
+
+    g_autofree gchar *url = gateway_config_dashboard_url(&cfg);
+    g_assert_cmpstr(url, ==, "http://127.0.0.1:18789/ui/");
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Registration
+ * ══════════════════════════════════════════════════════════════════ */
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    /* Dashboard display model */
+    g_test_add_func("/display_model/dashboard/running_expected_service",
+                    test_dashboard_running_expected_service);
+    g_test_add_func("/display_model/dashboard/healthy_outside_expected_service",
+                    test_dashboard_healthy_outside_expected_service);
+    g_test_add_func("/display_model/dashboard/listener_unresponsive",
+                    test_dashboard_listener_unresponsive);
+    g_test_add_func("/display_model/dashboard/listener_unverified",
+                    test_dashboard_listener_unverified);
+    g_test_add_func("/display_model/dashboard/stopped",
+                    test_dashboard_stopped);
+    g_test_add_func("/display_model/dashboard/needs_setup",
+                    test_dashboard_needs_setup);
+    g_test_add_func("/display_model/dashboard/starting",
+                    test_dashboard_starting);
+    g_test_add_func("/display_model/dashboard/null_output",
+                    test_dashboard_null_output);
+
+    /* Tray display model */
+    g_test_add_func("/display_model/tray/running", test_tray_running);
+    g_test_add_func("/display_model/tray/stopped", test_tray_stopped);
+    g_test_add_func("/display_model/tray/starting", test_tray_starting);
+    g_test_add_func("/display_model/tray/needs_setup", test_tray_needs_setup);
+    g_test_add_func("/display_model/tray/null_output", test_tray_null_output);
+
+    /* Config display model */
+    g_test_add_func("/display_model/config/valid", test_config_valid);
+    g_test_add_func("/display_model/config/valid_with_warnings", test_config_valid_with_warnings);
+    g_test_add_func("/display_model/config/invalid", test_config_invalid);
+    g_test_add_func("/display_model/config/no_health", test_config_no_health);
+
+    /* Environment checks */
+    g_test_add_func("/display_model/env/all_ok", test_env_all_ok);
+    g_test_add_func("/display_model/env/systemd_unavailable", test_env_systemd_unavailable);
+    g_test_add_func("/display_model/env/no_config_path", test_env_no_config_path);
+
+    /* Onboarding routing */
+    g_test_add_func("/display_model/onboarding/first_run_healthy",
+                    test_onboarding_first_run_healthy);
+    g_test_add_func("/display_model/onboarding/first_run_needs_setup",
+                    test_onboarding_first_run_needs_setup);
+    g_test_add_func("/display_model/onboarding/first_run_needs_install",
+                    test_onboarding_first_run_needs_install);
+    g_test_add_func("/display_model/onboarding/first_run_stopped",
+                    test_onboarding_first_run_stopped);
+    g_test_add_func("/display_model/onboarding/first_run_starting",
+                    test_onboarding_first_run_starting);
+    g_test_add_func("/display_model/onboarding/already_seen",
+                    test_onboarding_already_seen);
+    g_test_add_func("/display_model/onboarding/newer_version",
+                    test_onboarding_newer_version);
+    g_test_add_func("/display_model/onboarding/future_seen",
+                    test_onboarding_future_seen);
+    g_test_add_func("/display_model/onboarding/error_state",
+                    test_onboarding_error_state);
+    g_test_add_func("/display_model/onboarding/degraded",
+                    test_onboarding_degraded);
+    g_test_add_func("/display_model/onboarding/config_invalid",
+                    test_onboarding_config_invalid);
+
+    /* HTTP probe labels */
+    g_test_add_func("/display_model/probe_labels", test_probe_labels);
+
+    /* Dashboard URL builder */
+    g_test_add_func("/display_model/dashboard_url/default",
+                    test_dashboard_url_default);
+    g_test_add_func("/display_model/dashboard_url/with_base_path",
+                    test_dashboard_url_with_base_path);
+    g_test_add_func("/display_model/dashboard_url/with_token",
+                    test_dashboard_url_with_token);
+    g_test_add_func("/display_model/dashboard_url/secret_ref_no_token",
+                    test_dashboard_url_secret_ref_no_token);
+    g_test_add_func("/display_model/dashboard_url/invalid_config",
+                    test_dashboard_url_invalid_config);
+    g_test_add_func("/display_model/dashboard_url/null_config",
+                    test_dashboard_url_null_config);
+    g_test_add_func("/display_model/dashboard_url/no_leading_slash",
+                    test_dashboard_url_base_path_no_leading_slash);
+    g_test_add_func("/display_model/dashboard_url/trailing_slash",
+                    test_dashboard_url_base_path_trailing_slash);
+
+    return g_test_run();
+}


### PR DESCRIPTION
meson.build: add display_model.c, app_window.c, onboarding.c to sources; add test_display_model target (display_model.c, readiness.c, runtime_mode.c, gateway_config.c, log.c).

app_window.c/.h (new): primary companion window using AdwNavigationSplitView with ten sections (Dashboard, General, Config, Environment, Diagnostics, About, Instances, Debug, Sessions, Cron). Window opens only on first-run/recovery (onboarding) or explicit tray invocation; steady-state is tray-first. All implemented sections refresh on first show and on a recurring timer.

display_model.c/.h (new): pure UI-facing mapping helpers with no GTK dependency. Implements dashboard_display_model_build(), tray_display_model_build(), config_display_model_build(), environment_check_build(), onboarding_routing_decide(), http_probe_result_label(). Surfaces service_context_notice when the observed runtime is not explained by the expected systemd service path.

onboarding.c/.h (new): versioned, state-aware onboarding with shortened and full flows. Persists completion under the user state directory. Auto-shows after startup when the current version has not been completed. Routes back into the main window on completion.

diagnostics.c: make build_diagnostics_text() non-static for integrated reuse.
diagnostics.h (new): declare diagnostics_show_window() and build_diagnostics_text().

gateway_config.c/.h: parse gateway.controlUi.basePath into GatewayConfig; update gateway_config_free() and gateway_config_equivalent() for the new field. Add gateway_config_dashboard_url() deriving the Control UI URL from host, port, normalized base path, and optional non-SecretRef token fragment.

gateway_client.c/.h: add gateway_client_get_config() accessor.

tray_helper.c: restructure tray menu to status label, runtime label, Open OpenClaw, Open Dashboard, Start/Stop/Restart, Refresh, Diagnostics, Settings, Quit. Add middle-click secondary activation for Open OpenClaw. Handle RUNTIME: and DASHBOARD_URL: IPC commands.

tray.c: route Diagnostics to integrated section, Settings to General, Open OpenClaw to main window, Open Dashboard to URL. Publish runtime label and dashboard state to helper.

main.c: wrap onboarding evaluation in a proper G_SOURCE_REMOVE callback instead of an unsafe timeout cast.

tests/test_display_model.c (new): 47 tests covering dashboard/tray/config/ environment display models, onboarding routing, HTTP probe labels, and dashboard URL derivation including base path, token fragment, SecretRef omission, invalid/ null config, and path normalization edge cases.

This completes Phase 2A Core only. RPC-backed parity surfaces (Channels, Skills, remote Instances) are intentionally out of scope.