### PR TITLE
Add Linux gateway-backed sections and RPC validation (#48)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -36,6 +36,8 @@ sources = [
   'src/gateway_http.c',
   'src/gateway_protocol.c',
   'src/gateway_ws.c',
+  'src/gateway_rpc.c',
+  'src/gateway_data.c',
   'src/gateway_client.c',
   'src/state.c',
   'src/runtime_mode.c',
@@ -104,3 +106,19 @@ test_display_model_exe = executable('test_display_model',
    'src/runtime_mode.c', 'src/gateway_config.c', 'src/log.c'],
   dependencies : [glib_dep, gio_dep, json_glib_dep])
 test('display_model', test_display_model_exe)
+
+test_gateway_data_exe = executable('test_gateway_data',
+  ['tests/test_gateway_data.c', 'src/gateway_data.c'],
+  dependencies : [glib_dep, json_glib_dep])
+test('gateway_data', test_gateway_data_exe)
+
+test_gateway_rpc_exe = executable('test_gateway_rpc',
+  ['tests/test_gateway_rpc.c', 'src/gateway_rpc.c', 'src/gateway_protocol.c', 'src/log.c'],
+  dependencies : [glib_dep, gio_dep, json_glib_dep])
+test('gateway_rpc', test_gateway_rpc_exe)
+
+test_rpc_lifecycle_exe = executable('test_rpc_lifecycle',
+  ['tests/test_rpc_lifecycle.c', 'src/gateway_rpc.c', 'src/gateway_protocol.c',
+   'src/gateway_data.c', 'src/log.c'],
+  dependencies : [glib_dep, gio_dep, json_glib_dep])
+test('rpc_lifecycle', test_rpc_lifecycle_exe)

--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -24,6 +24,8 @@
 #include "gateway_client.h"
 #include "diagnostics.h"
 #include "onboarding.h"
+#include "gateway_rpc.h"
+#include "gateway_data.h"
 #include "log.h"
 
 /* ── Section metadata ── */
@@ -38,6 +40,8 @@ static const SectionMeta section_meta[SECTION_COUNT] = {
     [SECTION_DASHBOARD]    = { "dashboard",    "Dashboard",    "computer-symbolic" },
     [SECTION_GENERAL]      = { "general",      "General",      "preferences-system-symbolic" },
     [SECTION_CONFIG]       = { "config",       "Config",       "document-properties-symbolic" },
+    [SECTION_CHANNELS]     = { "channels",     "Channels",     "mail-send-symbolic" },
+    [SECTION_SKILLS]       = { "skills",       "Skills",       "applications-science-symbolic" },
     [SECTION_ENVIRONMENT]  = { "environment",  "Environment",  "system-run-symbolic" },
     [SECTION_DIAGNOSTICS]  = { "diagnostics",  "Diagnostics",  "utilities-system-monitor-symbolic" },
     [SECTION_ABOUT]        = { "about",        "About",        "help-about-symbolic" },
@@ -53,6 +57,20 @@ static GtkWidget *main_window = NULL;
 static GtkWidget *content_stack = NULL;
 static GtkWidget *sidebar_list = NULL;
 static guint refresh_timer_id = 0;
+static AppSection active_section = SECTION_DASHBOARD;
+
+/* Per-section RPC freshness: last successful fetch time (monotonic µs) */
+static gint64 rpc_last_fetch_us[SECTION_COUNT] = {0};
+#define RPC_FRESH_INTERVAL_US (30 * G_USEC_PER_SEC)  /* 30 s TTL */
+
+static gboolean rpc_section_is_stale(AppSection s) {
+    gint64 now = g_get_monotonic_time();
+    return (now - rpc_last_fetch_us[s]) >= RPC_FRESH_INTERVAL_US;
+}
+
+static void rpc_section_mark_fresh(AppSection s) {
+    rpc_last_fetch_us[s] = g_get_monotonic_time();
+}
 
 /* Section content widgets that need updating */
 static GtkWidget *section_pages[SECTION_COUNT] = {0};
@@ -68,14 +86,21 @@ static GtkWidget* build_environment_section(void);
 static GtkWidget* build_about_section(void);
 static GtkWidget* build_instances_section(void);
 static GtkWidget* build_debug_section(void);
+static GtkWidget* build_channels_section(void);
+static GtkWidget* build_skills_section(void);
 static GtkWidget* build_sessions_section(void);
 static GtkWidget* build_cron_section(void);
 static void refresh_dashboard_content(void);
 static void refresh_general_content(void);
 static void refresh_config_content(void);
+static void refresh_channels_content(void);
+static void refresh_skills_content(void);
+static void refresh_sessions_content(void);
+static void refresh_cron_content(void);
 static void refresh_diagnostics_content(void);
 static void refresh_environment_content(void);
-static void refresh_instances_content(void);
+static void refresh_instances_local_content(void);
+static void refresh_instances_remote_content(void);
 static void refresh_debug_content(void);
 static void on_sidebar_row_activated(GtkListBox *box, GtkListBoxRow *row, gpointer user_data);
 static void on_window_destroy(GtkWindow *window, gpointer user_data);
@@ -141,6 +166,10 @@ static GtkWidget* build_content_stack(void) {
             page = build_config_section();
         } else if (i == SECTION_DIAGNOSTICS) {
             page = build_diagnostics_section();
+        } else if (i == SECTION_CHANNELS) {
+            page = build_channels_section();
+        } else if (i == SECTION_SKILLS) {
+            page = build_skills_section();
         } else if (i == SECTION_ENVIRONMENT) {
             page = build_environment_section();
         } else if (i == SECTION_ABOUT) {
@@ -165,13 +194,26 @@ static GtkWidget* build_content_stack(void) {
 
 /* ── Sidebar row activation ── */
 
+static void refresh_active_rpc_section(AppSection section) {
+    switch (section) {
+    case SECTION_CHANNELS:  refresh_channels_content();  break;
+    case SECTION_SKILLS:    refresh_skills_content();    break;
+    case SECTION_INSTANCES: refresh_instances_remote_content();  break;
+    case SECTION_SESSIONS:  refresh_sessions_content();  break;
+    case SECTION_CRON:      refresh_cron_content();      break;
+    default: break;
+    }
+}
+
 static void on_sidebar_row_activated(GtkListBox *box, GtkListBoxRow *row, gpointer user_data) {
     (void)box;
     (void)user_data;
 
     int idx = gtk_list_box_row_get_index(row);
     if (idx >= 0 && idx < SECTION_COUNT) {
+        active_section = (AppSection)idx;
         gtk_stack_set_visible_child_name(GTK_STACK(content_stack), section_meta[idx].id);
+        refresh_active_rpc_section(active_section);
     }
 }
 
@@ -1291,6 +1333,12 @@ static GtkWidget *inst_endpoint_label = NULL;
 static GtkWidget *inst_unit_label = NULL;
 static GtkWidget *inst_state_label = NULL;
 
+/* Remote nodes (from node.list RPC) */
+static GtkWidget *inst_remote_box = NULL;
+static GtkWidget *inst_remote_status_label = NULL;
+static GatewayNodesData *inst_nodes_cache = NULL;
+static gboolean inst_nodes_fetch_in_flight = FALSE;
+
 static GtkWidget* inst_card_row(const char *heading, GtkWidget **out_value) {
     GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
     gtk_widget_set_margin_top(row, 2);
@@ -1363,11 +1411,140 @@ static GtkWidget* build_instances_section(void) {
     gtk_frame_set_child(GTK_FRAME(card_frame), card);
     gtk_box_append(GTK_BOX(page), card_frame);
 
+    /* Remote nodes section */
+    GtkWidget *remote_title = gtk_label_new("Remote Instances");
+    gtk_widget_add_css_class(remote_title, "heading");
+    gtk_label_set_xalign(GTK_LABEL(remote_title), 0.0);
+    gtk_widget_set_margin_top(remote_title, 16);
+    gtk_box_append(GTK_BOX(page), remote_title);
+
+    inst_remote_status_label = gtk_label_new("Loading…");
+    gtk_widget_add_css_class(inst_remote_status_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(inst_remote_status_label), 0.0);
+    gtk_box_append(GTK_BOX(page), inst_remote_status_label);
+
+    inst_remote_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 4);
+    gtk_widget_set_margin_top(inst_remote_box, 4);
+    gtk_box_append(GTK_BOX(page), inst_remote_box);
+
     gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
     return scrolled;
 }
 
-static void refresh_instances_content(void) {
+static void inst_rebuild_remote_nodes(void) {
+    if (!inst_remote_box) return;
+
+    GtkWidget *child;
+    while ((child = gtk_widget_get_first_child(inst_remote_box)) != NULL) {
+        gtk_box_remove(GTK_BOX(inst_remote_box), child);
+    }
+
+    if (!inst_nodes_cache || inst_nodes_cache->n_nodes == 0) {
+        GtkWidget *empty = gtk_label_new("No remote instances.");
+        gtk_widget_add_css_class(empty, "dim-label");
+        gtk_label_set_xalign(GTK_LABEL(empty), 0.0);
+        gtk_box_append(GTK_BOX(inst_remote_box), empty);
+        return;
+    }
+
+    for (gint i = 0; i < inst_nodes_cache->n_nodes; i++) {
+        GatewayNode *nd = &inst_nodes_cache->nodes[i];
+
+        GtkWidget *node_frame = gtk_frame_new(NULL);
+        gtk_widget_set_margin_top(node_frame, 4);
+
+        GtkWidget *node_card = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
+        gtk_widget_set_margin_start(node_card, 12);
+        gtk_widget_set_margin_end(node_card, 12);
+        gtk_widget_set_margin_top(node_card, 8);
+        gtk_widget_set_margin_bottom(node_card, 8);
+
+        /* Header row: status dot + name + platform */
+        GtkWidget *hdr = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+        GtkWidget *dot = gtk_label_new(nd->connected ? "●" : "○");
+        gtk_widget_add_css_class(dot, nd->connected ? "success" : "dim-label");
+        gtk_box_append(GTK_BOX(hdr), dot);
+
+        GtkWidget *name_lbl = gtk_label_new(
+            nd->display_name ? nd->display_name : nd->node_id);
+        gtk_widget_add_css_class(name_lbl, "heading");
+        gtk_label_set_xalign(GTK_LABEL(name_lbl), 0.0);
+        gtk_widget_set_hexpand(name_lbl, TRUE);
+        gtk_box_append(GTK_BOX(hdr), name_lbl);
+
+        if (nd->platform) {
+            GtkWidget *plat = gtk_label_new(nd->platform);
+            gtk_widget_add_css_class(plat, "dim-label");
+            gtk_box_append(GTK_BOX(hdr), plat);
+        }
+
+        gtk_box_append(GTK_BOX(node_card), hdr);
+
+        /* Detail rows */
+        if (nd->version) {
+            GtkWidget *ver_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+            GtkWidget *ver_h = gtk_label_new("Version");
+            gtk_widget_add_css_class(ver_h, "dim-label");
+            gtk_widget_set_size_request(ver_h, 100, -1);
+            gtk_box_append(GTK_BOX(ver_row), ver_h);
+            gtk_box_append(GTK_BOX(ver_row), gtk_label_new(nd->version));
+            gtk_box_append(GTK_BOX(node_card), ver_row);
+        }
+
+        if (nd->device_family) {
+            GtkWidget *dev_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+            GtkWidget *dev_h = gtk_label_new("Device");
+            gtk_widget_add_css_class(dev_h, "dim-label");
+            gtk_widget_set_size_request(dev_h, 100, -1);
+            gtk_box_append(GTK_BOX(dev_row), dev_h);
+            gtk_box_append(GTK_BOX(dev_row), gtk_label_new(nd->device_family));
+            gtk_box_append(GTK_BOX(node_card), dev_row);
+        }
+
+        gtk_frame_set_child(GTK_FRAME(node_frame), node_card);
+        gtk_box_append(GTK_BOX(inst_remote_box), node_frame);
+    }
+}
+
+static void on_nodes_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
+    (void)user_data;
+    inst_nodes_fetch_in_flight = FALSE;
+
+    if (!inst_remote_box) return;
+
+    if (!response->ok) {
+        if (inst_remote_status_label) {
+            g_autofree gchar *msg = g_strdup_printf("Error: %s",
+                response->error_msg ? response->error_msg : "unknown");
+            gtk_label_set_text(GTK_LABEL(inst_remote_status_label), msg);
+        }
+        return;
+    }
+
+    rpc_section_mark_fresh(SECTION_INSTANCES);
+    gateway_nodes_data_free(inst_nodes_cache);
+    inst_nodes_cache = gateway_data_parse_nodes(response->payload);
+
+    if (inst_remote_status_label) {
+        if (inst_nodes_cache) {
+            gint connected = 0;
+            for (gint i = 0; i < inst_nodes_cache->n_nodes; i++) {
+                if (inst_nodes_cache->nodes[i].connected) connected++;
+            }
+            g_autofree gchar *msg = g_strdup_printf("%d node%s (%d online)",
+                inst_nodes_cache->n_nodes,
+                inst_nodes_cache->n_nodes == 1 ? "" : "s",
+                connected);
+            gtk_label_set_text(GTK_LABEL(inst_remote_status_label), msg);
+        } else {
+            gtk_label_set_text(GTK_LABEL(inst_remote_status_label), "Failed to parse response");
+        }
+    }
+
+    inst_rebuild_remote_nodes();
+}
+
+static void refresh_instances_local_content(void) {
     if (!inst_hostname_label) return;
 
     AppState current = state_get_current();
@@ -1406,6 +1583,25 @@ static void refresh_instances_content(void) {
     } else {
         gtk_label_set_text(GTK_LABEL(inst_state_label),
             dm.active_state ? dm.active_state : "—");
+    }
+}
+
+static void refresh_instances_remote_content(void) {
+    if (!inst_remote_box || inst_nodes_fetch_in_flight) return;
+    if (!rpc_section_is_stale(SECTION_INSTANCES)) return;
+    if (!gateway_rpc_is_ready()) {
+        if (inst_remote_status_label)
+            gtk_label_set_text(GTK_LABEL(inst_remote_status_label), "Gateway not connected");
+        return;
+    }
+
+    inst_nodes_fetch_in_flight = TRUE;
+    g_autofree gchar *req_id = gateway_rpc_request(
+        "node.list", NULL, 0, on_nodes_rpc_response, NULL);
+    if (!req_id) {
+        inst_nodes_fetch_in_flight = FALSE;
+        if (inst_remote_status_label)
+            gtk_label_set_text(GTK_LABEL(inst_remote_status_label), "Failed to send request");
     }
 }
 
@@ -1590,12 +1786,480 @@ static void on_open_dashboard_for_section(GtkButton *b, gpointer d) {
     if (url) g_app_info_launch_default_for_uri(url, NULL, NULL);
 }
 
+/* ══════════════════════════════════════════════════════════════════
+ * Channels section — RPC-backed via channels.status
+ * ══════════════════════════════════════════════════════════════════ */
+
+static GtkWidget *channels_list_box = NULL;
+static GtkWidget *channels_status_label = NULL;
+static GatewayChannelsData *channels_data_cache = NULL;
+static gboolean channels_fetch_in_flight = FALSE;
+
+static void channels_rebuild_list(void) {
+    if (!channels_list_box) return;
+
+    /* Remove all existing children */
+    GtkWidget *child;
+    while ((child = gtk_widget_get_first_child(channels_list_box)) != NULL) {
+        gtk_box_remove(GTK_BOX(channels_list_box), child);
+    }
+
+    if (!channels_data_cache || channels_data_cache->n_channels == 0) {
+        GtkWidget *empty = gtk_label_new("No channels available.");
+        gtk_widget_add_css_class(empty, "dim-label");
+        gtk_label_set_xalign(GTK_LABEL(empty), 0.0);
+        gtk_box_append(GTK_BOX(channels_list_box), empty);
+        return;
+    }
+
+    for (gint i = 0; i < channels_data_cache->n_channels; i++) {
+        GatewayChannel *ch = &channels_data_cache->channels[i];
+
+        GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 12);
+        gtk_widget_set_margin_top(row, 6);
+        gtk_widget_set_margin_bottom(row, 6);
+
+        /* Status dot */
+        GtkWidget *dot = gtk_label_new(ch->connected ? "●" : "○");
+        if (ch->connected)
+            gtk_widget_add_css_class(dot, "success");
+        else
+            gtk_widget_add_css_class(dot, "dim-label");
+        gtk_box_append(GTK_BOX(row), dot);
+
+        /* Channel name */
+        GtkWidget *name = gtk_label_new(ch->label ? ch->label : ch->channel_id);
+        gtk_widget_add_css_class(name, "heading");
+        gtk_label_set_xalign(GTK_LABEL(name), 0.0);
+        gtk_widget_set_hexpand(name, TRUE);
+        gtk_box_append(GTK_BOX(row), name);
+
+        /* Account count */
+        if (ch->account_count > 0) {
+            g_autofree gchar *acct_str = g_strdup_printf("%d account%s",
+                ch->account_count, ch->account_count == 1 ? "" : "s");
+            GtkWidget *acct = gtk_label_new(acct_str);
+            gtk_widget_add_css_class(acct, "dim-label");
+            gtk_box_append(GTK_BOX(row), acct);
+        }
+
+        gtk_box_append(GTK_BOX(channels_list_box), row);
+
+        /* Detail label if available */
+        if (ch->detail_label) {
+            GtkWidget *detail = gtk_label_new(ch->detail_label);
+            gtk_widget_add_css_class(detail, "dim-label");
+            gtk_label_set_xalign(GTK_LABEL(detail), 0.0);
+            gtk_widget_set_margin_start(detail, 24);
+            gtk_box_append(GTK_BOX(channels_list_box), detail);
+        }
+    }
+}
+
+static void on_channels_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
+    (void)user_data;
+    channels_fetch_in_flight = FALSE;
+
+    if (!channels_list_box) return;
+
+    if (!response->ok) {
+        if (channels_status_label) {
+            g_autofree gchar *msg = g_strdup_printf("Error: %s",
+                response->error_msg ? response->error_msg : "unknown");
+            gtk_label_set_text(GTK_LABEL(channels_status_label), msg);
+        }
+        return;
+    }
+
+    rpc_section_mark_fresh(SECTION_CHANNELS);
+    gateway_channels_data_free(channels_data_cache);
+    channels_data_cache = gateway_data_parse_channels(response->payload);
+
+    if (channels_status_label) {
+        if (channels_data_cache) {
+            g_autofree gchar *msg = g_strdup_printf("%d channel%s",
+                channels_data_cache->n_channels,
+                channels_data_cache->n_channels == 1 ? "" : "s");
+            gtk_label_set_text(GTK_LABEL(channels_status_label), msg);
+        } else {
+            gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to parse response");
+        }
+    }
+
+    channels_rebuild_list();
+}
+
+static void refresh_channels_content(void) {
+    if (!channels_list_box || channels_fetch_in_flight) return;
+    if (!rpc_section_is_stale(SECTION_CHANNELS)) return;
+    if (!gateway_rpc_is_ready()) {
+        if (channels_status_label)
+            gtk_label_set_text(GTK_LABEL(channels_status_label), "Gateway not connected");
+        return;
+    }
+
+    channels_fetch_in_flight = TRUE;
+    g_autofree gchar *req_id = gateway_rpc_request(
+        "channels.status", NULL, 0, on_channels_rpc_response, NULL);
+    if (!req_id) {
+        channels_fetch_in_flight = FALSE;
+        if (channels_status_label)
+            gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to send request");
+    }
+}
+
+static GtkWidget* build_channels_section(void) {
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 24);
+    gtk_widget_set_margin_bottom(page, 24);
+
+    GtkWidget *title = gtk_label_new("Channels");
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(page), title);
+
+    channels_status_label = gtk_label_new("Loading…");
+    gtk_widget_add_css_class(channels_status_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(channels_status_label), 0.0);
+    gtk_box_append(GTK_BOX(page), channels_status_label);
+
+    GtkWidget *sep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_top(sep, 4);
+    gtk_widget_set_margin_bottom(sep, 4);
+    gtk_box_append(GTK_BOX(page), sep);
+
+    channels_list_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    gtk_box_append(GTK_BOX(page), channels_list_box);
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
+    return scrolled;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Skills section — RPC-backed via skills.status
+ * ══════════════════════════════════════════════════════════════════ */
+
+static GtkWidget *skills_list_box = NULL;
+static GtkWidget *skills_status_label = NULL;
+static GatewaySkillsData *skills_data_cache = NULL;
+static gboolean skills_fetch_in_flight = FALSE;
+
+static void skills_rebuild_list(void) {
+    if (!skills_list_box) return;
+
+    GtkWidget *child;
+    while ((child = gtk_widget_get_first_child(skills_list_box)) != NULL) {
+        gtk_box_remove(GTK_BOX(skills_list_box), child);
+    }
+
+    if (!skills_data_cache || skills_data_cache->n_skills == 0) {
+        GtkWidget *empty = gtk_label_new("No skills available.");
+        gtk_widget_add_css_class(empty, "dim-label");
+        gtk_label_set_xalign(GTK_LABEL(empty), 0.0);
+        gtk_box_append(GTK_BOX(skills_list_box), empty);
+        return;
+    }
+
+    for (gint i = 0; i < skills_data_cache->n_skills; i++) {
+        GatewaySkill *sk = &skills_data_cache->skills[i];
+
+        GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 12);
+        gtk_widget_set_margin_top(row, 6);
+        gtk_widget_set_margin_bottom(row, 6);
+
+        /* Status indicator */
+        const gchar *status_text;
+        const gchar *status_class;
+        if (sk->disabled) {
+            status_text = "○";
+            status_class = "dim-label";
+        } else if (sk->installed && sk->enabled) {
+            status_text = "●";
+            status_class = "success";
+        } else if (sk->enabled && !sk->installed) {
+            status_text = "◎";
+            status_class = "warning";
+        } else {
+            status_text = "○";
+            status_class = "dim-label";
+        }
+        GtkWidget *dot = gtk_label_new(status_text);
+        gtk_widget_add_css_class(dot, status_class);
+        gtk_box_append(GTK_BOX(row), dot);
+
+        /* Skill name */
+        GtkWidget *name = gtk_label_new(sk->name ? sk->name : sk->key);
+        gtk_widget_add_css_class(name, "heading");
+        gtk_label_set_xalign(GTK_LABEL(name), 0.0);
+        gtk_widget_set_hexpand(name, TRUE);
+        gtk_box_append(GTK_BOX(row), name);
+
+        /* Source badge */
+        if (sk->source) {
+            GtkWidget *badge = gtk_label_new(sk->source);
+            gtk_widget_add_css_class(badge, "dim-label");
+            gtk_box_append(GTK_BOX(row), badge);
+        }
+
+        /* Update available indicator */
+        if (sk->has_update) {
+            GtkWidget *upd = gtk_label_new("Update available");
+            gtk_widget_add_css_class(upd, "accent");
+            gtk_box_append(GTK_BOX(row), upd);
+        }
+
+        gtk_box_append(GTK_BOX(skills_list_box), row);
+
+        /* Description */
+        if (sk->description) {
+            GtkWidget *desc = gtk_label_new(sk->description);
+            gtk_widget_add_css_class(desc, "dim-label");
+            gtk_label_set_xalign(GTK_LABEL(desc), 0.0);
+            gtk_label_set_wrap(GTK_LABEL(desc), TRUE);
+            gtk_widget_set_margin_start(desc, 24);
+            gtk_box_append(GTK_BOX(skills_list_box), desc);
+        }
+    }
+}
+
+static void on_skills_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
+    (void)user_data;
+    skills_fetch_in_flight = FALSE;
+
+    if (!skills_list_box) return;
+
+    if (!response->ok) {
+        if (skills_status_label) {
+            g_autofree gchar *msg = g_strdup_printf("Error: %s",
+                response->error_msg ? response->error_msg : "unknown");
+            gtk_label_set_text(GTK_LABEL(skills_status_label), msg);
+        }
+        return;
+    }
+
+    rpc_section_mark_fresh(SECTION_SKILLS);
+    gateway_skills_data_free(skills_data_cache);
+    skills_data_cache = gateway_data_parse_skills(response->payload);
+
+    if (skills_status_label) {
+        if (skills_data_cache) {
+            gint enabled = 0;
+            for (gint i = 0; i < skills_data_cache->n_skills; i++) {
+                if (skills_data_cache->skills[i].enabled && !skills_data_cache->skills[i].disabled)
+                    enabled++;
+            }
+            g_autofree gchar *msg = g_strdup_printf("%d skill%s (%d enabled)",
+                skills_data_cache->n_skills,
+                skills_data_cache->n_skills == 1 ? "" : "s",
+                enabled);
+            gtk_label_set_text(GTK_LABEL(skills_status_label), msg);
+        } else {
+            gtk_label_set_text(GTK_LABEL(skills_status_label), "Failed to parse response");
+        }
+    }
+
+    skills_rebuild_list();
+}
+
+static void refresh_skills_content(void) {
+    if (!skills_list_box || skills_fetch_in_flight) return;
+    if (!rpc_section_is_stale(SECTION_SKILLS)) return;
+    if (!gateway_rpc_is_ready()) {
+        if (skills_status_label)
+            gtk_label_set_text(GTK_LABEL(skills_status_label), "Gateway not connected");
+        return;
+    }
+
+    skills_fetch_in_flight = TRUE;
+    g_autofree gchar *req_id = gateway_rpc_request(
+        "skills.status", NULL, 0, on_skills_rpc_response, NULL);
+    if (!req_id) {
+        skills_fetch_in_flight = FALSE;
+        if (skills_status_label)
+            gtk_label_set_text(GTK_LABEL(skills_status_label), "Failed to send request");
+    }
+}
+
+static GtkWidget* build_skills_section(void) {
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 24);
+    gtk_widget_set_margin_bottom(page, 24);
+
+    GtkWidget *title = gtk_label_new("Skills");
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(page), title);
+
+    skills_status_label = gtk_label_new("Loading…");
+    gtk_widget_add_css_class(skills_status_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(skills_status_label), 0.0);
+    gtk_box_append(GTK_BOX(page), skills_status_label);
+
+    GtkWidget *sep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_top(sep, 4);
+    gtk_widget_set_margin_bottom(sep, 4);
+    gtk_box_append(GTK_BOX(page), sep);
+
+    skills_list_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    gtk_box_append(GTK_BOX(page), skills_list_box);
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
+    return scrolled;
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Sessions section — RPC-backed via sessions.list
+ * ══════════════════════════════════════════════════════════════════ */
+
+static GtkWidget *sessions_list_box = NULL;
+static GtkWidget *sessions_status_label = NULL;
+static GatewaySessionsData *sessions_data_cache = NULL;
+static gboolean sessions_fetch_in_flight = FALSE;
+
+static void sessions_rebuild_list(void) {
+    if (!sessions_list_box) return;
+
+    GtkWidget *child;
+    while ((child = gtk_widget_get_first_child(sessions_list_box)) != NULL) {
+        gtk_box_remove(GTK_BOX(sessions_list_box), child);
+    }
+
+    if (!sessions_data_cache || sessions_data_cache->n_sessions == 0) {
+        GtkWidget *empty = gtk_label_new("No sessions.");
+        gtk_widget_add_css_class(empty, "dim-label");
+        gtk_label_set_xalign(GTK_LABEL(empty), 0.0);
+        gtk_box_append(GTK_BOX(sessions_list_box), empty);
+        return;
+    }
+
+    for (gint i = 0; i < sessions_data_cache->n_sessions; i++) {
+        GatewaySession *s = &sessions_data_cache->sessions[i];
+
+        GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 12);
+        gtk_widget_set_margin_top(row, 4);
+        gtk_widget_set_margin_bottom(row, 4);
+
+        /* Status indicator */
+        const gchar *dot_text = "○";
+        const gchar *dot_class = "dim-label";
+        if (s->status && g_strcmp0(s->status, "running") == 0) {
+            dot_text = "●";
+            dot_class = "success";
+        } else if (s->status && g_strcmp0(s->status, "failed") == 0) {
+            dot_text = "●";
+            dot_class = "error";
+        }
+        GtkWidget *dot = gtk_label_new(dot_text);
+        gtk_widget_add_css_class(dot, dot_class);
+        gtk_box_append(GTK_BOX(row), dot);
+
+        /* Session name */
+        const gchar *name_str = s->display_name ? s->display_name : s->key;
+        GtkWidget *name = gtk_label_new(name_str);
+        gtk_widget_add_css_class(name, "heading");
+        gtk_label_set_xalign(GTK_LABEL(name), 0.0);
+        gtk_label_set_ellipsize(GTK_LABEL(name), PANGO_ELLIPSIZE_END);
+        gtk_widget_set_hexpand(name, TRUE);
+        gtk_box_append(GTK_BOX(row), name);
+
+        /* Channel badge */
+        if (s->channel) {
+            GtkWidget *ch_badge = gtk_label_new(s->channel);
+            gtk_widget_add_css_class(ch_badge, "dim-label");
+            gtk_box_append(GTK_BOX(row), ch_badge);
+        }
+
+        /* Model badge */
+        if (s->model) {
+            GtkWidget *model_badge = gtk_label_new(s->model);
+            gtk_widget_add_css_class(model_badge, "dim-label");
+            gtk_box_append(GTK_BOX(row), model_badge);
+        }
+
+        gtk_box_append(GTK_BOX(sessions_list_box), row);
+
+        /* Subject detail */
+        if (s->subject) {
+            GtkWidget *subj = gtk_label_new(s->subject);
+            gtk_widget_add_css_class(subj, "dim-label");
+            gtk_label_set_xalign(GTK_LABEL(subj), 0.0);
+            gtk_label_set_ellipsize(GTK_LABEL(subj), PANGO_ELLIPSIZE_END);
+            gtk_widget_set_margin_start(subj, 24);
+            gtk_box_append(GTK_BOX(sessions_list_box), subj);
+        }
+    }
+}
+
+static void on_sessions_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
+    (void)user_data;
+    sessions_fetch_in_flight = FALSE;
+
+    if (!sessions_list_box) return;
+
+    if (!response->ok) {
+        if (sessions_status_label) {
+            g_autofree gchar *msg = g_strdup_printf("Error: %s",
+                response->error_msg ? response->error_msg : "unknown");
+            gtk_label_set_text(GTK_LABEL(sessions_status_label), msg);
+        }
+        return;
+    }
+
+    rpc_section_mark_fresh(SECTION_SESSIONS);
+    gateway_sessions_data_free(sessions_data_cache);
+    sessions_data_cache = gateway_data_parse_sessions(response->payload);
+
+    if (sessions_status_label) {
+        if (sessions_data_cache) {
+            g_autofree gchar *msg = g_strdup_printf("%d session%s",
+                sessions_data_cache->n_sessions,
+                sessions_data_cache->n_sessions == 1 ? "" : "s");
+            gtk_label_set_text(GTK_LABEL(sessions_status_label), msg);
+        } else {
+            gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to parse response");
+        }
+    }
+
+    sessions_rebuild_list();
+}
+
+static void refresh_sessions_content(void) {
+    if (!sessions_list_box || sessions_fetch_in_flight) return;
+    if (!rpc_section_is_stale(SECTION_SESSIONS)) return;
+    if (!gateway_rpc_is_ready()) {
+        if (sessions_status_label)
+            gtk_label_set_text(GTK_LABEL(sessions_status_label), "Gateway not connected");
+        return;
+    }
+
+    sessions_fetch_in_flight = TRUE;
+    g_autofree gchar *req_id = gateway_rpc_request(
+        "sessions.list", NULL, 0, on_sessions_rpc_response, NULL);
+    if (!req_id) {
+        sessions_fetch_in_flight = FALSE;
+        if (sessions_status_label)
+            gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
+    }
+}
+
 static GtkWidget* build_sessions_section(void) {
     GtkWidget *scrolled = gtk_scrolled_window_new();
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
                                    GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
 
-    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
     gtk_widget_set_margin_start(page, 24);
     gtk_widget_set_margin_end(page, 24);
     gtk_widget_set_margin_top(page, 24);
@@ -1606,44 +2270,177 @@ static GtkWidget* build_sessions_section(void) {
     gtk_label_set_xalign(GTK_LABEL(title), 0.0);
     gtk_box_append(GTK_BOX(page), title);
 
-    GtkWidget *desc = gtk_label_new(
-        "Sessions represent active messaging conversations between "
-        "users and the AI agent. Each channel connection maintains "
-        "its own session with message history and context.");
-    gtk_label_set_wrap(GTK_LABEL(desc), TRUE);
-    gtk_label_set_xalign(GTK_LABEL(desc), 0.0);
-    gtk_box_append(GTK_BOX(page), desc);
+    sessions_status_label = gtk_label_new("Loading…");
+    gtk_widget_add_css_class(sessions_status_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(sessions_status_label), 0.0);
+    gtk_box_append(GTK_BOX(page), sessions_status_label);
 
-    GtkWidget *info = gtk_label_new(
-        "View and manage sessions in the gateway dashboard.");
-    gtk_widget_add_css_class(info, "dim-label");
-    gtk_label_set_xalign(GTK_LABEL(info), 0.0);
-    gtk_box_append(GTK_BOX(page), info);
-
+    /* Dashboard handoff button */
     GtkWidget *btn = gtk_button_new_with_label("Open in Dashboard");
-    gtk_widget_add_css_class(btn, "suggested-action");
+    gtk_widget_add_css_class(btn, "flat");
     gtk_widget_set_halign(btn, GTK_ALIGN_START);
-    gtk_widget_set_margin_top(btn, 8);
     g_signal_connect(btn, "clicked", G_CALLBACK(on_open_dashboard_for_section), NULL);
     gtk_box_append(GTK_BOX(page), btn);
+
+    GtkWidget *sep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_top(sep, 4);
+    gtk_widget_set_margin_bottom(sep, 4);
+    gtk_box_append(GTK_BOX(page), sep);
+
+    sessions_list_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    gtk_box_append(GTK_BOX(page), sessions_list_box);
 
     gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
     return scrolled;
 }
 
 /* ══════════════════════════════════════════════════════════════════
- * Cron section (Tier B — entry point)
- *
- * Header, short description, "Open in Dashboard" action.
- * Full cron management lives in the dashboard web UI.
+ * Cron section — RPC-backed via cron.list
  * ══════════════════════════════════════════════════════════════════ */
+
+static GtkWidget *cron_list_box = NULL;
+static GtkWidget *cron_status_label = NULL;
+static GatewayCronData *cron_data_cache = NULL;
+static gboolean cron_fetch_in_flight = FALSE;
+
+static void cron_rebuild_list(void) {
+    if (!cron_list_box) return;
+
+    GtkWidget *child;
+    while ((child = gtk_widget_get_first_child(cron_list_box)) != NULL) {
+        gtk_box_remove(GTK_BOX(cron_list_box), child);
+    }
+
+    if (!cron_data_cache || cron_data_cache->n_jobs == 0) {
+        GtkWidget *empty = gtk_label_new("No cron jobs.");
+        gtk_widget_add_css_class(empty, "dim-label");
+        gtk_label_set_xalign(GTK_LABEL(empty), 0.0);
+        gtk_box_append(GTK_BOX(cron_list_box), empty);
+        return;
+    }
+
+    for (gint i = 0; i < cron_data_cache->n_jobs; i++) {
+        GatewayCronJob *job = &cron_data_cache->jobs[i];
+
+        GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 12);
+        gtk_widget_set_margin_top(row, 4);
+        gtk_widget_set_margin_bottom(row, 4);
+
+        /* Enabled/disabled dot */
+        GtkWidget *dot = gtk_label_new(job->enabled ? "●" : "○");
+        gtk_widget_add_css_class(dot, job->enabled ? "success" : "dim-label");
+        gtk_box_append(GTK_BOX(row), dot);
+
+        /* Job name */
+        GtkWidget *name = gtk_label_new(job->name ? job->name : job->id);
+        gtk_widget_add_css_class(name, "heading");
+        gtk_label_set_xalign(GTK_LABEL(name), 0.0);
+        gtk_label_set_ellipsize(GTK_LABEL(name), PANGO_ELLIPSIZE_END);
+        gtk_widget_set_hexpand(name, TRUE);
+        gtk_box_append(GTK_BOX(row), name);
+
+        /* Last run status badge */
+        if (job->last_run_status) {
+            GtkWidget *status_badge = gtk_label_new(job->last_run_status);
+            const gchar *badge_class = "dim-label";
+            if (g_strcmp0(job->last_run_status, "ok") == 0) badge_class = "success";
+            else if (g_strcmp0(job->last_run_status, "error") == 0) badge_class = "error";
+            gtk_widget_add_css_class(status_badge, badge_class);
+            gtk_box_append(GTK_BOX(row), status_badge);
+        }
+
+        gtk_box_append(GTK_BOX(cron_list_box), row);
+
+        /* Description or last error */
+        const gchar *detail = job->last_error ? job->last_error : job->description;
+        if (detail) {
+            GtkWidget *desc = gtk_label_new(detail);
+            gtk_widget_add_css_class(desc, job->last_error ? "error" : "dim-label");
+            gtk_label_set_xalign(GTK_LABEL(desc), 0.0);
+            gtk_label_set_wrap(GTK_LABEL(desc), TRUE);
+            gtk_label_set_ellipsize(GTK_LABEL(desc), PANGO_ELLIPSIZE_END);
+            gtk_label_set_max_width_chars(GTK_LABEL(desc), 80);
+            gtk_widget_set_margin_start(desc, 24);
+            gtk_box_append(GTK_BOX(cron_list_box), desc);
+        }
+    }
+
+    /* Pagination note */
+    if (cron_data_cache->has_more) {
+        g_autofree gchar *more_text = g_strdup_printf(
+            "Showing %d of %d total jobs. Open the dashboard for full list.",
+            cron_data_cache->n_jobs, cron_data_cache->total);
+        GtkWidget *more = gtk_label_new(more_text);
+        gtk_widget_add_css_class(more, "dim-label");
+        gtk_label_set_xalign(GTK_LABEL(more), 0.0);
+        gtk_widget_set_margin_top(more, 8);
+        gtk_box_append(GTK_BOX(cron_list_box), more);
+    }
+}
+
+static void on_cron_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
+    (void)user_data;
+    cron_fetch_in_flight = FALSE;
+
+    if (!cron_list_box) return;
+
+    if (!response->ok) {
+        if (cron_status_label) {
+            g_autofree gchar *msg = g_strdup_printf("Error: %s",
+                response->error_msg ? response->error_msg : "unknown");
+            gtk_label_set_text(GTK_LABEL(cron_status_label), msg);
+        }
+        return;
+    }
+
+    rpc_section_mark_fresh(SECTION_CRON);
+    gateway_cron_data_free(cron_data_cache);
+    cron_data_cache = gateway_data_parse_cron(response->payload);
+
+    if (cron_status_label) {
+        if (cron_data_cache) {
+            gint enabled = 0;
+            for (gint i = 0; i < cron_data_cache->n_jobs; i++) {
+                if (cron_data_cache->jobs[i].enabled) enabled++;
+            }
+            g_autofree gchar *msg = g_strdup_printf("%d job%s (%d enabled, %d total)",
+                cron_data_cache->n_jobs,
+                cron_data_cache->n_jobs == 1 ? "" : "s",
+                enabled, cron_data_cache->total);
+            gtk_label_set_text(GTK_LABEL(cron_status_label), msg);
+        } else {
+            gtk_label_set_text(GTK_LABEL(cron_status_label), "Failed to parse response");
+        }
+    }
+
+    cron_rebuild_list();
+}
+
+static void refresh_cron_content(void) {
+    if (!cron_list_box || cron_fetch_in_flight) return;
+    if (!rpc_section_is_stale(SECTION_CRON)) return;
+    if (!gateway_rpc_is_ready()) {
+        if (cron_status_label)
+            gtk_label_set_text(GTK_LABEL(cron_status_label), "Gateway not connected");
+        return;
+    }
+
+    cron_fetch_in_flight = TRUE;
+    g_autofree gchar *req_id = gateway_rpc_request(
+        "cron.list", NULL, 0, on_cron_rpc_response, NULL);
+    if (!req_id) {
+        cron_fetch_in_flight = FALSE;
+        if (cron_status_label)
+            gtk_label_set_text(GTK_LABEL(cron_status_label), "Failed to send request");
+    }
+}
 
 static GtkWidget* build_cron_section(void) {
     GtkWidget *scrolled = gtk_scrolled_window_new();
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
                                    GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
 
-    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
     gtk_widget_set_margin_start(page, 24);
     gtk_widget_set_margin_end(page, 24);
     gtk_widget_set_margin_top(page, 24);
@@ -1654,26 +2451,25 @@ static GtkWidget* build_cron_section(void) {
     gtk_label_set_xalign(GTK_LABEL(title), 0.0);
     gtk_box_append(GTK_BOX(page), title);
 
-    GtkWidget *desc = gtk_label_new(
-        "Cron jobs allow the AI agent to perform scheduled tasks "
-        "automatically. Configure recurring actions, periodic checks, "
-        "and timed workflows.");
-    gtk_label_set_wrap(GTK_LABEL(desc), TRUE);
-    gtk_label_set_xalign(GTK_LABEL(desc), 0.0);
-    gtk_box_append(GTK_BOX(page), desc);
+    cron_status_label = gtk_label_new("Loading…");
+    gtk_widget_add_css_class(cron_status_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(cron_status_label), 0.0);
+    gtk_box_append(GTK_BOX(page), cron_status_label);
 
-    GtkWidget *info = gtk_label_new(
-        "View and manage cron jobs in the gateway dashboard.");
-    gtk_widget_add_css_class(info, "dim-label");
-    gtk_label_set_xalign(GTK_LABEL(info), 0.0);
-    gtk_box_append(GTK_BOX(page), info);
-
+    /* Dashboard handoff button */
     GtkWidget *btn = gtk_button_new_with_label("Open in Dashboard");
-    gtk_widget_add_css_class(btn, "suggested-action");
+    gtk_widget_add_css_class(btn, "flat");
     gtk_widget_set_halign(btn, GTK_ALIGN_START);
-    gtk_widget_set_margin_top(btn, 8);
     g_signal_connect(btn, "clicked", G_CALLBACK(on_open_dashboard_for_section), NULL);
     gtk_box_append(GTK_BOX(page), btn);
+
+    GtkWidget *sep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_top(sep, 4);
+    gtk_widget_set_margin_bottom(sep, 4);
+    gtk_box_append(GTK_BOX(page), sep);
+
+    cron_list_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    gtk_box_append(GTK_BOX(page), cron_list_box);
 
     gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
     return scrolled;
@@ -1689,8 +2485,10 @@ static gboolean on_refresh_tick(gpointer user_data) {
         refresh_config_content();
         refresh_diagnostics_content();
         refresh_environment_content();
-        refresh_instances_content();
+        refresh_instances_local_content();
         refresh_debug_content();
+        /* RPC-backed sections refresh on activation + TTL, not every tick */
+        refresh_active_rpc_section(active_section);
         return G_SOURCE_CONTINUE;
     }
     refresh_timer_id = 0;
@@ -1779,11 +2577,42 @@ static void on_window_destroy(GtkWindow *window, gpointer user_data) {
     inst_endpoint_label = NULL;
     inst_unit_label = NULL;
     inst_state_label = NULL;
+    inst_remote_box = NULL;
+    inst_remote_status_label = NULL;
+    inst_nodes_fetch_in_flight = FALSE;
+    gateway_nodes_data_free(inst_nodes_cache);
+    inst_nodes_cache = NULL;
 
     dbg_state_label = NULL;
     dbg_unit_label = NULL;
     dbg_journal_label = NULL;
 
+    channels_list_box = NULL;
+    channels_status_label = NULL;
+    channels_fetch_in_flight = FALSE;
+    gateway_channels_data_free(channels_data_cache);
+    channels_data_cache = NULL;
+
+    skills_list_box = NULL;
+    skills_status_label = NULL;
+    skills_fetch_in_flight = FALSE;
+    gateway_skills_data_free(skills_data_cache);
+    skills_data_cache = NULL;
+
+    sessions_list_box = NULL;
+    sessions_status_label = NULL;
+    sessions_fetch_in_flight = FALSE;
+    gateway_sessions_data_free(sessions_data_cache);
+    sessions_data_cache = NULL;
+
+    cron_list_box = NULL;
+    cron_status_label = NULL;
+    cron_fetch_in_flight = FALSE;
+    gateway_cron_data_free(cron_data_cache);
+    cron_data_cache = NULL;
+
+    active_section = SECTION_DASHBOARD;
+    memset(rpc_last_fetch_us, 0, sizeof(rpc_last_fetch_us));
     memset(section_pages, 0, sizeof(section_pages));
 }
 
@@ -1825,14 +2654,15 @@ void app_window_show(void) {
 
     g_signal_connect(main_window, "destroy", G_CALLBACK(on_window_destroy), NULL);
 
-    /* Initial content fill for ALL sections + start auto-refresh */
+    /* Initial content fill for local/cheap sections + start auto-refresh */
     refresh_dashboard_content();
     refresh_general_content();
     refresh_config_content();
     refresh_diagnostics_content();
     refresh_environment_content();
-    refresh_instances_content();
+    refresh_instances_local_content();
     refresh_debug_content();
+    /* RPC-backed sections will fetch on first sidebar activation */
     refresh_timer_id = g_timeout_add_seconds(1, on_refresh_tick, NULL);
 
     gtk_window_present(GTK_WINDOW(main_window));
@@ -1843,6 +2673,7 @@ void app_window_navigate_to(AppSection section) {
 
     app_window_show();
 
+    active_section = section;
     if (content_stack) {
         gtk_stack_set_visible_child_name(GTK_STACK(content_stack), section_meta[section].id);
     }
@@ -1852,6 +2683,7 @@ void app_window_navigate_to(AppSection section) {
             gtk_list_box_select_row(GTK_LIST_BOX(sidebar_list), row);
         }
     }
+    refresh_active_rpc_section(active_section);
 }
 
 gboolean app_window_is_visible(void) {

--- a/apps/linux/src/app_window.h
+++ b/apps/linux/src/app_window.h
@@ -21,6 +21,8 @@ typedef enum {
     SECTION_DASHBOARD,
     SECTION_GENERAL,
     SECTION_CONFIG,
+    SECTION_CHANNELS,
+    SECTION_SKILLS,
     SECTION_ENVIRONMENT,
     SECTION_DIAGNOSTICS,
     SECTION_ABOUT,
@@ -34,4 +36,3 @@ typedef enum {
 void app_window_show(void);
 void app_window_navigate_to(AppSection section);
 gboolean app_window_is_visible(void);
-

--- a/apps/linux/src/gateway_data.c
+++ b/apps/linux/src/gateway_data.c
@@ -1,0 +1,398 @@
+/*
+ * gateway_data.c
+ *
+ * Gateway data adapter layer for the OpenClaw Linux Companion App.
+ *
+ * Parses JSON RPC response payloads into plain C structs, matching the
+ * verified gateway contracts (channels.status, skills.status, sessions.list,
+ * cron.list, node.list). No GTK dependency.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "gateway_data.h"
+#include <string.h>
+
+/* ── Helpers ─────────────────────────────────────────────────────── */
+
+static gchar* json_get_string_or_null(JsonObject *obj, const gchar *member) {
+    if (!obj || !json_object_has_member(obj, member)) return NULL;
+    JsonNode *node = json_object_get_member(obj, member);
+    if (!node || json_node_is_null(node)) return NULL;
+    if (json_node_get_value_type(node) != G_TYPE_STRING) return NULL;
+    const gchar *val = json_node_get_string(node);
+    return val ? g_strdup(val) : NULL;
+}
+
+static gint64 json_get_int64_or_zero(JsonObject *obj, const gchar *member) {
+    if (!obj || !json_object_has_member(obj, member)) return 0;
+    JsonNode *node = json_object_get_member(obj, member);
+    if (!node || json_node_is_null(node)) return 0;
+    GType vt = json_node_get_value_type(node);
+    if (vt == G_TYPE_INT64) return json_node_get_int(node);
+    if (vt == G_TYPE_DOUBLE) return (gint64)json_node_get_double(node);
+    return 0;
+}
+
+static gboolean json_get_bool_or_false(JsonObject *obj, const gchar *member) {
+    if (!obj || !json_object_has_member(obj, member)) return FALSE;
+    JsonNode *node = json_object_get_member(obj, member);
+    if (!node || json_node_is_null(node)) return FALSE;
+    if (json_node_get_value_type(node) == G_TYPE_BOOLEAN)
+        return json_node_get_boolean(node);
+    return FALSE;
+}
+
+static gint json_get_int_or_zero(JsonObject *obj, const gchar *member) {
+    return (gint)json_get_int64_or_zero(obj, member);
+}
+
+/* ── Channels ────────────────────────────────────────────────────── */
+
+void gateway_channels_data_free(GatewayChannelsData *data) {
+    if (!data) return;
+    for (gint i = 0; i < data->n_channels; i++) {
+        g_free(data->channels[i].channel_id);
+        g_free(data->channels[i].label);
+        g_free(data->channels[i].detail_label);
+        g_free(data->channels[i].default_account_id);
+    }
+    g_free(data->channels);
+    g_strfreev(data->channel_order);
+    g_free(data);
+}
+
+GatewayChannelsData* gateway_data_parse_channels(JsonNode *payload) {
+    if (!payload || !JSON_NODE_HOLDS_OBJECT(payload)) return NULL;
+    JsonObject *root = json_node_get_object(payload);
+
+    GatewayChannelsData *data = g_new0(GatewayChannelsData, 1);
+    data->ts = json_get_int64_or_zero(root, "ts");
+
+    /* channelOrder: string[] */
+    JsonArray *order_arr = NULL;
+    if (json_object_has_member(root, "channelOrder")) {
+        JsonNode *n = json_object_get_member(root, "channelOrder");
+        if (n && JSON_NODE_HOLDS_ARRAY(n))
+            order_arr = json_node_get_array(n);
+    }
+
+    if (order_arr) {
+        guint len = json_array_get_length(order_arr);
+        data->n_channel_order = (gint)len;
+        data->channel_order = g_new0(gchar*, len + 1);
+        for (guint i = 0; i < len; i++) {
+            const gchar *s = json_array_get_string_element(order_arr, i);
+            data->channel_order[i] = g_strdup(s ? s : "");
+        }
+        data->channel_order[len] = NULL;
+    }
+
+    /* channelLabels: Record<string, string> */
+    JsonObject *labels = NULL;
+    if (json_object_has_member(root, "channelLabels")) {
+        JsonNode *n = json_object_get_member(root, "channelLabels");
+        if (n && JSON_NODE_HOLDS_OBJECT(n))
+            labels = json_node_get_object(n);
+    }
+
+    /* channelDetailLabels: Record<string, string> */
+    JsonObject *detail_labels = NULL;
+    if (json_object_has_member(root, "channelDetailLabels")) {
+        JsonNode *n = json_object_get_member(root, "channelDetailLabels");
+        if (n && JSON_NODE_HOLDS_OBJECT(n))
+            detail_labels = json_node_get_object(n);
+    }
+
+    /* channelDefaultAccountId: Record<string, string> */
+    JsonObject *default_accounts = NULL;
+    if (json_object_has_member(root, "channelDefaultAccountId")) {
+        JsonNode *n = json_object_get_member(root, "channelDefaultAccountId");
+        if (n && JSON_NODE_HOLDS_OBJECT(n))
+            default_accounts = json_node_get_object(n);
+    }
+
+    /* channels: Record<string, { connected?: boolean }> */
+    JsonObject *channels_obj = NULL;
+    if (json_object_has_member(root, "channels")) {
+        JsonNode *n = json_object_get_member(root, "channels");
+        if (n && JSON_NODE_HOLDS_OBJECT(n))
+            channels_obj = json_node_get_object(n);
+    }
+
+    /* channelAccounts: Record<string, array> — count per channel */
+    JsonObject *accounts_obj = NULL;
+    if (json_object_has_member(root, "channelAccounts")) {
+        JsonNode *n = json_object_get_member(root, "channelAccounts");
+        if (n && JSON_NODE_HOLDS_OBJECT(n))
+            accounts_obj = json_node_get_object(n);
+    }
+
+    /* Build channel list from channelOrder */
+    if (data->channel_order && data->n_channel_order > 0) {
+        data->n_channels = data->n_channel_order;
+        data->channels = g_new0(GatewayChannel, data->n_channels);
+
+        for (gint i = 0; i < data->n_channels; i++) {
+            const gchar *cid = data->channel_order[i];
+            data->channels[i].channel_id = g_strdup(cid);
+
+            if (labels)
+                data->channels[i].label = json_get_string_or_null(labels, cid);
+            if (detail_labels)
+                data->channels[i].detail_label = json_get_string_or_null(detail_labels, cid);
+            if (default_accounts)
+                data->channels[i].default_account_id = json_get_string_or_null(default_accounts, cid);
+
+            if (channels_obj && json_object_has_member(channels_obj, cid)) {
+                JsonNode *cn = json_object_get_member(channels_obj, cid);
+                if (cn && JSON_NODE_HOLDS_OBJECT(cn)) {
+                    JsonObject *co = json_node_get_object(cn);
+                    data->channels[i].connected = json_get_bool_or_false(co, "connected");
+                }
+            }
+
+            if (accounts_obj && json_object_has_member(accounts_obj, cid)) {
+                JsonNode *an = json_object_get_member(accounts_obj, cid);
+                if (an && JSON_NODE_HOLDS_ARRAY(an))
+                    data->channels[i].account_count = (gint)json_array_get_length(json_node_get_array(an));
+            }
+        }
+    }
+
+    return data;
+}
+
+/* ── Skills ──────────────────────────────────────────────────────── */
+
+void gateway_skills_data_free(GatewaySkillsData *data) {
+    if (!data) return;
+    for (gint i = 0; i < data->n_skills; i++) {
+        g_free(data->skills[i].name);
+        g_free(data->skills[i].description);
+        g_free(data->skills[i].source);
+        g_free(data->skills[i].key);
+    }
+    g_free(data->skills);
+    g_free(data->workspace_dir);
+    g_free(data);
+}
+
+GatewaySkillsData* gateway_data_parse_skills(JsonNode *payload) {
+    if (!payload || !JSON_NODE_HOLDS_OBJECT(payload)) return NULL;
+    JsonObject *root = json_node_get_object(payload);
+
+    GatewaySkillsData *data = g_new0(GatewaySkillsData, 1);
+    data->workspace_dir = json_get_string_or_null(root, "workspaceDir");
+
+    JsonArray *skills_arr = NULL;
+    if (json_object_has_member(root, "skills")) {
+        JsonNode *n = json_object_get_member(root, "skills");
+        if (n && JSON_NODE_HOLDS_ARRAY(n))
+            skills_arr = json_node_get_array(n);
+    }
+
+    if (skills_arr) {
+        guint len = json_array_get_length(skills_arr);
+        data->n_skills = (gint)len;
+        data->skills = g_new0(GatewaySkill, len);
+
+        for (guint i = 0; i < len; i++) {
+            JsonNode *elem = json_array_get_element(skills_arr, i);
+            if (!elem || !JSON_NODE_HOLDS_OBJECT(elem)) continue;
+            JsonObject *obj = json_node_get_object(elem);
+
+            data->skills[i].name = json_get_string_or_null(obj, "name");
+            data->skills[i].description = json_get_string_or_null(obj, "description");
+            data->skills[i].source = json_get_string_or_null(obj, "source");
+            data->skills[i].key = json_get_string_or_null(obj, "key");
+            data->skills[i].enabled = json_get_bool_or_false(obj, "enabled");
+            data->skills[i].disabled = json_get_bool_or_false(obj, "disabled");
+            data->skills[i].installed = json_get_bool_or_false(obj, "installed");
+            data->skills[i].managed = json_get_bool_or_false(obj, "managed");
+            data->skills[i].bundled = json_get_bool_or_false(obj, "bundled");
+            data->skills[i].has_update = json_get_bool_or_false(obj, "hasUpdate");
+            data->skills[i].eligible = json_get_bool_or_false(obj, "eligible");
+        }
+    }
+
+    return data;
+}
+
+/* ── Sessions ────────────────────────────────────────────────────── */
+
+void gateway_sessions_data_free(GatewaySessionsData *data) {
+    if (!data) return;
+    for (gint i = 0; i < data->n_sessions; i++) {
+        g_free(data->sessions[i].key);
+        g_free(data->sessions[i].kind);
+        g_free(data->sessions[i].display_name);
+        g_free(data->sessions[i].channel);
+        g_free(data->sessions[i].subject);
+        g_free(data->sessions[i].status);
+        g_free(data->sessions[i].model_provider);
+        g_free(data->sessions[i].model);
+    }
+    g_free(data->sessions);
+    g_free(data);
+}
+
+GatewaySessionsData* gateway_data_parse_sessions(JsonNode *payload) {
+    if (!payload || !JSON_NODE_HOLDS_OBJECT(payload)) return NULL;
+    JsonObject *root = json_node_get_object(payload);
+
+    GatewaySessionsData *data = g_new0(GatewaySessionsData, 1);
+    data->ts = json_get_int64_or_zero(root, "ts");
+    data->count = json_get_int_or_zero(root, "count");
+
+    JsonArray *sessions_arr = NULL;
+    if (json_object_has_member(root, "sessions")) {
+        JsonNode *n = json_object_get_member(root, "sessions");
+        if (n && JSON_NODE_HOLDS_ARRAY(n))
+            sessions_arr = json_node_get_array(n);
+    }
+
+    if (sessions_arr) {
+        guint len = json_array_get_length(sessions_arr);
+        data->n_sessions = (gint)len;
+        data->sessions = g_new0(GatewaySession, len);
+
+        for (guint i = 0; i < len; i++) {
+            JsonNode *elem = json_array_get_element(sessions_arr, i);
+            if (!elem || !JSON_NODE_HOLDS_OBJECT(elem)) continue;
+            JsonObject *obj = json_node_get_object(elem);
+
+            data->sessions[i].key = json_get_string_or_null(obj, "key");
+            data->sessions[i].kind = json_get_string_or_null(obj, "kind");
+            data->sessions[i].display_name = json_get_string_or_null(obj, "displayName");
+            data->sessions[i].channel = json_get_string_or_null(obj, "channel");
+            data->sessions[i].subject = json_get_string_or_null(obj, "subject");
+            data->sessions[i].status = json_get_string_or_null(obj, "status");
+            data->sessions[i].model_provider = json_get_string_or_null(obj, "modelProvider");
+            data->sessions[i].model = json_get_string_or_null(obj, "model");
+            data->sessions[i].updated_at = json_get_int64_or_zero(obj, "updatedAt");
+        }
+    }
+
+    return data;
+}
+
+/* ── Cron ────────────────────────────────────────────────────────── */
+
+void gateway_cron_data_free(GatewayCronData *data) {
+    if (!data) return;
+    for (gint i = 0; i < data->n_jobs; i++) {
+        g_free(data->jobs[i].id);
+        g_free(data->jobs[i].name);
+        g_free(data->jobs[i].description);
+        g_free(data->jobs[i].last_run_status);
+        g_free(data->jobs[i].last_error);
+    }
+    g_free(data->jobs);
+    g_free(data);
+}
+
+GatewayCronData* gateway_data_parse_cron(JsonNode *payload) {
+    if (!payload || !JSON_NODE_HOLDS_OBJECT(payload)) return NULL;
+    JsonObject *root = json_node_get_object(payload);
+
+    GatewayCronData *data = g_new0(GatewayCronData, 1);
+    data->total = json_get_int_or_zero(root, "total");
+    data->offset = json_get_int_or_zero(root, "offset");
+    data->limit = json_get_int_or_zero(root, "limit");
+    data->has_more = json_get_bool_or_false(root, "hasMore");
+
+    JsonArray *jobs_arr = NULL;
+    if (json_object_has_member(root, "jobs")) {
+        JsonNode *n = json_object_get_member(root, "jobs");
+        if (n && JSON_NODE_HOLDS_ARRAY(n))
+            jobs_arr = json_node_get_array(n);
+    }
+
+    if (jobs_arr) {
+        guint len = json_array_get_length(jobs_arr);
+        data->n_jobs = (gint)len;
+        data->jobs = g_new0(GatewayCronJob, len);
+
+        for (guint i = 0; i < len; i++) {
+            JsonNode *elem = json_array_get_element(jobs_arr, i);
+            if (!elem || !JSON_NODE_HOLDS_OBJECT(elem)) continue;
+            JsonObject *obj = json_node_get_object(elem);
+
+            data->jobs[i].id = json_get_string_or_null(obj, "id");
+            data->jobs[i].name = json_get_string_or_null(obj, "name");
+            data->jobs[i].description = json_get_string_or_null(obj, "description");
+            data->jobs[i].enabled = json_get_bool_or_false(obj, "enabled");
+            data->jobs[i].created_at_ms = json_get_int64_or_zero(obj, "createdAtMs");
+            data->jobs[i].updated_at_ms = json_get_int64_or_zero(obj, "updatedAtMs");
+
+            /* Nested state object */
+            if (json_object_has_member(obj, "state")) {
+                JsonNode *sn = json_object_get_member(obj, "state");
+                if (sn && JSON_NODE_HOLDS_OBJECT(sn)) {
+                    JsonObject *state = json_node_get_object(sn);
+                    data->jobs[i].next_run_at_ms = json_get_int64_or_zero(state, "nextRunAtMs");
+                    data->jobs[i].last_run_at_ms = json_get_int64_or_zero(state, "lastRunAtMs");
+                    data->jobs[i].last_run_status = json_get_string_or_null(state, "lastRunStatus");
+                    data->jobs[i].last_error = json_get_string_or_null(state, "lastError");
+                }
+            }
+        }
+    }
+
+    return data;
+}
+
+/* ── Nodes ───────────────────────────────────────────────────────── */
+
+void gateway_nodes_data_free(GatewayNodesData *data) {
+    if (!data) return;
+    for (gint i = 0; i < data->n_nodes; i++) {
+        g_free(data->nodes[i].node_id);
+        g_free(data->nodes[i].display_name);
+        g_free(data->nodes[i].platform);
+        g_free(data->nodes[i].version);
+        g_free(data->nodes[i].device_family);
+    }
+    g_free(data->nodes);
+    g_free(data);
+}
+
+GatewayNodesData* gateway_data_parse_nodes(JsonNode *payload) {
+    if (!payload || !JSON_NODE_HOLDS_OBJECT(payload)) return NULL;
+    JsonObject *root = json_node_get_object(payload);
+
+    GatewayNodesData *data = g_new0(GatewayNodesData, 1);
+    data->ts = json_get_int64_or_zero(root, "ts");
+
+    JsonArray *nodes_arr = NULL;
+    if (json_object_has_member(root, "nodes")) {
+        JsonNode *n = json_object_get_member(root, "nodes");
+        if (n && JSON_NODE_HOLDS_ARRAY(n))
+            nodes_arr = json_node_get_array(n);
+    }
+
+    if (nodes_arr) {
+        guint len = json_array_get_length(nodes_arr);
+        data->n_nodes = (gint)len;
+        data->nodes = g_new0(GatewayNode, len);
+
+        for (guint i = 0; i < len; i++) {
+            JsonNode *elem = json_array_get_element(nodes_arr, i);
+            if (!elem || !JSON_NODE_HOLDS_OBJECT(elem)) continue;
+            JsonObject *obj = json_node_get_object(elem);
+
+            data->nodes[i].node_id = json_get_string_or_null(obj, "nodeId");
+            data->nodes[i].display_name = json_get_string_or_null(obj, "displayName");
+            data->nodes[i].platform = json_get_string_or_null(obj, "platform");
+            data->nodes[i].version = json_get_string_or_null(obj, "version");
+            data->nodes[i].device_family = json_get_string_or_null(obj, "deviceFamily");
+            data->nodes[i].paired = json_get_bool_or_false(obj, "paired");
+            data->nodes[i].connected = json_get_bool_or_false(obj, "connected");
+            data->nodes[i].connected_at_ms = json_get_int64_or_zero(obj, "connectedAtMs");
+            data->nodes[i].approved_at_ms = json_get_int64_or_zero(obj, "approvedAtMs");
+        }
+    }
+
+    return data;
+}

--- a/apps/linux/src/gateway_data.h
+++ b/apps/linux/src/gateway_data.h
@@ -1,0 +1,141 @@
+/*
+ * gateway_data.h
+ *
+ * Gateway data adapter layer for the OpenClaw Linux Companion App.
+ *
+ * Defines C structs mirroring verified gateway RPC response payloads
+ * (channels.status, skills.status, sessions.list, cron.list, node.list)
+ * and provides JSON→struct parsing functions. No GTK dependency;
+ * testable with plain GLib + json-glib.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_GATEWAY_DATA_H
+#define OPENCLAW_LINUX_GATEWAY_DATA_H
+
+#include <glib.h>
+#include <json-glib/json-glib.h>
+
+/* ── Channels ────────────────────────────────────────────────────── */
+
+typedef struct {
+    gchar *channel_id;
+    gchar *label;
+    gchar *detail_label;
+    gchar *default_account_id;
+    gboolean connected;
+    gint account_count;
+} GatewayChannel;
+
+typedef struct {
+    gint64 ts;
+    GatewayChannel *channels;
+    gint n_channels;
+    gchar **channel_order;  /* NULL-terminated */
+    gint n_channel_order;
+} GatewayChannelsData;
+
+void gateway_channels_data_free(GatewayChannelsData *data);
+GatewayChannelsData* gateway_data_parse_channels(JsonNode *payload);
+
+/* ── Skills ──────────────────────────────────────────────────────── */
+
+typedef struct {
+    gchar *name;
+    gchar *description;
+    gchar *source;
+    gchar *key;
+    gboolean enabled;
+    gboolean disabled;
+    gboolean installed;
+    gboolean managed;
+    gboolean bundled;
+    gboolean has_update;
+    gboolean eligible;
+} GatewaySkill;
+
+typedef struct {
+    gchar *workspace_dir;
+    GatewaySkill *skills;
+    gint n_skills;
+} GatewaySkillsData;
+
+void gateway_skills_data_free(GatewaySkillsData *data);
+GatewaySkillsData* gateway_data_parse_skills(JsonNode *payload);
+
+/* ── Sessions ────────────────────────────────────────────────────── */
+
+typedef struct {
+    gchar *key;
+    gchar *kind;           /* "direct", "group", "global", "unknown" */
+    gchar *display_name;
+    gchar *channel;
+    gchar *subject;
+    gchar *status;         /* "running", "done", "failed", "killed", "timeout", or NULL */
+    gchar *model_provider;
+    gchar *model;
+    gint64 updated_at;     /* ms since epoch, or 0 */
+} GatewaySession;
+
+typedef struct {
+    gint64 ts;
+    gint count;
+    GatewaySession *sessions;
+    gint n_sessions;
+} GatewaySessionsData;
+
+void gateway_sessions_data_free(GatewaySessionsData *data);
+GatewaySessionsData* gateway_data_parse_sessions(JsonNode *payload);
+
+/* ── Cron ────────────────────────────────────────────────────────── */
+
+typedef struct {
+    gchar *id;
+    gchar *name;
+    gchar *description;
+    gboolean enabled;
+    gint64 created_at_ms;
+    gint64 updated_at_ms;
+    gint64 next_run_at_ms;    /* from state.nextRunAtMs, 0 if absent */
+    gint64 last_run_at_ms;    /* from state.lastRunAtMs, 0 if absent */
+    gchar *last_run_status;   /* "ok", "error", "skipped", or NULL */
+    gchar *last_error;
+} GatewayCronJob;
+
+typedef struct {
+    GatewayCronJob *jobs;
+    gint n_jobs;
+    gint total;
+    gint offset;
+    gint limit;
+    gboolean has_more;
+} GatewayCronData;
+
+void gateway_cron_data_free(GatewayCronData *data);
+GatewayCronData* gateway_data_parse_cron(JsonNode *payload);
+
+/* ── Nodes (Remote Instances) ────────────────────────────────────── */
+
+typedef struct {
+    gchar *node_id;
+    gchar *display_name;
+    gchar *platform;
+    gchar *version;
+    gchar *device_family;
+    gboolean paired;
+    gboolean connected;
+    gint64 connected_at_ms;
+    gint64 approved_at_ms;
+} GatewayNode;
+
+typedef struct {
+    gint64 ts;
+    GatewayNode *nodes;
+    gint n_nodes;
+} GatewayNodesData;
+
+void gateway_nodes_data_free(GatewayNodesData *data);
+GatewayNodesData* gateway_data_parse_nodes(JsonNode *payload);
+
+#endif /* OPENCLAW_LINUX_GATEWAY_DATA_H */

--- a/apps/linux/src/gateway_rpc.c
+++ b/apps/linux/src/gateway_rpc.c
@@ -1,0 +1,274 @@
+/*
+ * gateway_rpc.c
+ *
+ * Gateway RPC request/response layer for the OpenClaw Linux Companion App.
+ *
+ * Implements outbound request dispatch, pending-request registry with
+ * GHashTable<request_id, PendingRpcRequest>, response correlation,
+ * per-request timeouts, and connection-loss cleanup.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "gateway_rpc.h"
+#include "gateway_ws.h"
+#include "log.h"
+#include <string.h>
+
+typedef struct {
+    gchar               *request_id;
+    gchar               *method;
+    GatewayRpcCallback   callback;
+    gpointer             user_data;
+    guint                timeout_id;
+} PendingRpcRequest;
+
+/* Pending request registry: request_id → PendingRpcRequest* */
+static GHashTable *pending_requests = NULL;
+
+/* Forward declarations */
+static void pending_rpc_request_free(PendingRpcRequest *req);
+static gboolean on_request_timeout(gpointer user_data);
+static void ws_send_rpc_frame(const gchar *request_id, const gchar *method,
+                              JsonNode *params_json);
+
+static void ensure_registry(void) {
+    if (!pending_requests) {
+        pending_requests = g_hash_table_new_full(
+            g_str_hash, g_str_equal,
+            NULL, /* key is owned by PendingRpcRequest */
+            (GDestroyNotify)pending_rpc_request_free);
+    }
+}
+
+static void pending_rpc_request_free(PendingRpcRequest *req) {
+    if (!req) return;
+    if (req->timeout_id) {
+        g_source_remove(req->timeout_id);
+        req->timeout_id = 0;
+    }
+    g_free(req->request_id);
+    g_free(req->method);
+    g_free(req);
+}
+
+gchar* gateway_rpc_request(const gchar *method,
+                           JsonNode *params_json,
+                           guint timeout_ms,
+                           GatewayRpcCallback callback,
+                           gpointer user_data) {
+    if (!method || !callback) return NULL;
+
+    if (!gateway_rpc_is_ready()) {
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                    "rpc request rejected: WS not connected (method=%s)", method);
+        return NULL;
+    }
+
+    ensure_registry();
+
+    gchar *request_id = g_uuid_string_random();
+    if (!request_id) return NULL;
+
+    PendingRpcRequest *pending = g_new0(PendingRpcRequest, 1);
+    pending->request_id = g_strdup(request_id);
+    pending->method = g_strdup(method);
+    pending->callback = callback;
+    pending->user_data = user_data;
+
+    guint effective_timeout = timeout_ms > 0 ? timeout_ms : GATEWAY_RPC_DEFAULT_TIMEOUT_MS;
+    pending->timeout_id = g_timeout_add(effective_timeout, on_request_timeout,
+                                        g_strdup(request_id));
+
+    g_hash_table_insert(pending_requests, pending->request_id, pending);
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
+                 "rpc request sent id=%s method=%s timeout=%u ms",
+                 request_id, method, effective_timeout);
+
+    ws_send_rpc_frame(request_id, method, params_json);
+
+    return request_id;
+}
+
+gboolean gateway_rpc_handle_response(const GatewayFrame *frame) {
+    if (!frame || frame->type != GATEWAY_FRAME_RES) return FALSE;
+    if (!frame->id || !pending_requests) return FALSE;
+
+    PendingRpcRequest *pending = g_hash_table_lookup(pending_requests, frame->id);
+    if (!pending) return FALSE;
+
+    /* Remove timeout before invoking callback */
+    if (pending->timeout_id) {
+        g_source_remove(pending->timeout_id);
+        pending->timeout_id = 0;
+    }
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
+                 "rpc response received id=%s method=%s ok=%s",
+                 frame->id, pending->method,
+                 frame->error ? "false" : "true");
+
+    GatewayRpcResponse response = {
+        .ok = (frame->error == NULL),
+        .payload = frame->payload ? json_node_copy(frame->payload) : NULL,
+        .error_code = frame->code ? g_strdup(frame->code) : NULL,
+        .error_msg = frame->error ? g_strdup(frame->error) : NULL,
+    };
+
+    GatewayRpcCallback cb = pending->callback;
+    gpointer cb_data = pending->user_data;
+
+    /* Remove from registry (frees the PendingRpcRequest but not response) */
+    g_hash_table_remove(pending_requests, frame->id);
+
+    cb(&response, cb_data);
+
+    gateway_rpc_response_free_members(&response);
+    return TRUE;
+}
+
+void gateway_rpc_fail_all_pending(const gchar *reason) {
+    if (!pending_requests) return;
+
+    guint count = g_hash_table_size(pending_requests);
+    if (count == 0) return;
+
+    OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                "rpc failing %u pending requests: %s", count,
+                reason ? reason : "unknown");
+
+    /* Collect all entries first since callback might re-enter */
+    GList *values = g_hash_table_get_values(pending_requests);
+    GList *entries = NULL;
+    for (GList *l = values; l; l = l->next) {
+        PendingRpcRequest *req = l->data;
+        /* Detach timeout so pending_rpc_request_free doesn't double-remove */
+        if (req->timeout_id) {
+            g_source_remove(req->timeout_id);
+            req->timeout_id = 0;
+        }
+        entries = g_list_prepend(entries, req);
+    }
+    g_list_free(values);
+
+    /* Clear the table without calling destroy (we handle it below) */
+    g_hash_table_steal_all(pending_requests);
+
+    gchar *err_msg = g_strdup_printf("Connection lost: %s",
+                                     reason ? reason : "unknown");
+
+    for (GList *l = entries; l; l = l->next) {
+        PendingRpcRequest *req = l->data;
+
+        GatewayRpcResponse response = {
+            .ok = FALSE,
+            .payload = NULL,
+            .error_code = g_strdup("CONNECTION_LOST"),
+            .error_msg = g_strdup(err_msg),
+        };
+
+        req->callback(&response, req->user_data);
+        gateway_rpc_response_free_members(&response);
+
+        /* Free the request manually since we used steal_all */
+        g_free(req->request_id);
+        g_free(req->method);
+        g_free(req);
+    }
+
+    g_list_free(entries);
+    g_free(err_msg);
+}
+
+gboolean gateway_rpc_is_ready(void) {
+    return gateway_ws_get_state() == GATEWAY_WS_CONNECTED;
+}
+
+void gateway_rpc_response_free_members(GatewayRpcResponse *response) {
+    if (!response) return;
+    if (response->payload) {
+        json_node_unref(response->payload);
+        response->payload = NULL;
+    }
+    g_free(response->error_code);
+    response->error_code = NULL;
+    g_free(response->error_msg);
+    response->error_msg = NULL;
+}
+
+/* --- Internal helpers --- */
+
+static gboolean on_request_timeout(gpointer user_data) {
+    gchar *request_id = user_data;
+    if (!request_id || !pending_requests) {
+        g_free(request_id);
+        return G_SOURCE_REMOVE;
+    }
+
+    PendingRpcRequest *pending = g_hash_table_lookup(pending_requests, request_id);
+    if (!pending) {
+        g_free(request_id);
+        return G_SOURCE_REMOVE;
+    }
+
+    /* Clear timeout_id before removal so destroy doesn't double-remove */
+    pending->timeout_id = 0;
+
+    OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                "rpc request timed out id=%s method=%s", request_id, pending->method);
+
+    GatewayRpcResponse response = {
+        .ok = FALSE,
+        .payload = NULL,
+        .error_code = g_strdup("TIMEOUT"),
+        .error_msg = g_strdup_printf("Request timed out: %s", pending->method),
+    };
+
+    GatewayRpcCallback cb = pending->callback;
+    gpointer cb_data = pending->user_data;
+
+    g_hash_table_remove(pending_requests, request_id);
+    g_free(request_id);
+
+    cb(&response, cb_data);
+    gateway_rpc_response_free_members(&response);
+
+    return G_SOURCE_REMOVE;
+}
+
+static void ws_send_rpc_frame(const gchar *request_id, const gchar *method,
+                              JsonNode *params_json) {
+    g_autoptr(JsonBuilder) builder = json_builder_new();
+
+    json_builder_begin_object(builder);
+
+    json_builder_set_member_name(builder, "type");
+    json_builder_add_string_value(builder, "req");
+
+    json_builder_set_member_name(builder, "id");
+    json_builder_add_string_value(builder, request_id);
+
+    json_builder_set_member_name(builder, "method");
+    json_builder_add_string_value(builder, method);
+
+    json_builder_set_member_name(builder, "params");
+    if (params_json) {
+        json_builder_add_value(builder, json_node_copy(params_json));
+    } else {
+        json_builder_begin_object(builder);
+        json_builder_end_object(builder);
+    }
+
+    json_builder_end_object(builder);
+
+    g_autoptr(JsonGenerator) gen = json_generator_new();
+    JsonNode *root = json_builder_get_root(builder);
+    json_generator_set_root(gen, root);
+    g_autofree gchar *json_str = json_generator_to_data(gen, NULL);
+    json_node_unref(root);
+
+    if (json_str) {
+        gateway_ws_send_text(json_str);
+    }
+}

--- a/apps/linux/src/gateway_rpc.h
+++ b/apps/linux/src/gateway_rpc.h
@@ -1,0 +1,76 @@
+/*
+ * gateway_rpc.h
+ *
+ * Gateway RPC request/response layer for the OpenClaw Linux Companion App.
+ *
+ * Provides an outbound request API over the authenticated WebSocket connection,
+ * with unique request ID generation, a pending-request registry, response
+ * correlation, per-request timeouts, and graceful error handling.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_GATEWAY_RPC_H
+#define OPENCLAW_LINUX_GATEWAY_RPC_H
+
+#include "gateway_protocol.h"
+#include <glib.h>
+#include <json-glib/json-glib.h>
+
+/* Default per-request timeout in milliseconds */
+#define GATEWAY_RPC_DEFAULT_TIMEOUT_MS 15000
+
+typedef struct {
+    gboolean ok;
+    JsonNode *payload;     /* owned; caller must json_node_unref when done */
+    gchar    *error_code;  /* NULL on success */
+    gchar    *error_msg;   /* NULL on success */
+} GatewayRpcResponse;
+
+typedef void (*GatewayRpcCallback)(const GatewayRpcResponse *response,
+                                   gpointer user_data);
+
+/*
+ * Send an RPC request over the authenticated WS connection.
+ *
+ * method:      gateway method name (e.g. "channels.status")
+ * params_json: optional JsonNode* for the params object (ownership NOT taken;
+ *              caller retains ownership). Pass NULL for empty params.
+ * timeout_ms:  per-request timeout; 0 uses GATEWAY_RPC_DEFAULT_TIMEOUT_MS.
+ * callback:    invoked on the main thread with the response or error.
+ * user_data:   passed to callback.
+ *
+ * Returns a request ID string (caller-owned, g_free when done), or NULL if the
+ * request could not be sent (e.g. WS not connected). On NULL return, the
+ * callback is NOT invoked.
+ */
+gchar* gateway_rpc_request(const gchar *method,
+                           JsonNode *params_json,
+                           guint timeout_ms,
+                           GatewayRpcCallback callback,
+                           gpointer user_data);
+
+/*
+ * Called by gateway_ws when an authenticated GATEWAY_FRAME_RES is received.
+ * Returns TRUE if the frame was consumed by a pending RPC request.
+ */
+gboolean gateway_rpc_handle_response(const GatewayFrame *frame);
+
+/*
+ * Fail all pending requests with a connection-loss error.
+ * Called by gateway_ws on disconnect / reconnect / shutdown.
+ */
+void gateway_rpc_fail_all_pending(const gchar *reason);
+
+/*
+ * Returns TRUE if the WS connection is authenticated and ready for RPC.
+ */
+gboolean gateway_rpc_is_ready(void);
+
+/*
+ * Free a GatewayRpcResponse's owned members (but not the struct itself,
+ * as it is typically stack-allocated by the RPC layer).
+ */
+void gateway_rpc_response_free_members(GatewayRpcResponse *response);
+
+#endif /* OPENCLAW_LINUX_GATEWAY_RPC_H */

--- a/apps/linux/src/gateway_ws.c
+++ b/apps/linux/src/gateway_ws.c
@@ -20,6 +20,7 @@
 
 #include "gateway_ws.h"
 #include "gateway_protocol.h"
+#include "gateway_rpc.h"
 #include "log.h"
 #include <libsoup/soup.h>
 #include <string.h>
@@ -184,6 +185,7 @@ static gboolean ws_on_tick_watchdog(gpointer user_data) {
         gdouble tolerance = ws_client->tick_interval_ms * 2.0;
         if (delta_ms > tolerance) {
             OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY, "ws tick missed (%.0f ms > %.0f ms tolerance), reconnecting", delta_ms, tolerance);
+            gateway_rpc_fail_all_pending("Tick missed; reconnecting");
             ws_cleanup_connection();
             ws_set_error("Tick missed; reconnecting");
             ws_set_state(GATEWAY_WS_DISCONNECTED);
@@ -315,6 +317,13 @@ static void ws_handle_frame(const gchar *text) {
                     ws_set_state(GATEWAY_WS_CONNECTED);
                 }
             }
+        } else if (ws_client->state == GATEWAY_WS_CONNECTED) {
+            /* Post-auth response: dispatch to RPC pending-request registry */
+            if (!gateway_rpc_handle_response(frame)) {
+                OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
+                             "ws unmatched response id=%s (no pending request)",
+                             frame->id ? frame->id : "(none)");
+            }
         }
         break;
 
@@ -348,6 +357,7 @@ static void ws_on_closed(SoupWebsocketConnection *conn, gpointer user_data) {
     ws_client->rpc_ok = FALSE;
     g_clear_object(&ws_client->ws_conn);
     ws_stop_timers();
+    gateway_rpc_fail_all_pending("WebSocket connection closed");
 
     if (ws_client->state != GATEWAY_WS_AUTH_FAILED) {
         ws_set_error("Connection closed");
@@ -478,6 +488,7 @@ void gateway_ws_connect(const gchar *ws_url, const gchar *auth_mode,
 void gateway_ws_disconnect(void) {
     if (!ws_client) return;
     ws_client->should_reconnect = FALSE;
+    gateway_rpc_fail_all_pending("Disconnected by user");
     ws_cleanup_connection();
     ws_client->rpc_ok = FALSE;
     ws_set_state(GATEWAY_WS_DISCONNECTED);
@@ -487,6 +498,7 @@ void gateway_ws_shutdown(void) {
     if (!ws_client) return;
     ws_client->should_reconnect = FALSE;
     ws_client->callback = NULL;
+    gateway_rpc_fail_all_pending("Shutdown");
     ws_cleanup_connection();
     g_clear_object(&ws_client->session);
     g_free(ws_client->url);
@@ -497,6 +509,14 @@ void gateway_ws_shutdown(void) {
     g_free(ws_client->last_error);
     g_free(ws_client);
     ws_client = NULL;
+}
+
+gboolean gateway_ws_send_text(const gchar *text) {
+    if (!ws_client || !ws_client->ws_conn || !text) return FALSE;
+    if (soup_websocket_connection_get_state(ws_client->ws_conn) != SOUP_WEBSOCKET_STATE_OPEN)
+        return FALSE;
+    soup_websocket_connection_send_text(ws_client->ws_conn, text);
+    return TRUE;
 }
 
 GatewayWsState gateway_ws_get_state(void) {

--- a/apps/linux/src/gateway_ws.h
+++ b/apps/linux/src/gateway_ws.h
@@ -46,4 +46,11 @@ GatewayWsState gateway_ws_get_state(void);
 const gchar* gateway_ws_get_last_error(void);
 const gchar* gateway_ws_state_to_string(GatewayWsState state);
 
+/*
+ * Send a raw text frame over the authenticated WebSocket connection.
+ * Used by gateway_rpc to dispatch outbound request frames.
+ * Returns TRUE if the frame was sent, FALSE if the connection is not open.
+ */
+gboolean gateway_ws_send_text(const gchar *text);
+
 #endif /* OPENCLAW_LINUX_GATEWAY_WS_H */

--- a/apps/linux/src/tray_helper.c
+++ b/apps/linux/src/tray_helper.c
@@ -7,6 +7,27 @@
  * internal helper to prevent runtime GType collisions with the main GTK4 app.
  * Handles IPC commands to render state and gate user actions.
  *
+ * ── GNOME Tray Host-Behavior Contract ──
+ *
+ * Under Ayatana AppIndicator on Ubuntu GNOME (SNI protocol):
+ *
+ *  - Left-click:  Host-controlled. GNOME Shell (via ubuntu-appindicators
+ *                 extension) opens the indicator menu. The app does NOT
+ *                 control or override this behavior and MUST NOT attempt to.
+ *
+ *  - Right-click: Host-controlled. Same as left-click on GNOME; opens the
+ *                 indicator menu. On KDE/XFCE the host may present a
+ *                 separate context menu, but the app does not differentiate.
+ *
+ *  - Middle-click: App-controlled via app_indicator_set_secondary_activate_target.
+ *                  This helper maps middle-click to "Open OpenClaw" (line 187).
+ *                  Note: GNOME Shell ignores middle-click (host limitation);
+ *                  this only fires on KDE/XFCE/other hosts that support it.
+ *
+ * Summary: the app owns only the menu contents and the middle-click target.
+ * All click-to-menu routing is host behavior. Do not add left/right click
+ * differentiation — it is unsupported and will silently fail on GNOME.
+ *
  * Author: Thiago Camargo <thiagocmc@proton.me>
  */
 

--- a/apps/linux/tests/test_gateway_data.c
+++ b/apps/linux/tests/test_gateway_data.c
@@ -1,0 +1,761 @@
+/*
+ * test_gateway_data.c
+ *
+ * Unit tests for the gateway data adapter layer (gateway_data.h).
+ * Verifies JSON→struct parsing for all five RPC response shapes
+ * against the verified gateway contracts.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "../src/gateway_data.h"
+#include <json-glib/json-glib.h>
+#include <string.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define ASSERT(cond, msg) do { \
+    tests_run++; \
+    if (!(cond)) { \
+        g_printerr("FAIL [%s:%d]: %s\n", __FILE__, __LINE__, msg); \
+    } else { \
+        tests_passed++; \
+    } \
+} while(0)
+
+static JsonNode* parse_json(const gchar *json_str) {
+    JsonParser *parser = json_parser_new();
+    GError *error = NULL;
+    json_parser_load_from_data(parser, json_str, -1, &error);
+    if (error) {
+        g_printerr("JSON parse error: %s\n", error->message);
+        g_error_free(error);
+        g_object_unref(parser);
+        return NULL;
+    }
+    JsonNode *root = json_node_copy(json_parser_get_root(parser));
+    g_object_unref(parser);
+    return root;
+}
+
+/* ── Channels tests ──────────────────────────────────────────────── */
+
+static void test_channels_parse_basic(void) {
+    const gchar *json =
+        "{"
+        "  \"ts\": 1700000000000,"
+        "  \"channelOrder\": [\"telegram\", \"discord\"],"
+        "  \"channelLabels\": { \"telegram\": \"Telegram\", \"discord\": \"Discord\" },"
+        "  \"channelDetailLabels\": { \"telegram\": \"Telegram Bot\" },"
+        "  \"channelDefaultAccountId\": { \"telegram\": \"bot-123\" },"
+        "  \"channels\": { \"telegram\": { \"connected\": true }, \"discord\": { \"connected\": false } },"
+        "  \"channelAccounts\": { \"telegram\": [{}, {}], \"discord\": [{}] }"
+        "}";
+
+    JsonNode *node = parse_json(json);
+    ASSERT(node != NULL, "channels json parsed");
+
+    GatewayChannelsData *data = gateway_data_parse_channels(node);
+    ASSERT(data != NULL, "channels data parsed");
+    ASSERT(data->ts == 1700000000000, "channels ts");
+    ASSERT(data->n_channels == 2, "channels count");
+    ASSERT(data->n_channel_order == 2, "channel_order count");
+
+    ASSERT(g_strcmp0(data->channels[0].channel_id, "telegram") == 0, "ch[0] id");
+    ASSERT(g_strcmp0(data->channels[0].label, "Telegram") == 0, "ch[0] label");
+    ASSERT(g_strcmp0(data->channels[0].detail_label, "Telegram Bot") == 0, "ch[0] detail_label");
+    ASSERT(g_strcmp0(data->channels[0].default_account_id, "bot-123") == 0, "ch[0] default_account_id");
+    ASSERT(data->channels[0].connected == TRUE, "ch[0] connected");
+    ASSERT(data->channels[0].account_count == 2, "ch[0] account_count");
+
+    ASSERT(g_strcmp0(data->channels[1].channel_id, "discord") == 0, "ch[1] id");
+    ASSERT(g_strcmp0(data->channels[1].label, "Discord") == 0, "ch[1] label");
+    ASSERT(data->channels[1].detail_label == NULL, "ch[1] detail_label null");
+    ASSERT(data->channels[1].connected == FALSE, "ch[1] connected");
+    ASSERT(data->channels[1].account_count == 1, "ch[1] account_count");
+
+    gateway_channels_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_channels_parse_empty(void) {
+    JsonNode *node = parse_json("{}");
+    GatewayChannelsData *data = gateway_data_parse_channels(node);
+    ASSERT(data != NULL, "empty channels data parsed");
+    ASSERT(data->n_channels == 0, "empty channels count");
+    ASSERT(data->channel_order == NULL, "empty channel_order null");
+    gateway_channels_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_channels_parse_null(void) {
+    GatewayChannelsData *data = gateway_data_parse_channels(NULL);
+    ASSERT(data == NULL, "null channels returns null");
+}
+
+/* ── Skills tests ────────────────────────────────────────────────── */
+
+static void test_skills_parse_basic(void) {
+    const gchar *json =
+        "{"
+        "  \"workspaceDir\": \"/home/user/.openclaw/agent\","
+        "  \"managedSkillsDir\": \"/home/user/.openclaw/skills\","
+        "  \"skills\": ["
+        "    {"
+        "      \"name\": \"Web Search\","
+        "      \"description\": \"Search the web\","
+        "      \"source\": \"bundled\","
+        "      \"key\": \"web-search\","
+        "      \"enabled\": true,"
+        "      \"disabled\": false,"
+        "      \"installed\": true,"
+        "      \"managed\": false,"
+        "      \"bundled\": true,"
+        "      \"hasUpdate\": false,"
+        "      \"eligible\": true"
+        "    },"
+        "    {"
+        "      \"name\": \"Code Runner\","
+        "      \"description\": \"Run code\","
+        "      \"source\": \"managed\","
+        "      \"key\": \"code-runner\","
+        "      \"enabled\": false,"
+        "      \"disabled\": true,"
+        "      \"installed\": true,"
+        "      \"managed\": true,"
+        "      \"bundled\": false,"
+        "      \"hasUpdate\": true,"
+        "      \"eligible\": false"
+        "    }"
+        "  ]"
+        "}";
+
+    JsonNode *node = parse_json(json);
+    GatewaySkillsData *data = gateway_data_parse_skills(node);
+    ASSERT(data != NULL, "skills data parsed");
+    ASSERT(g_strcmp0(data->workspace_dir, "/home/user/.openclaw/agent") == 0, "workspace_dir");
+    ASSERT(data->n_skills == 2, "skills count");
+
+    ASSERT(g_strcmp0(data->skills[0].name, "Web Search") == 0, "skill[0] name");
+    ASSERT(data->skills[0].enabled == TRUE, "skill[0] enabled");
+    ASSERT(data->skills[0].bundled == TRUE, "skill[0] bundled");
+    ASSERT(data->skills[0].has_update == FALSE, "skill[0] has_update");
+
+    ASSERT(g_strcmp0(data->skills[1].name, "Code Runner") == 0, "skill[1] name");
+    ASSERT(data->skills[1].disabled == TRUE, "skill[1] disabled");
+    ASSERT(data->skills[1].has_update == TRUE, "skill[1] has_update");
+    ASSERT(data->skills[1].eligible == FALSE, "skill[1] eligible");
+
+    gateway_skills_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_skills_parse_empty(void) {
+    JsonNode *node = parse_json("{\"skills\": []}");
+    GatewaySkillsData *data = gateway_data_parse_skills(node);
+    ASSERT(data != NULL, "empty skills parsed");
+    ASSERT(data->n_skills == 0, "empty skills count");
+    gateway_skills_data_free(data);
+    json_node_unref(node);
+}
+
+/* ── Sessions tests ──────────────────────────────────────────────── */
+
+static void test_sessions_parse_basic(void) {
+    const gchar *json =
+        "{"
+        "  \"ts\": 1700000001000,"
+        "  \"path\": \"/tmp/sessions\","
+        "  \"count\": 2,"
+        "  \"defaults\": { \"modelProvider\": \"openai\", \"model\": \"gpt-4\", \"contextTokens\": 8192 },"
+        "  \"sessions\": ["
+        "    {"
+        "      \"key\": \"main\","
+        "      \"kind\": \"direct\","
+        "      \"displayName\": \"Main Session\","
+        "      \"channel\": \"telegram\","
+        "      \"subject\": \"user@example.com\","
+        "      \"status\": \"running\","
+        "      \"modelProvider\": \"openai\","
+        "      \"model\": \"gpt-4o\","
+        "      \"updatedAt\": 1700000000500"
+        "    },"
+        "    {"
+        "      \"key\": \"agent:sub-1:task-abc\","
+        "      \"kind\": \"group\","
+        "      \"updatedAt\": 1700000000100"
+        "    }"
+        "  ]"
+        "}";
+
+    JsonNode *node = parse_json(json);
+    GatewaySessionsData *data = gateway_data_parse_sessions(node);
+    ASSERT(data != NULL, "sessions data parsed");
+    ASSERT(data->ts == 1700000001000, "sessions ts");
+    ASSERT(data->count == 2, "sessions count");
+    ASSERT(data->n_sessions == 2, "sessions array count");
+
+    ASSERT(g_strcmp0(data->sessions[0].key, "main") == 0, "session[0] key");
+    ASSERT(g_strcmp0(data->sessions[0].kind, "direct") == 0, "session[0] kind");
+    ASSERT(g_strcmp0(data->sessions[0].display_name, "Main Session") == 0, "session[0] display_name");
+    ASSERT(g_strcmp0(data->sessions[0].channel, "telegram") == 0, "session[0] channel");
+    ASSERT(g_strcmp0(data->sessions[0].status, "running") == 0, "session[0] status");
+    ASSERT(data->sessions[0].updated_at == 1700000000500, "session[0] updated_at");
+
+    ASSERT(g_strcmp0(data->sessions[1].key, "agent:sub-1:task-abc") == 0, "session[1] key");
+    ASSERT(g_strcmp0(data->sessions[1].kind, "group") == 0, "session[1] kind");
+    ASSERT(data->sessions[1].display_name == NULL, "session[1] display_name null");
+    ASSERT(data->sessions[1].status == NULL, "session[1] status null");
+
+    gateway_sessions_data_free(data);
+    json_node_unref(node);
+}
+
+/* ── Cron tests ──────────────────────────────────────────────────── */
+
+static void test_cron_parse_basic(void) {
+    const gchar *json =
+        "{"
+        "  \"jobs\": ["
+        "    {"
+        "      \"id\": \"job-1\","
+        "      \"name\": \"Daily Report\","
+        "      \"description\": \"Generates daily summary\","
+        "      \"enabled\": true,"
+        "      \"createdAtMs\": 1700000000000,"
+        "      \"updatedAtMs\": 1700000001000,"
+        "      \"state\": {"
+        "        \"nextRunAtMs\": 1700100000000,"
+        "        \"lastRunAtMs\": 1700000000000,"
+        "        \"lastRunStatus\": \"ok\""
+        "      }"
+        "    },"
+        "    {"
+        "      \"id\": \"job-2\","
+        "      \"name\": \"Cleanup\","
+        "      \"enabled\": false,"
+        "      \"createdAtMs\": 1700000000000,"
+        "      \"updatedAtMs\": 1700000002000,"
+        "      \"state\": {"
+        "        \"lastRunStatus\": \"error\","
+        "        \"lastError\": \"timeout exceeded\""
+        "      }"
+        "    }"
+        "  ],"
+        "  \"total\": 5,"
+        "  \"offset\": 0,"
+        "  \"limit\": 2,"
+        "  \"hasMore\": true,"
+        "  \"nextOffset\": 2"
+        "}";
+
+    JsonNode *node = parse_json(json);
+    GatewayCronData *data = gateway_data_parse_cron(node);
+    ASSERT(data != NULL, "cron data parsed");
+    ASSERT(data->n_jobs == 2, "cron jobs count");
+    ASSERT(data->total == 5, "cron total");
+    ASSERT(data->offset == 0, "cron offset");
+    ASSERT(data->limit == 2, "cron limit");
+    ASSERT(data->has_more == TRUE, "cron has_more");
+
+    ASSERT(g_strcmp0(data->jobs[0].id, "job-1") == 0, "job[0] id");
+    ASSERT(g_strcmp0(data->jobs[0].name, "Daily Report") == 0, "job[0] name");
+    ASSERT(data->jobs[0].enabled == TRUE, "job[0] enabled");
+    ASSERT(data->jobs[0].next_run_at_ms == 1700100000000, "job[0] next_run_at_ms");
+    ASSERT(g_strcmp0(data->jobs[0].last_run_status, "ok") == 0, "job[0] last_run_status");
+
+    ASSERT(g_strcmp0(data->jobs[1].id, "job-2") == 0, "job[1] id");
+    ASSERT(data->jobs[1].enabled == FALSE, "job[1] enabled");
+    ASSERT(g_strcmp0(data->jobs[1].last_run_status, "error") == 0, "job[1] last_run_status");
+    ASSERT(g_strcmp0(data->jobs[1].last_error, "timeout exceeded") == 0, "job[1] last_error");
+
+    gateway_cron_data_free(data);
+    json_node_unref(node);
+}
+
+/* ── Nodes tests ─────────────────────────────────────────────────── */
+
+static void test_nodes_parse_basic(void) {
+    const gchar *json =
+        "{"
+        "  \"ts\": 1700000002000,"
+        "  \"nodes\": ["
+        "    {"
+        "      \"nodeId\": \"node-abc\","
+        "      \"displayName\": \"iPhone 15\","
+        "      \"platform\": \"ios\","
+        "      \"version\": \"1.2.0\","
+        "      \"deviceFamily\": \"iPhone\","
+        "      \"paired\": true,"
+        "      \"connected\": true,"
+        "      \"connectedAtMs\": 1700000001500,"
+        "      \"approvedAtMs\": 1699999000000"
+        "    },"
+        "    {"
+        "      \"nodeId\": \"node-xyz\","
+        "      \"displayName\": \"iPad\","
+        "      \"paired\": true,"
+        "      \"connected\": false"
+        "    }"
+        "  ]"
+        "}";
+
+    JsonNode *node = parse_json(json);
+    GatewayNodesData *data = gateway_data_parse_nodes(node);
+    ASSERT(data != NULL, "nodes data parsed");
+    ASSERT(data->ts == 1700000002000, "nodes ts");
+    ASSERT(data->n_nodes == 2, "nodes count");
+
+    ASSERT(g_strcmp0(data->nodes[0].node_id, "node-abc") == 0, "node[0] id");
+    ASSERT(g_strcmp0(data->nodes[0].display_name, "iPhone 15") == 0, "node[0] display_name");
+    ASSERT(g_strcmp0(data->nodes[0].platform, "ios") == 0, "node[0] platform");
+    ASSERT(data->nodes[0].connected == TRUE, "node[0] connected");
+    ASSERT(data->nodes[0].connected_at_ms == 1700000001500, "node[0] connected_at_ms");
+
+    ASSERT(g_strcmp0(data->nodes[1].node_id, "node-xyz") == 0, "node[1] id");
+    ASSERT(data->nodes[1].connected == FALSE, "node[1] connected");
+    ASSERT(data->nodes[1].platform == NULL, "node[1] platform null");
+
+    gateway_nodes_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_nodes_parse_empty(void) {
+    JsonNode *node = parse_json("{\"ts\": 0, \"nodes\": []}");
+    GatewayNodesData *data = gateway_data_parse_nodes(node);
+    ASSERT(data != NULL, "empty nodes parsed");
+    ASSERT(data->n_nodes == 0, "empty nodes count");
+    gateway_nodes_data_free(data);
+    json_node_unref(node);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Negative / malformed / partial / wrong-type tests
+ * ══════════════════════════════════════════════════════════════════ */
+
+/* ── Channels negative ───────────────────────────────────────────── */
+
+static void test_channels_wrong_type_channel_order(void) {
+    /* channelOrder is string instead of array */
+    JsonNode *node = parse_json(
+        "{\"channelOrder\": \"not-an-array\", \"channels\": {}}");
+    GatewayChannelsData *data = gateway_data_parse_channels(node);
+    ASSERT(data != NULL, "ch_wrong_type: parsed without crash");
+    ASSERT(data->n_channel_order == 0, "ch_wrong_type: no channel_order");
+    ASSERT(data->n_channels == 0, "ch_wrong_type: no channels");
+    gateway_channels_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_channels_labels_wrong_type(void) {
+    /* channelLabels is array instead of object */
+    JsonNode *node = parse_json(
+        "{\"channelOrder\": [\"x\"], \"channelLabels\": [1,2]}");
+    GatewayChannelsData *data = gateway_data_parse_channels(node);
+    ASSERT(data != NULL, "ch_labels_wrong: parsed");
+    ASSERT(data->n_channels == 1, "ch_labels_wrong: 1 channel");
+    ASSERT(data->channels[0].label == NULL, "ch_labels_wrong: label is NULL");
+    gateway_channels_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_channels_accounts_not_array(void) {
+    /* channelAccounts["x"] is string instead of array */
+    JsonNode *node = parse_json(
+        "{\"channelOrder\": [\"x\"], \"channelAccounts\": {\"x\": \"bad\"}}");
+    GatewayChannelsData *data = gateway_data_parse_channels(node);
+    ASSERT(data != NULL, "ch_acct_bad: parsed");
+    ASSERT(data->channels[0].account_count == 0, "ch_acct_bad: account_count 0");
+    gateway_channels_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_channels_non_object_payload(void) {
+    /* Payload is an array, not an object */
+    JsonNode *node = parse_json("[1, 2, 3]");
+    GatewayChannelsData *data = gateway_data_parse_channels(node);
+    ASSERT(data == NULL, "ch_array_payload: returns NULL");
+    json_node_unref(node);
+}
+
+/* ── Skills negative ─────────────────────────────────────────────── */
+
+static void test_skills_missing_array(void) {
+    /* No "skills" key at all */
+    JsonNode *node = parse_json("{\"workspaceDir\": \"/tmp\"}");
+    GatewaySkillsData *data = gateway_data_parse_skills(node);
+    ASSERT(data != NULL, "sk_no_arr: parsed");
+    ASSERT(data->n_skills == 0, "sk_no_arr: 0 skills");
+    ASSERT(g_strcmp0(data->workspace_dir, "/tmp") == 0, "sk_no_arr: workspace_dir");
+    gateway_skills_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_skills_array_wrong_type(void) {
+    /* "skills" is a string, not an array */
+    JsonNode *node = parse_json("{\"skills\": \"nope\"}");
+    GatewaySkillsData *data = gateway_data_parse_skills(node);
+    ASSERT(data != NULL, "sk_wrong_type: parsed");
+    ASSERT(data->n_skills == 0, "sk_wrong_type: 0 skills");
+    gateway_skills_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_skills_mixed_valid_invalid(void) {
+    /* One valid skill, one non-object element (number) */
+    const gchar *json =
+        "{\"skills\": ["
+        "  {\"name\": \"Good\", \"enabled\": true},"
+        "  42,"
+        "  {\"name\": \"Also Good\", \"enabled\": false}"
+        "]}";
+    JsonNode *node = parse_json(json);
+    GatewaySkillsData *data = gateway_data_parse_skills(node);
+    ASSERT(data != NULL, "sk_mixed: parsed");
+    ASSERT(data->n_skills == 3, "sk_mixed: array len 3");
+    ASSERT(g_strcmp0(data->skills[0].name, "Good") == 0, "sk_mixed: skill[0] ok");
+    /* skills[1] was non-object → skipped by continue, fields stay zeroed */
+    ASSERT(data->skills[1].name == NULL, "sk_mixed: skill[1] zeroed");
+    ASSERT(g_strcmp0(data->skills[2].name, "Also Good") == 0, "sk_mixed: skill[2] ok");
+    gateway_skills_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_skills_partial_fields(void) {
+    /* Skill with only name, all booleans default to false */
+    JsonNode *node = parse_json("{\"skills\": [{\"name\": \"Minimal\"}]}");
+    GatewaySkillsData *data = gateway_data_parse_skills(node);
+    ASSERT(data != NULL, "sk_partial: parsed");
+    ASSERT(g_strcmp0(data->skills[0].name, "Minimal") == 0, "sk_partial: name");
+    ASSERT(data->skills[0].enabled == FALSE, "sk_partial: enabled default");
+    ASSERT(data->skills[0].disabled == FALSE, "sk_partial: disabled default");
+    ASSERT(data->skills[0].installed == FALSE, "sk_partial: installed default");
+    ASSERT(data->skills[0].has_update == FALSE, "sk_partial: has_update default");
+    ASSERT(data->skills[0].key == NULL, "sk_partial: key NULL");
+    ASSERT(data->skills[0].description == NULL, "sk_partial: description NULL");
+    gateway_skills_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_skills_wrong_type_booleans(void) {
+    /* Boolean fields are strings instead of booleans */
+    JsonNode *node = parse_json(
+        "{\"skills\": [{\"name\": \"X\", \"enabled\": \"yes\", \"disabled\": 1}]}");
+    GatewaySkillsData *data = gateway_data_parse_skills(node);
+    ASSERT(data != NULL, "sk_bool_wrong: parsed");
+    ASSERT(data->skills[0].enabled == FALSE, "sk_bool_wrong: string not bool");
+    ASSERT(data->skills[0].disabled == FALSE, "sk_bool_wrong: int not bool");
+    gateway_skills_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_skills_null_input(void) {
+    GatewaySkillsData *data = gateway_data_parse_skills(NULL);
+    ASSERT(data == NULL, "sk_null: returns NULL");
+}
+
+/* ── Sessions negative ───────────────────────────────────────────── */
+
+static void test_sessions_missing_array(void) {
+    JsonNode *node = parse_json("{\"ts\": 100, \"count\": 0}");
+    GatewaySessionsData *data = gateway_data_parse_sessions(node);
+    ASSERT(data != NULL, "sess_no_arr: parsed");
+    ASSERT(data->n_sessions == 0, "sess_no_arr: 0 sessions");
+    ASSERT(data->ts == 100, "sess_no_arr: ts preserved");
+    gateway_sessions_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_sessions_array_wrong_type(void) {
+    JsonNode *node = parse_json("{\"sessions\": \"nope\"}");
+    GatewaySessionsData *data = gateway_data_parse_sessions(node);
+    ASSERT(data != NULL, "sess_wrong_type: parsed");
+    ASSERT(data->n_sessions == 0, "sess_wrong_type: 0 sessions");
+    gateway_sessions_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_sessions_partial_item(void) {
+    /* Session with only key and kind, all optional fields NULL */
+    JsonNode *node = parse_json(
+        "{\"sessions\": [{\"key\": \"s1\", \"kind\": \"direct\"}]}");
+    GatewaySessionsData *data = gateway_data_parse_sessions(node);
+    ASSERT(data != NULL, "sess_partial: parsed");
+    ASSERT(data->n_sessions == 1, "sess_partial: 1 session");
+    ASSERT(g_strcmp0(data->sessions[0].key, "s1") == 0, "sess_partial: key");
+    ASSERT(data->sessions[0].display_name == NULL, "sess_partial: display_name NULL");
+    ASSERT(data->sessions[0].channel == NULL, "sess_partial: channel NULL");
+    ASSERT(data->sessions[0].status == NULL, "sess_partial: status NULL");
+    ASSERT(data->sessions[0].model == NULL, "sess_partial: model NULL");
+    ASSERT(data->sessions[0].updated_at == 0, "sess_partial: updated_at 0");
+    gateway_sessions_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_sessions_mixed_valid_invalid(void) {
+    /* One valid, one non-object (string), one valid */
+    const gchar *json =
+        "{\"sessions\": ["
+        "  {\"key\": \"a\", \"kind\": \"direct\"},"
+        "  \"garbage\","
+        "  {\"key\": \"b\", \"kind\": \"group\"}"
+        "]}";
+    JsonNode *node = parse_json(json);
+    GatewaySessionsData *data = gateway_data_parse_sessions(node);
+    ASSERT(data != NULL, "sess_mixed: parsed");
+    ASSERT(data->n_sessions == 3, "sess_mixed: array len 3");
+    ASSERT(g_strcmp0(data->sessions[0].key, "a") == 0, "sess_mixed: [0] ok");
+    ASSERT(data->sessions[1].key == NULL, "sess_mixed: [1] zeroed");
+    ASSERT(g_strcmp0(data->sessions[2].key, "b") == 0, "sess_mixed: [2] ok");
+    gateway_sessions_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_sessions_wrong_type_fields(void) {
+    /* updatedAt is string, key is number */
+    JsonNode *node = parse_json(
+        "{\"sessions\": [{\"key\": 12345, \"updatedAt\": \"not-a-number\"}]}");
+    GatewaySessionsData *data = gateway_data_parse_sessions(node);
+    ASSERT(data != NULL, "sess_wrong_fields: parsed");
+    ASSERT(data->sessions[0].key == NULL, "sess_wrong_fields: int key → NULL");
+    ASSERT(data->sessions[0].updated_at == 0, "sess_wrong_fields: str updated_at → 0");
+    gateway_sessions_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_sessions_null_input(void) {
+    GatewaySessionsData *data = gateway_data_parse_sessions(NULL);
+    ASSERT(data == NULL, "sess_null: returns NULL");
+}
+
+static void test_sessions_empty(void) {
+    JsonNode *node = parse_json("{\"sessions\": []}");
+    GatewaySessionsData *data = gateway_data_parse_sessions(node);
+    ASSERT(data != NULL, "sess_empty: parsed");
+    ASSERT(data->n_sessions == 0, "sess_empty: 0 sessions");
+    gateway_sessions_data_free(data);
+    json_node_unref(node);
+}
+
+/* ── Cron negative ───────────────────────────────────────────────── */
+
+static void test_cron_missing_jobs(void) {
+    JsonNode *node = parse_json("{\"total\": 5}");
+    GatewayCronData *data = gateway_data_parse_cron(node);
+    ASSERT(data != NULL, "cron_no_jobs: parsed");
+    ASSERT(data->n_jobs == 0, "cron_no_jobs: 0 jobs");
+    ASSERT(data->total == 5, "cron_no_jobs: total preserved");
+    gateway_cron_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_cron_jobs_wrong_type(void) {
+    JsonNode *node = parse_json("{\"jobs\": \"nope\"}");
+    GatewayCronData *data = gateway_data_parse_cron(node);
+    ASSERT(data != NULL, "cron_wrong_type: parsed");
+    ASSERT(data->n_jobs == 0, "cron_wrong_type: 0 jobs");
+    gateway_cron_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_cron_malformed_state(void) {
+    /* state is a string instead of object */
+    const gchar *json =
+        "{\"jobs\": [{\"id\": \"j1\", \"name\": \"Test\", \"enabled\": true, \"state\": \"broken\"}]}";
+    JsonNode *node = parse_json(json);
+    GatewayCronData *data = gateway_data_parse_cron(node);
+    ASSERT(data != NULL, "cron_bad_state: parsed");
+    ASSERT(data->n_jobs == 1, "cron_bad_state: 1 job");
+    ASSERT(g_strcmp0(data->jobs[0].id, "j1") == 0, "cron_bad_state: id ok");
+    ASSERT(data->jobs[0].next_run_at_ms == 0, "cron_bad_state: next_run default");
+    ASSERT(data->jobs[0].last_run_status == NULL, "cron_bad_state: no status");
+    gateway_cron_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_cron_mixed_valid_invalid(void) {
+    const gchar *json =
+        "{\"jobs\": ["
+        "  {\"id\": \"good\", \"name\": \"OK\", \"enabled\": true},"
+        "  null,"
+        "  {\"id\": \"also-good\", \"name\": \"Fine\"}"
+        "]}";
+    JsonNode *node = parse_json(json);
+    GatewayCronData *data = gateway_data_parse_cron(node);
+    ASSERT(data != NULL, "cron_mixed: parsed");
+    ASSERT(data->n_jobs == 3, "cron_mixed: array len 3");
+    ASSERT(g_strcmp0(data->jobs[0].id, "good") == 0, "cron_mixed: [0] ok");
+    ASSERT(data->jobs[1].id == NULL, "cron_mixed: [1] zeroed");
+    ASSERT(g_strcmp0(data->jobs[2].id, "also-good") == 0, "cron_mixed: [2] ok");
+    gateway_cron_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_cron_partial_fields(void) {
+    /* Job with only id, everything else defaults */
+    JsonNode *node = parse_json("{\"jobs\": [{\"id\": \"j1\"}]}");
+    GatewayCronData *data = gateway_data_parse_cron(node);
+    ASSERT(data != NULL, "cron_partial: parsed");
+    ASSERT(g_strcmp0(data->jobs[0].id, "j1") == 0, "cron_partial: id");
+    ASSERT(data->jobs[0].name == NULL, "cron_partial: name NULL");
+    ASSERT(data->jobs[0].enabled == FALSE, "cron_partial: enabled default");
+    ASSERT(data->jobs[0].created_at_ms == 0, "cron_partial: created default");
+    gateway_cron_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_cron_null_input(void) {
+    GatewayCronData *data = gateway_data_parse_cron(NULL);
+    ASSERT(data == NULL, "cron_null: returns NULL");
+}
+
+static void test_cron_empty(void) {
+    JsonNode *node = parse_json("{\"jobs\": []}");
+    GatewayCronData *data = gateway_data_parse_cron(node);
+    ASSERT(data != NULL, "cron_empty: parsed");
+    ASSERT(data->n_jobs == 0, "cron_empty: 0 jobs");
+    gateway_cron_data_free(data);
+    json_node_unref(node);
+}
+
+/* ── Nodes negative ──────────────────────────────────────────────── */
+
+static void test_nodes_missing_array(void) {
+    JsonNode *node = parse_json("{\"ts\": 999}");
+    GatewayNodesData *data = gateway_data_parse_nodes(node);
+    ASSERT(data != NULL, "nodes_no_arr: parsed");
+    ASSERT(data->n_nodes == 0, "nodes_no_arr: 0 nodes");
+    ASSERT(data->ts == 999, "nodes_no_arr: ts preserved");
+    gateway_nodes_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_nodes_array_wrong_type(void) {
+    JsonNode *node = parse_json("{\"nodes\": \"nope\"}");
+    GatewayNodesData *data = gateway_data_parse_nodes(node);
+    ASSERT(data != NULL, "nodes_wrong_type: parsed");
+    ASSERT(data->n_nodes == 0, "nodes_wrong_type: 0 nodes");
+    gateway_nodes_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_nodes_partial_fields(void) {
+    /* Node with only nodeId */
+    JsonNode *node = parse_json(
+        "{\"nodes\": [{\"nodeId\": \"n1\"}]}");
+    GatewayNodesData *data = gateway_data_parse_nodes(node);
+    ASSERT(data != NULL, "nodes_partial: parsed");
+    ASSERT(g_strcmp0(data->nodes[0].node_id, "n1") == 0, "nodes_partial: id");
+    ASSERT(data->nodes[0].display_name == NULL, "nodes_partial: name NULL");
+    ASSERT(data->nodes[0].platform == NULL, "nodes_partial: platform NULL");
+    ASSERT(data->nodes[0].connected == FALSE, "nodes_partial: connected default");
+    ASSERT(data->nodes[0].paired == FALSE, "nodes_partial: paired default");
+    ASSERT(data->nodes[0].connected_at_ms == 0, "nodes_partial: connected_at default");
+    gateway_nodes_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_nodes_mixed_valid_invalid(void) {
+    const gchar *json =
+        "{\"nodes\": ["
+        "  {\"nodeId\": \"ok\", \"connected\": true},"
+        "  42,"
+        "  {\"nodeId\": \"fine\"}"
+        "]}";
+    JsonNode *node = parse_json(json);
+    GatewayNodesData *data = gateway_data_parse_nodes(node);
+    ASSERT(data != NULL, "nodes_mixed: parsed");
+    ASSERT(data->n_nodes == 3, "nodes_mixed: array len 3");
+    ASSERT(g_strcmp0(data->nodes[0].node_id, "ok") == 0, "nodes_mixed: [0] ok");
+    ASSERT(data->nodes[1].node_id == NULL, "nodes_mixed: [1] zeroed");
+    ASSERT(g_strcmp0(data->nodes[2].node_id, "fine") == 0, "nodes_mixed: [2] ok");
+    gateway_nodes_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_nodes_wrong_type_fields(void) {
+    /* connected is string, connectedAtMs is string */
+    JsonNode *node = parse_json(
+        "{\"nodes\": [{\"nodeId\": \"n1\", \"connected\": \"yes\", \"connectedAtMs\": \"bad\"}]}");
+    GatewayNodesData *data = gateway_data_parse_nodes(node);
+    ASSERT(data != NULL, "nodes_wrong_fields: parsed");
+    ASSERT(data->nodes[0].connected == FALSE, "nodes_wrong_fields: str → false");
+    ASSERT(data->nodes[0].connected_at_ms == 0, "nodes_wrong_fields: str → 0");
+    gateway_nodes_data_free(data);
+    json_node_unref(node);
+}
+
+static void test_nodes_null_input(void) {
+    GatewayNodesData *data = gateway_data_parse_nodes(NULL);
+    ASSERT(data == NULL, "nodes_null: returns NULL");
+}
+
+static void test_nodes_non_object_payload(void) {
+    JsonNode *node = parse_json("\"just a string\"");
+    GatewayNodesData *data = gateway_data_parse_nodes(node);
+    ASSERT(data == NULL, "nodes_str_payload: returns NULL");
+    json_node_unref(node);
+}
+
+/* ── Main ────────────────────────────────────────────────────────── */
+
+int main(void) {
+    /* Channels — happy path */
+    test_channels_parse_basic();
+    test_channels_parse_empty();
+    test_channels_parse_null();
+    /* Channels — negative */
+    test_channels_wrong_type_channel_order();
+    test_channels_labels_wrong_type();
+    test_channels_accounts_not_array();
+    test_channels_non_object_payload();
+
+    /* Skills — happy path */
+    test_skills_parse_basic();
+    test_skills_parse_empty();
+    /* Skills — negative */
+    test_skills_missing_array();
+    test_skills_array_wrong_type();
+    test_skills_mixed_valid_invalid();
+    test_skills_partial_fields();
+    test_skills_wrong_type_booleans();
+    test_skills_null_input();
+
+    /* Sessions — happy path */
+    test_sessions_parse_basic();
+    /* Sessions — negative */
+    test_sessions_missing_array();
+    test_sessions_array_wrong_type();
+    test_sessions_partial_item();
+    test_sessions_mixed_valid_invalid();
+    test_sessions_wrong_type_fields();
+    test_sessions_null_input();
+    test_sessions_empty();
+
+    /* Cron — happy path */
+    test_cron_parse_basic();
+    /* Cron — negative */
+    test_cron_missing_jobs();
+    test_cron_jobs_wrong_type();
+    test_cron_malformed_state();
+    test_cron_mixed_valid_invalid();
+    test_cron_partial_fields();
+    test_cron_null_input();
+    test_cron_empty();
+
+    /* Nodes — happy path */
+    test_nodes_parse_basic();
+    test_nodes_parse_empty();
+    /* Nodes — negative */
+    test_nodes_missing_array();
+    test_nodes_array_wrong_type();
+    test_nodes_partial_fields();
+    test_nodes_mixed_valid_invalid();
+    test_nodes_wrong_type_fields();
+    test_nodes_null_input();
+    test_nodes_non_object_payload();
+
+    g_print("gateway_data: %d/%d tests passed\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}

--- a/apps/linux/tests/test_gateway_rpc.c
+++ b/apps/linux/tests/test_gateway_rpc.c
@@ -1,0 +1,439 @@
+/*
+ * test_gateway_rpc.c
+ *
+ * Unit tests for the gateway RPC request/response layer (gateway_rpc.h).
+ * Covers response correlation, timeout, unmatched response, fail-all-pending,
+ * and response-member cleanup safety.
+ *
+ * Provides mock implementations of gateway_ws_get_state() and
+ * gateway_ws_send_text() so gateway_rpc.c can be tested in isolation.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "../src/gateway_rpc.h"
+#include "../src/gateway_ws.h"
+#include "../src/gateway_protocol.h"
+#include <json-glib/json-glib.h>
+#include <string.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define ASSERT(cond, msg) do { \
+    tests_run++; \
+    if (!(cond)) { \
+        g_printerr("FAIL [%s:%d]: %s\n", __FILE__, __LINE__, msg); \
+    } else { \
+        tests_passed++; \
+    } \
+} while(0)
+
+/* ── Mock gateway_ws ─────────────────────────────────────────────── */
+
+static GatewayWsState mock_ws_state = GATEWAY_WS_CONNECTED;
+static gchar *mock_last_sent_text = NULL;
+static gint mock_send_count = 0;
+
+GatewayWsState gateway_ws_get_state(void) {
+    return mock_ws_state;
+}
+
+gboolean gateway_ws_send_text(const gchar *text) {
+    if (mock_ws_state != GATEWAY_WS_CONNECTED) return FALSE;
+    g_free(mock_last_sent_text);
+    mock_last_sent_text = g_strdup(text);
+    mock_send_count++;
+    return TRUE;
+}
+
+static void mock_reset(void) {
+    mock_ws_state = GATEWAY_WS_CONNECTED;
+    g_free(mock_last_sent_text);
+    mock_last_sent_text = NULL;
+    mock_send_count = 0;
+}
+
+/* ── Callback tracking ───────────────────────────────────────────── */
+
+typedef struct {
+    gboolean called;
+    gboolean ok;
+    gchar *error_code;
+    gchar *error_msg;
+    gboolean has_payload;
+    gint call_count;
+} CallbackRecord;
+
+static void reset_record(CallbackRecord *r) {
+    r->called = FALSE;
+    r->ok = FALSE;
+    g_free(r->error_code);
+    r->error_code = NULL;
+    g_free(r->error_msg);
+    r->error_msg = NULL;
+    r->has_payload = FALSE;
+    r->call_count = 0;
+}
+
+static void test_callback(const GatewayRpcResponse *response, gpointer user_data) {
+    CallbackRecord *r = user_data;
+    r->called = TRUE;
+    r->ok = response->ok;
+    r->error_code = g_strdup(response->error_code);
+    r->error_msg = g_strdup(response->error_msg);
+    r->has_payload = (response->payload != NULL);
+    r->call_count++;
+}
+
+/* ── Helper: extract request ID from mock_last_sent_text ─────────── */
+
+static gchar* extract_request_id_from_sent(void) {
+    if (!mock_last_sent_text) return NULL;
+    JsonParser *parser = json_parser_new();
+    GError *error = NULL;
+    json_parser_load_from_data(parser, mock_last_sent_text, -1, &error);
+    if (error) {
+        g_error_free(error);
+        g_object_unref(parser);
+        return NULL;
+    }
+    JsonNode *root = json_parser_get_root(parser);
+    if (!root || !JSON_NODE_HOLDS_OBJECT(root)) {
+        g_object_unref(parser);
+        return NULL;
+    }
+    JsonObject *obj = json_node_get_object(root);
+    const gchar *id = json_object_get_string_member_with_default(obj, "id", NULL);
+    gchar *result = id ? g_strdup(id) : NULL;
+    g_object_unref(parser);
+    return result;
+}
+
+/* ── Helper: build a GatewayFrame for response delivery ──────────── */
+
+static GatewayFrame* make_success_frame(const gchar *id) {
+    GatewayFrame *f = g_new0(GatewayFrame, 1);
+    f->type = GATEWAY_FRAME_RES;
+    f->id = g_strdup(id);
+    f->error = NULL;
+    f->code = NULL;
+
+    /* Build a simple payload: {"result": "ok"} */
+    JsonBuilder *builder = json_builder_new();
+    json_builder_begin_object(builder);
+    json_builder_set_member_name(builder, "result");
+    json_builder_add_string_value(builder, "ok");
+    json_builder_end_object(builder);
+    f->payload = json_builder_get_root(builder);
+    g_object_unref(builder);
+
+    return f;
+}
+
+static GatewayFrame* make_error_frame(const gchar *id, const gchar *code, const gchar *msg) {
+    GatewayFrame *f = g_new0(GatewayFrame, 1);
+    f->type = GATEWAY_FRAME_RES;
+    f->id = g_strdup(id);
+    f->error = g_strdup(msg);
+    f->code = g_strdup(code);
+    f->payload = NULL;
+    return f;
+}
+
+static void free_test_frame(GatewayFrame *f) {
+    if (!f) return;
+    g_free(f->id);
+    g_free(f->method);
+    g_free(f->error);
+    g_free(f->code);
+    g_free(f->event_type);
+    if (f->payload) json_node_unref(f->payload);
+    g_free(f);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Test 1: Response correlation by request ID
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_response_correlation(void) {
+    mock_reset();
+    CallbackRecord r = {0};
+
+    gchar *req_id = gateway_rpc_request("test.method", NULL, 5000, test_callback, &r);
+    ASSERT(req_id != NULL, "correlation: request sent");
+    ASSERT(mock_send_count == 1, "correlation: one frame sent");
+
+    /* Extract the actual ID from the sent frame */
+    g_autofree gchar *sent_id = extract_request_id_from_sent();
+    ASSERT(sent_id != NULL, "correlation: sent frame has id");
+    ASSERT(g_strcmp0(req_id, sent_id) == 0, "correlation: returned id matches sent id");
+
+    /* Deliver matching response */
+    GatewayFrame *frame = make_success_frame(req_id);
+    gboolean consumed = gateway_rpc_handle_response(frame);
+    ASSERT(consumed == TRUE, "correlation: response consumed");
+    ASSERT(r.called == TRUE, "correlation: callback fired");
+    ASSERT(r.ok == TRUE, "correlation: response ok");
+    ASSERT(r.has_payload == TRUE, "correlation: has payload");
+
+    /* Delivering same ID again should not match */
+    CallbackRecord r2 = {0};
+    gboolean consumed2 = gateway_rpc_handle_response(frame);
+    ASSERT(consumed2 == FALSE, "correlation: re-delivery not consumed");
+
+    free_test_frame(frame);
+    reset_record(&r);
+    reset_record(&r2);
+    g_free(req_id);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Test 2: Unmatched response handling
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_unmatched_response(void) {
+    mock_reset();
+
+    /* Deliver response for unknown ID — no pending requests */
+    GatewayFrame *frame = make_success_frame("nonexistent-id-12345");
+    gboolean consumed = gateway_rpc_handle_response(frame);
+    ASSERT(consumed == FALSE, "unmatched: unknown id not consumed");
+    free_test_frame(frame);
+
+    /* NULL frame */
+    gboolean consumed_null = gateway_rpc_handle_response(NULL);
+    ASSERT(consumed_null == FALSE, "unmatched: null frame not consumed");
+
+    /* Wrong frame type */
+    GatewayFrame event_frame = {
+        .type = GATEWAY_FRAME_EVENT,
+        .id = "some-id",
+    };
+    gboolean consumed_event = gateway_rpc_handle_response(&event_frame);
+    ASSERT(consumed_event == FALSE, "unmatched: event frame not consumed");
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Test 3: Error response handling
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_error_response(void) {
+    mock_reset();
+    CallbackRecord r = {0};
+
+    gchar *req_id = gateway_rpc_request("test.error", NULL, 5000, test_callback, &r);
+    ASSERT(req_id != NULL, "error_resp: request sent");
+
+    GatewayFrame *frame = make_error_frame(req_id, "NOT_FOUND", "Resource not found");
+    gboolean consumed = gateway_rpc_handle_response(frame);
+    ASSERT(consumed == TRUE, "error_resp: consumed");
+    ASSERT(r.called == TRUE, "error_resp: callback fired");
+    ASSERT(r.ok == FALSE, "error_resp: not ok");
+    ASSERT(g_strcmp0(r.error_code, "NOT_FOUND") == 0, "error_resp: error_code");
+    ASSERT(g_strcmp0(r.error_msg, "Resource not found") == 0, "error_resp: error_msg");
+
+    free_test_frame(frame);
+    reset_record(&r);
+    g_free(req_id);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Test 4: Per-request timeout
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_request_timeout(void) {
+    mock_reset();
+    CallbackRecord r = {0};
+
+    /* Use a very short timeout (50ms) */
+    gchar *req_id = gateway_rpc_request("test.timeout", NULL, 50, test_callback, &r);
+    ASSERT(req_id != NULL, "timeout: request sent");
+    ASSERT(r.called == FALSE, "timeout: callback not yet fired");
+
+    /* Run GLib main loop briefly to let timeout fire */
+    GMainContext *ctx = g_main_context_default();
+    gint64 deadline = g_get_monotonic_time() + 300 * 1000; /* 300ms */
+    while (!r.called && g_get_monotonic_time() < deadline) {
+        g_main_context_iteration(ctx, FALSE);
+        g_usleep(1000);
+    }
+
+    ASSERT(r.called == TRUE, "timeout: callback fired after timeout");
+    ASSERT(r.ok == FALSE, "timeout: response not ok");
+    ASSERT(g_strcmp0(r.error_code, "TIMEOUT") == 0, "timeout: error_code is TIMEOUT");
+    ASSERT(r.error_msg != NULL, "timeout: has error message");
+
+    /* Request should be removed from registry */
+    GatewayFrame *frame = make_success_frame(req_id);
+    gboolean consumed = gateway_rpc_handle_response(frame);
+    ASSERT(consumed == FALSE, "timeout: late response not consumed");
+
+    free_test_frame(frame);
+    reset_record(&r);
+    g_free(req_id);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Test 5: Fail-all-pending on disconnect
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_fail_all_pending(void) {
+    mock_reset();
+    CallbackRecord r1 = {0}, r2 = {0}, r3 = {0};
+
+    gchar *id1 = gateway_rpc_request("test.a", NULL, 15000, test_callback, &r1);
+    gchar *id2 = gateway_rpc_request("test.b", NULL, 15000, test_callback, &r2);
+    gchar *id3 = gateway_rpc_request("test.c", NULL, 15000, test_callback, &r3);
+    ASSERT(id1 != NULL && id2 != NULL && id3 != NULL, "fail_all: 3 requests sent");
+
+    gateway_rpc_fail_all_pending("test disconnect");
+
+    ASSERT(r1.called == TRUE, "fail_all: r1 callback fired");
+    ASSERT(r1.ok == FALSE, "fail_all: r1 not ok");
+    ASSERT(g_strcmp0(r1.error_code, "CONNECTION_LOST") == 0, "fail_all: r1 CONNECTION_LOST");
+    ASSERT(r1.call_count == 1, "fail_all: r1 called exactly once");
+
+    ASSERT(r2.called == TRUE, "fail_all: r2 callback fired");
+    ASSERT(g_strcmp0(r2.error_code, "CONNECTION_LOST") == 0, "fail_all: r2 CONNECTION_LOST");
+    ASSERT(r2.call_count == 1, "fail_all: r2 called exactly once");
+
+    ASSERT(r3.called == TRUE, "fail_all: r3 callback fired");
+    ASSERT(g_strcmp0(r3.error_code, "CONNECTION_LOST") == 0, "fail_all: r3 CONNECTION_LOST");
+    ASSERT(r3.call_count == 1, "fail_all: r3 called exactly once");
+
+    /* Registry should be empty — delivering a response should fail */
+    GatewayFrame *frame = make_success_frame(id1);
+    gboolean consumed = gateway_rpc_handle_response(frame);
+    ASSERT(consumed == FALSE, "fail_all: registry empty after fail_all");
+    free_test_frame(frame);
+
+    /* Calling fail_all again with empty registry is a safe no-op */
+    gateway_rpc_fail_all_pending("second call");
+
+    reset_record(&r1);
+    reset_record(&r2);
+    reset_record(&r3);
+    g_free(id1);
+    g_free(id2);
+    g_free(id3);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Test 6: Request rejected when not connected
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_request_when_disconnected(void) {
+    mock_reset();
+    mock_ws_state = GATEWAY_WS_DISCONNECTED;
+    CallbackRecord r = {0};
+
+    gchar *req_id = gateway_rpc_request("test.dc", NULL, 5000, test_callback, &r);
+    ASSERT(req_id == NULL, "disconnected: request returns NULL");
+    ASSERT(r.called == FALSE, "disconnected: callback not fired");
+    ASSERT(mock_send_count == 0, "disconnected: nothing sent");
+
+    mock_reset();
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Test 7: Send-path safety — send fails but registry stays clean
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_send_returns_false(void) {
+    mock_reset();
+    CallbackRecord r = {0};
+
+    /*
+     * gateway_rpc_request checks is_ready first (returns TRUE since
+     * mock_ws_state == CONNECTED), but ws_send_rpc_frame internally
+     * calls gateway_ws_send_text which returns TRUE in our mock.
+     * We can't easily make the send fail mid-flight without more
+     * complex mocking. Instead, verify that NULL callback is rejected.
+     */
+    gchar *req_id = gateway_rpc_request("test.null_cb", NULL, 5000, NULL, NULL);
+    ASSERT(req_id == NULL, "send_safety: null callback rejected");
+
+    gchar *req_id2 = gateway_rpc_request(NULL, NULL, 5000, test_callback, &r);
+    ASSERT(req_id2 == NULL, "send_safety: null method rejected");
+
+    mock_reset();
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Test 8: Response member cleanup safety
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_response_cleanup(void) {
+    /* Test gateway_rpc_response_free_members with various states */
+    GatewayRpcResponse resp = {0};
+    gateway_rpc_response_free_members(&resp);
+    ASSERT(resp.payload == NULL, "cleanup: null payload safe");
+    ASSERT(resp.error_code == NULL, "cleanup: null error_code safe");
+
+    /* With populated members */
+    resp.payload = json_node_new(JSON_NODE_NULL);
+    resp.error_code = g_strdup("TEST");
+    resp.error_msg = g_strdup("test message");
+    gateway_rpc_response_free_members(&resp);
+    ASSERT(resp.payload == NULL, "cleanup: payload freed");
+    ASSERT(resp.error_code == NULL, "cleanup: error_code freed");
+    ASSERT(resp.error_msg == NULL, "cleanup: error_msg freed");
+
+    /* NULL response */
+    gateway_rpc_response_free_members(NULL);
+    tests_run++;
+    tests_passed++; /* If we got here, no crash */
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * Test 9: Multiple concurrent requests with interleaved responses
+ * ══════════════════════════════════════════════════════════════════ */
+
+static void test_interleaved_responses(void) {
+    mock_reset();
+    CallbackRecord ra = {0}, rb = {0};
+
+    gchar *id_a = gateway_rpc_request("test.a", NULL, 5000, test_callback, &ra);
+    gchar *id_b = gateway_rpc_request("test.b", NULL, 5000, test_callback, &rb);
+    ASSERT(id_a != NULL && id_b != NULL, "interleaved: both requests sent");
+
+    /* Deliver B first */
+    GatewayFrame *frame_b = make_success_frame(id_b);
+    gboolean consumed_b = gateway_rpc_handle_response(frame_b);
+    ASSERT(consumed_b == TRUE, "interleaved: B consumed");
+    ASSERT(rb.called == TRUE, "interleaved: B callback fired");
+    ASSERT(ra.called == FALSE, "interleaved: A callback not fired yet");
+
+    /* Deliver A second */
+    GatewayFrame *frame_a = make_success_frame(id_a);
+    gboolean consumed_a = gateway_rpc_handle_response(frame_a);
+    ASSERT(consumed_a == TRUE, "interleaved: A consumed");
+    ASSERT(ra.called == TRUE, "interleaved: A callback fired");
+
+    free_test_frame(frame_a);
+    free_test_frame(frame_b);
+    reset_record(&ra);
+    reset_record(&rb);
+    g_free(id_a);
+    g_free(id_b);
+}
+
+/* ── Main ────────────────────────────────────────────────────────── */
+
+int main(void) {
+    test_response_correlation();
+    test_unmatched_response();
+    test_error_response();
+    test_request_timeout();
+    test_fail_all_pending();
+    test_request_when_disconnected();
+    test_send_returns_false();
+    test_response_cleanup();
+    test_interleaved_responses();
+
+    g_free(mock_last_sent_text);
+
+    g_print("gateway_rpc: %d/%d tests passed\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}

--- a/apps/linux/tests/test_rpc_lifecycle.c
+++ b/apps/linux/tests/test_rpc_lifecycle.c
@@ -1,0 +1,541 @@
+/*
+ * test_rpc_lifecycle.c
+ *
+ * RPC-backed section lifecycle and WS↔RPC integration validation.
+ *
+ * Covers:
+ *  - Section callback behavior for: disconnected, error, timeout, reconnect
+ *  - TTL freshness gating correctness
+ *  - WS↔RPC integration: authenticated dispatch, unmatched response,
+ *    disconnect/shutdown cleanup, send-path safety
+ *
+ * Uses the same mock gateway_ws approach as test_gateway_rpc.c:
+ * provides stub implementations of gateway_ws_get_state() and
+ * gateway_ws_send_text() so gateway_rpc.c is tested in isolation.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "../src/gateway_rpc.h"
+#include "../src/gateway_ws.h"
+#include "../src/gateway_protocol.h"
+#include "../src/gateway_data.h"
+#include <json-glib/json-glib.h>
+#include <string.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define ASSERT(cond, msg) do { \
+    tests_run++; \
+    if (!(cond)) { \
+        g_printerr("FAIL [%s:%d]: %s\n", __FILE__, __LINE__, msg); \
+    } else { \
+        tests_passed++; \
+    } \
+} while(0)
+
+/* ── Mock gateway_ws ─────────────────────────────────────────────── */
+
+static GatewayWsState mock_ws_state = GATEWAY_WS_CONNECTED;
+static gchar *mock_last_sent_text = NULL;
+static gint mock_send_count = 0;
+
+GatewayWsState gateway_ws_get_state(void) {
+    return mock_ws_state;
+}
+
+gboolean gateway_ws_send_text(const gchar *text) {
+    if (mock_ws_state != GATEWAY_WS_CONNECTED) return FALSE;
+    g_free(mock_last_sent_text);
+    mock_last_sent_text = g_strdup(text);
+    mock_send_count++;
+    return TRUE;
+}
+
+static void mock_reset(void) {
+    mock_ws_state = GATEWAY_WS_CONNECTED;
+    g_free(mock_last_sent_text);
+    mock_last_sent_text = NULL;
+    mock_send_count = 0;
+}
+
+/* ── Callback tracking (simulates section callback behavior) ───── */
+
+typedef struct {
+    gboolean called;
+    gboolean ok;
+    gchar *error_code;
+    gchar *error_msg;
+    gboolean has_payload;
+    gint call_count;
+    /* Simulated section state */
+    gboolean fetch_in_flight;
+} SectionRecord;
+
+static void reset_section_record(SectionRecord *r) {
+    r->called = FALSE;
+    r->ok = FALSE;
+    g_free(r->error_code);
+    r->error_code = NULL;
+    g_free(r->error_msg);
+    r->error_msg = NULL;
+    r->has_payload = FALSE;
+    r->call_count = 0;
+    r->fetch_in_flight = FALSE;
+}
+
+static void section_callback(const GatewayRpcResponse *response, gpointer user_data) {
+    SectionRecord *r = user_data;
+    r->called = TRUE;
+    r->ok = response->ok;
+    r->error_code = g_strdup(response->error_code);
+    r->error_msg = g_strdup(response->error_msg);
+    r->has_payload = (response->payload != NULL);
+    r->call_count++;
+    r->fetch_in_flight = FALSE;
+}
+
+/* ── Helpers ─────────────────────────────────────────────────────── */
+
+static GatewayFrame* make_success_frame(const gchar *id, const gchar *payload_json) {
+    GatewayFrame *f = g_new0(GatewayFrame, 1);
+    f->type = GATEWAY_FRAME_RES;
+    f->id = g_strdup(id);
+    if (payload_json) {
+        JsonParser *p = json_parser_new();
+        json_parser_load_from_data(p, payload_json, -1, NULL);
+        f->payload = json_node_copy(json_parser_get_root(p));
+        g_object_unref(p);
+    }
+    return f;
+}
+
+static GatewayFrame* make_error_frame(const gchar *id, const gchar *code, const gchar *msg) {
+    GatewayFrame *f = g_new0(GatewayFrame, 1);
+    f->type = GATEWAY_FRAME_RES;
+    f->id = g_strdup(id);
+    f->error = g_strdup(msg);
+    f->code = g_strdup(code);
+    return f;
+}
+
+static void free_frame(GatewayFrame *f) {
+    if (!f) return;
+    g_free(f->id); g_free(f->method); g_free(f->error);
+    g_free(f->code); g_free(f->event_type);
+    if (f->payload) json_node_unref(f->payload);
+    g_free(f);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * SECTION LIFECYCLE TESTS
+ * ══════════════════════════════════════════════════════════════════ */
+
+/*
+ * Scenario 1: Disconnected state
+ * - Section attempts fetch while gateway is disconnected
+ * - gateway_rpc_request returns NULL, callback not fired
+ * - No request storm
+ */
+static void test_lifecycle_disconnected(void) {
+    mock_reset();
+    mock_ws_state = GATEWAY_WS_DISCONNECTED;
+    SectionRecord r = {0};
+
+    gchar *id = gateway_rpc_request("channels.status", NULL, 5000, section_callback, &r);
+    ASSERT(id == NULL, "lc_disconnected: request rejected");
+    ASSERT(r.called == FALSE, "lc_disconnected: callback not fired");
+    ASSERT(mock_send_count == 0, "lc_disconnected: nothing sent");
+
+    /* Repeated attempts also rejected cleanly */
+    gchar *id2 = gateway_rpc_request("skills.status", NULL, 5000, section_callback, &r);
+    ASSERT(id2 == NULL, "lc_disconnected: second request also rejected");
+    ASSERT(mock_send_count == 0, "lc_disconnected: still nothing sent");
+
+    reset_section_record(&r);
+    mock_reset();
+}
+
+/*
+ * Scenario 2: RPC error response
+ * - Section sends request, gets error response
+ * - in-flight flag clears, error_code/error_msg available
+ * - Subsequent retry still works
+ */
+static void test_lifecycle_error_response(void) {
+    mock_reset();
+    SectionRecord r = {0};
+    r.fetch_in_flight = TRUE;
+
+    gchar *id = gateway_rpc_request("sessions.list", NULL, 5000, section_callback, &r);
+    ASSERT(id != NULL, "lc_error: request sent");
+
+    GatewayFrame *frame = make_error_frame(id, "INTERNAL_ERROR", "Something broke");
+    gboolean consumed = gateway_rpc_handle_response(frame);
+    ASSERT(consumed == TRUE, "lc_error: consumed");
+    ASSERT(r.called == TRUE, "lc_error: callback fired");
+    ASSERT(r.ok == FALSE, "lc_error: not ok");
+    ASSERT(g_strcmp0(r.error_code, "INTERNAL_ERROR") == 0, "lc_error: error_code");
+    ASSERT(r.fetch_in_flight == FALSE, "lc_error: in-flight cleared");
+
+    /* Retry after error — should work */
+    reset_section_record(&r);
+    r.fetch_in_flight = TRUE;
+    gchar *id2 = gateway_rpc_request("sessions.list", NULL, 5000, section_callback, &r);
+    ASSERT(id2 != NULL, "lc_error: retry request sent");
+
+    GatewayFrame *frame2 = make_success_frame(id2, "{\"ts\":1,\"sessions\":[]}");
+    consumed = gateway_rpc_handle_response(frame2);
+    ASSERT(consumed == TRUE, "lc_error: retry consumed");
+    ASSERT(r.ok == TRUE, "lc_error: retry ok");
+    ASSERT(r.fetch_in_flight == FALSE, "lc_error: retry in-flight cleared");
+
+    free_frame(frame);
+    free_frame(frame2);
+    reset_section_record(&r);
+    g_free(id);
+    g_free(id2);
+}
+
+/*
+ * Scenario 3: Timeout path
+ * - Section sends request with short timeout
+ * - Timeout fires, callback receives TIMEOUT error
+ * - Section leaves loading state cleanly
+ * - Retry after timeout works
+ */
+static void test_lifecycle_timeout_recovery(void) {
+    mock_reset();
+    SectionRecord r = {0};
+    r.fetch_in_flight = TRUE;
+
+    gchar *id = gateway_rpc_request("cron.list", NULL, 50, section_callback, &r);
+    ASSERT(id != NULL, "lc_timeout: request sent");
+    ASSERT(r.fetch_in_flight == TRUE, "lc_timeout: in-flight set");
+
+    /* Run main loop to let timeout fire */
+    GMainContext *ctx = g_main_context_default();
+    gint64 deadline = g_get_monotonic_time() + 300 * 1000;
+    while (!r.called && g_get_monotonic_time() < deadline) {
+        g_main_context_iteration(ctx, FALSE);
+        g_usleep(1000);
+    }
+
+    ASSERT(r.called == TRUE, "lc_timeout: callback fired");
+    ASSERT(r.ok == FALSE, "lc_timeout: not ok");
+    ASSERT(g_strcmp0(r.error_code, "TIMEOUT") == 0, "lc_timeout: TIMEOUT error");
+    ASSERT(r.fetch_in_flight == FALSE, "lc_timeout: in-flight cleared");
+
+    /* Retry after timeout */
+    reset_section_record(&r);
+    r.fetch_in_flight = TRUE;
+    gchar *id2 = gateway_rpc_request("cron.list", NULL, 5000, section_callback, &r);
+    ASSERT(id2 != NULL, "lc_timeout: retry sent");
+
+    GatewayFrame *frame = make_success_frame(id2, "{\"jobs\":[],\"total\":0}");
+    gboolean consumed = gateway_rpc_handle_response(frame);
+    ASSERT(consumed == TRUE, "lc_timeout: retry consumed");
+    ASSERT(r.ok == TRUE, "lc_timeout: retry ok");
+    ASSERT(r.fetch_in_flight == FALSE, "lc_timeout: retry in-flight cleared");
+
+    free_frame(frame);
+    reset_section_record(&r);
+    g_free(id);
+    g_free(id2);
+}
+
+/*
+ * Scenario 4: Reconnect after failure
+ * - Request pending, disconnect occurs (fail_all_pending)
+ * - All sections get CONNECTION_LOST
+ * - After reconnect, fresh requests succeed
+ */
+static void test_lifecycle_reconnect_after_failure(void) {
+    mock_reset();
+    SectionRecord ch = {0}, sk = {0}, sess = {0};
+    ch.fetch_in_flight = TRUE;
+    sk.fetch_in_flight = TRUE;
+    sess.fetch_in_flight = TRUE;
+
+    gchar *id1 = gateway_rpc_request("channels.status", NULL, 15000, section_callback, &ch);
+    gchar *id2 = gateway_rpc_request("skills.status", NULL, 15000, section_callback, &sk);
+    gchar *id3 = gateway_rpc_request("sessions.list", NULL, 15000, section_callback, &sess);
+    ASSERT(id1 && id2 && id3, "lc_reconnect: 3 requests sent");
+
+    /* Simulate disconnect */
+    mock_ws_state = GATEWAY_WS_DISCONNECTED;
+    gateway_rpc_fail_all_pending("connection dropped");
+
+    ASSERT(ch.called == TRUE, "lc_reconnect: ch callback fired");
+    ASSERT(ch.ok == FALSE, "lc_reconnect: ch not ok");
+    ASSERT(g_strcmp0(ch.error_code, "CONNECTION_LOST") == 0, "lc_reconnect: ch CONNECTION_LOST");
+    ASSERT(ch.fetch_in_flight == FALSE, "lc_reconnect: ch in-flight cleared");
+
+    ASSERT(sk.called == TRUE, "lc_reconnect: sk callback fired");
+    ASSERT(sk.fetch_in_flight == FALSE, "lc_reconnect: sk in-flight cleared");
+
+    ASSERT(sess.called == TRUE, "lc_reconnect: sess callback fired");
+    ASSERT(sess.fetch_in_flight == FALSE, "lc_reconnect: sess in-flight cleared");
+
+    /* Simulate reconnect */
+    mock_ws_state = GATEWAY_WS_CONNECTED;
+    reset_section_record(&ch);
+    ch.fetch_in_flight = TRUE;
+
+    gchar *id4 = gateway_rpc_request("channels.status", NULL, 5000, section_callback, &ch);
+    ASSERT(id4 != NULL, "lc_reconnect: post-reconnect request sent");
+
+    GatewayFrame *frame = make_success_frame(id4,
+        "{\"ts\":1,\"channelOrder\":[],\"channels\":{}}");
+    gboolean consumed = gateway_rpc_handle_response(frame);
+    ASSERT(consumed == TRUE, "lc_reconnect: post-reconnect consumed");
+    ASSERT(ch.ok == TRUE, "lc_reconnect: post-reconnect ok");
+    ASSERT(ch.fetch_in_flight == FALSE, "lc_reconnect: post-reconnect in-flight cleared");
+
+    free_frame(frame);
+    reset_section_record(&ch);
+    reset_section_record(&sk);
+    reset_section_record(&sess);
+    g_free(id1); g_free(id2); g_free(id3); g_free(id4);
+}
+
+/*
+ * Scenario 5: Successful response feeds into data parser correctly
+ * - Channels section gets a valid channels.status response
+ * - Parser produces correct struct
+ * - Validates the full RPC → adapter pipeline
+ */
+static void test_lifecycle_channels_full_pipeline(void) {
+    mock_reset();
+    SectionRecord r = {0};
+
+    gchar *id = gateway_rpc_request("channels.status", NULL, 5000, section_callback, &r);
+    ASSERT(id != NULL, "lc_pipeline_ch: request sent");
+
+    const gchar *payload =
+        "{\"ts\":1700000000000,\"channelOrder\":[\"telegram\"],"
+        "\"channelLabels\":{\"telegram\":\"Telegram\"},"
+        "\"channels\":{\"telegram\":{\"connected\":true}},"
+        "\"channelAccounts\":{\"telegram\":[{},{}]}}";
+
+    GatewayFrame *frame = make_success_frame(id, payload);
+    gateway_rpc_handle_response(frame);
+    ASSERT(r.ok == TRUE, "lc_pipeline_ch: ok");
+    ASSERT(r.has_payload == TRUE, "lc_pipeline_ch: has payload");
+
+    /* Now parse the payload as the section callback would */
+    /* Re-create the frame to get the payload for parsing */
+    GatewayFrame *frame2 = make_success_frame(id, payload);
+    GatewayChannelsData *data = gateway_data_parse_channels(frame2->payload);
+    ASSERT(data != NULL, "lc_pipeline_ch: data parsed");
+    ASSERT(data->n_channels == 1, "lc_pipeline_ch: 1 channel");
+    ASSERT(g_strcmp0(data->channels[0].channel_id, "telegram") == 0, "lc_pipeline_ch: telegram");
+    ASSERT(data->channels[0].connected == TRUE, "lc_pipeline_ch: connected");
+    ASSERT(data->channels[0].account_count == 2, "lc_pipeline_ch: 2 accounts");
+
+    gateway_channels_data_free(data);
+    free_frame(frame);
+    free_frame(frame2);
+    reset_section_record(&r);
+    g_free(id);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+ * WS↔RPC INTEGRATION TESTS
+ * ══════════════════════════════════════════════════════════════════ */
+
+/*
+ * Test: Authenticated response dispatch
+ * - Post-auth GATEWAY_FRAME_RES reaches RPC layer via handle_response
+ * - Correct callback fires
+ */
+static void test_ws_rpc_authenticated_dispatch(void) {
+    mock_reset();
+    SectionRecord r = {0};
+
+    gchar *id = gateway_rpc_request("node.list", NULL, 5000, section_callback, &r);
+    ASSERT(id != NULL, "ws_dispatch: request sent");
+
+    GatewayFrame *frame = make_success_frame(id, "{\"ts\":1,\"nodes\":[]}");
+    gboolean consumed = gateway_rpc_handle_response(frame);
+    ASSERT(consumed == TRUE, "ws_dispatch: consumed by RPC layer");
+    ASSERT(r.called == TRUE, "ws_dispatch: callback fired");
+    ASSERT(r.ok == TRUE, "ws_dispatch: ok");
+
+    free_frame(frame);
+    reset_section_record(&r);
+    g_free(id);
+}
+
+/*
+ * Test: Unmatched response safety
+ * - Response for unknown ID is safely ignored
+ * - Response with wrong frame type is ignored
+ * - NULL frame is handled
+ */
+static void test_ws_rpc_unmatched_safety(void) {
+    mock_reset();
+
+    GatewayFrame *unknown = make_success_frame("nonexistent-uuid", "{}");
+    gboolean c1 = gateway_rpc_handle_response(unknown);
+    ASSERT(c1 == FALSE, "ws_unmatched: unknown id safe");
+    free_frame(unknown);
+
+    gboolean c2 = gateway_rpc_handle_response(NULL);
+    ASSERT(c2 == FALSE, "ws_unmatched: null frame safe");
+
+    GatewayFrame event = { .type = GATEWAY_FRAME_EVENT, .id = "some-id" };
+    gboolean c3 = gateway_rpc_handle_response(&event);
+    ASSERT(c3 == FALSE, "ws_unmatched: event frame rejected");
+
+    GatewayFrame req = { .type = GATEWAY_FRAME_REQ, .id = "some-id" };
+    gboolean c4 = gateway_rpc_handle_response(&req);
+    ASSERT(c4 == FALSE, "ws_unmatched: req frame rejected");
+}
+
+/*
+ * Test: Disconnect cleanup hooks
+ * - Multiple pending requests
+ * - fail_all_pending (simulating ws_on_closed / disconnect / shutdown / tick-miss)
+ * - All callbacks fire exactly once with CONNECTION_LOST
+ * - Registry is empty afterward
+ * - Second fail_all_pending is safe no-op
+ */
+static void test_ws_rpc_disconnect_cleanup(void) {
+    mock_reset();
+    SectionRecord r1 = {0}, r2 = {0};
+
+    gchar *id1 = gateway_rpc_request("channels.status", NULL, 15000, section_callback, &r1);
+    gchar *id2 = gateway_rpc_request("node.list", NULL, 15000, section_callback, &r2);
+    ASSERT(id1 && id2, "ws_cleanup: 2 requests");
+
+    /* Simulate ws_on_closed path */
+    gateway_rpc_fail_all_pending("ws_on_closed");
+    ASSERT(r1.called && r1.call_count == 1, "ws_cleanup: r1 once");
+    ASSERT(r2.called && r2.call_count == 1, "ws_cleanup: r2 once");
+    ASSERT(g_strcmp0(r1.error_code, "CONNECTION_LOST") == 0, "ws_cleanup: r1 code");
+    ASSERT(g_strcmp0(r2.error_code, "CONNECTION_LOST") == 0, "ws_cleanup: r2 code");
+
+    /* Simulate tick-miss reconnect path: second fail_all is no-op */
+    gateway_rpc_fail_all_pending("tick watchdog");
+    ASSERT(r1.call_count == 1, "ws_cleanup: r1 still once after second fail");
+    ASSERT(r2.call_count == 1, "ws_cleanup: r2 still once after second fail");
+
+    /* Registry empty: response delivery fails */
+    GatewayFrame *late = make_success_frame(id1, "{}");
+    gboolean consumed = gateway_rpc_handle_response(late);
+    ASSERT(consumed == FALSE, "ws_cleanup: late delivery rejected");
+
+    free_frame(late);
+    reset_section_record(&r1);
+    reset_section_record(&r2);
+    g_free(id1);
+    g_free(id2);
+}
+
+/*
+ * Test: Send-path safety when not connected
+ * - gateway_ws_send_text returns FALSE when disconnected
+ * - gateway_rpc_request returns NULL (pre-check)
+ * - No registry garbage left
+ */
+static void test_ws_rpc_send_path_safety(void) {
+    mock_reset();
+    mock_ws_state = GATEWAY_WS_DISCONNECTED;
+    SectionRecord r = {0};
+
+    gchar *id = gateway_rpc_request("skills.status", NULL, 5000, section_callback, &r);
+    ASSERT(id == NULL, "ws_send_safety: rejected when disconnected");
+    ASSERT(r.called == FALSE, "ws_send_safety: no callback");
+    ASSERT(mock_send_count == 0, "ws_send_safety: nothing sent");
+
+    /* Transition to various non-connected states */
+    GatewayWsState non_ready_states[] = {
+        GATEWAY_WS_CONNECTING,
+        GATEWAY_WS_CHALLENGE_WAIT,
+        GATEWAY_WS_AUTHENTICATING,
+        GATEWAY_WS_AUTH_FAILED,
+        GATEWAY_WS_ERROR
+    };
+    for (int i = 0; i < 5; i++) {
+        mock_ws_state = non_ready_states[i];
+        gchar *id2 = gateway_rpc_request("test.method", NULL, 5000, section_callback, &r);
+        ASSERT(id2 == NULL, "ws_send_safety: rejected in non-ready state");
+    }
+
+    /* Verify is_ready only returns TRUE for CONNECTED */
+    mock_ws_state = GATEWAY_WS_CONNECTED;
+    ASSERT(gateway_rpc_is_ready() == TRUE, "ws_send_safety: ready when connected");
+    mock_ws_state = GATEWAY_WS_DISCONNECTED;
+    ASSERT(gateway_rpc_is_ready() == FALSE, "ws_send_safety: not ready when disconnected");
+
+    reset_section_record(&r);
+    mock_reset();
+}
+
+/*
+ * Test: Sent frame structure validation
+ * - Verify the JSON sent over WS matches the gateway protocol
+ */
+static void test_ws_rpc_frame_structure(void) {
+    mock_reset();
+    SectionRecord r = {0};
+
+    gchar *id = gateway_rpc_request("channels.status", NULL, 5000, section_callback, &r);
+    ASSERT(id != NULL, "ws_frame: request sent");
+    ASSERT(mock_last_sent_text != NULL, "ws_frame: text captured");
+
+    /* Parse and validate the sent frame */
+    JsonParser *parser = json_parser_new();
+    json_parser_load_from_data(parser, mock_last_sent_text, -1, NULL);
+    JsonNode *root = json_parser_get_root(parser);
+    ASSERT(root != NULL && JSON_NODE_HOLDS_OBJECT(root), "ws_frame: valid JSON object");
+
+    JsonObject *obj = json_node_get_object(root);
+    const gchar *type = json_object_get_string_member_with_default(obj, "type", NULL);
+    ASSERT(g_strcmp0(type, "req") == 0, "ws_frame: type is req");
+
+    const gchar *frame_id = json_object_get_string_member_with_default(obj, "id", NULL);
+    ASSERT(frame_id != NULL, "ws_frame: has id");
+    ASSERT(g_strcmp0(frame_id, id) == 0, "ws_frame: id matches returned id");
+
+    const gchar *method = json_object_get_string_member_with_default(obj, "method", NULL);
+    ASSERT(g_strcmp0(method, "channels.status") == 0, "ws_frame: method correct");
+
+    ASSERT(json_object_has_member(obj, "params"), "ws_frame: has params");
+    JsonNode *params_node = json_object_get_member(obj, "params");
+    ASSERT(JSON_NODE_HOLDS_OBJECT(params_node), "ws_frame: params is object");
+
+    g_object_unref(parser);
+
+    /* Clean up pending request */
+    GatewayFrame *frame = make_success_frame(id, "{}");
+    gateway_rpc_handle_response(frame);
+    free_frame(frame);
+    reset_section_record(&r);
+    g_free(id);
+}
+
+/* ── Main ────────────────────────────────────────────────────────── */
+
+int main(void) {
+    /* Section lifecycle */
+    test_lifecycle_disconnected();
+    test_lifecycle_error_response();
+    test_lifecycle_timeout_recovery();
+    test_lifecycle_reconnect_after_failure();
+    test_lifecycle_channels_full_pipeline();
+
+    /* WS↔RPC integration */
+    test_ws_rpc_authenticated_dispatch();
+    test_ws_rpc_unmatched_safety();
+    test_ws_rpc_disconnect_cleanup();
+    test_ws_rpc_send_path_safety();
+    test_ws_rpc_frame_structure();
+
+    g_free(mock_last_sent_text);
+
+    g_print("rpc_lifecycle: %d/%d tests passed\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}


### PR DESCRIPTION
Implement a reusable gateway RPC request/response layer for the Linux companion app and wire it into the authenticated WebSocket transport. Add a GTK-free gateway data adapter layer for channels, skills, sessions, cron jobs, and remote nodes. Expand the Linux app with native Channels and Skills sections, upgrade Instances with remote nodes, and replace Sessions and Cron stubs with read-only RPC-backed views while preserving dashboard handoff.

Refine refresh behavior by tracking the active section and applying per-section TTL freshness gating so hidden RPC-backed sections are not polled continuously. Free section caches on window destroy and document the Ubuntu GNOME AppIndicator host-behavior contract in the tray helper.

Add focused automated validation for gateway data parsing, RPC request correlation and failure handling, and RPC-backed lifecycle behavior.

Changes:
- add gateway_rpc request/response infrastructure
- add gateway_data protocol-to-struct adapter layer
- add Channels and Skills Linux sections
- add remote Instances data via node.list
- replace Sessions and Cron stubs with RPC-backed read-only views
- add active-section TTL refresh gating
- add cache cleanup on window destroy
- document GNOME tray host behavior
- add test_gateway_data, test_gateway_rpc, and test_rpc_lifecycle
- wire new tests into Meson