### PR TITLE
fix(linux): harden gateway/systemd/tray integration and validate hello-ok/config paths (#52)

### DIFF
--- a/apps/linux/src/gateway_client.c
+++ b/apps/linux/src/gateway_client.c
@@ -329,6 +329,9 @@ void gateway_client_refresh(void) {
 
     if (equivalent) {
         if (new_config->valid) {
+            /* F1: Preserve/update metadata fields that matter operationally */
+            g_free(current_config->config_path);
+            current_config->config_path = g_strdup(new_config->config_path);
             /* Unchanged valid config — lightweight health refresh */
             gateway_config_free(new_config);
             do_health_check();

--- a/apps/linux/src/gateway_config.c
+++ b/apps/linux/src/gateway_config.c
@@ -25,6 +25,15 @@
 #include <json-glib/json-glib.h>
 #include <string.h>
 
+/* E10: Helper to securely clear sensitive strings before freeing */
+static void secure_clear_free(gchar *s) {
+    if (s) {
+        volatile gchar *p = s;
+        while (*p) *p++ = '\0';
+    }
+    g_free(s);
+}
+
 static gchar* resolve_config_path(const GatewayConfigContext *ctx) {
     const gchar *override = g_getenv("OPENCLAW_CONFIG_PATH");
     if (override && override[0] != '\0') {
@@ -57,9 +66,9 @@ static gchar* resolve_config_path(const GatewayConfigContext *ctx) {
     }
     g_free(primary);
 
-    /* Legacy fallback candidates */
-    static const gchar *legacy_dirs[] = { ".clawdbot", ".moldbot", NULL };
-    static const gchar *legacy_names[] = { "openclaw.json", "clawdbot.json", "moldbot.json", NULL };
+    /* E7: Correct legacy moltbot fallback names */
+    static const gchar *legacy_dirs[] = { ".clawdbot", ".moltbot", NULL };
+    static const gchar *legacy_names[] = { "openclaw.json", "clawdbot.json", "moltbot.json", NULL };
 
     for (gint d = 0; legacy_dirs[d]; d++) {
         for (gint n = 0; legacy_names[n]; n++) {
@@ -73,6 +82,20 @@ static gchar* resolve_config_path(const GatewayConfigContext *ctx) {
 
     /* Default (may not exist yet) */
     return g_build_filename(home, ".openclaw", "openclaw.json", NULL);
+}
+
+/* E6: Validate port member is numeric */
+static gboolean is_valid_port_member(JsonObject *gateway_obj) {
+    if (!gateway_obj || !json_object_has_member(gateway_obj, "port")) {
+        return TRUE; /* Not present is OK - will use default */
+    }
+    JsonNode *port_node = json_object_get_member(gateway_obj, "port");
+    /* Accept int, uint, or int64; reject non-numeric */
+    GType node_type = json_node_get_value_type(port_node);
+    if (node_type != G_TYPE_INT64 && node_type != G_TYPE_INT && node_type != G_TYPE_UINT) {
+        return FALSE;
+    }
+    return TRUE;
 }
 
 static gint resolve_port(JsonObject *gateway_obj) {
@@ -283,9 +306,32 @@ GatewayConfig* gateway_config_load(const GatewayConfigContext *ctx) {
     }
 
     JsonObject *root_obj = json_node_get_object(root);
+
+    /* E1: Reject malformed-present gateway node (must be object if present) */
+    if (json_object_has_member(root_obj, "gateway")) {
+        JsonNode *gw_node = json_object_get_member(root_obj, "gateway");
+        if (!JSON_NODE_HOLDS_OBJECT(gw_node)) {
+            config->valid = FALSE;
+            config->error_code = GW_CFG_ERR_GATEWAY_NOT_OBJECT;
+            config->error = g_strdup("gateway exists but is not a JSON object");
+            return config;
+        }
+    }
+
     JsonObject *gateway_obj = NULL;
     if (json_object_has_member(root_obj, "gateway")) {
         gateway_obj = json_object_get_object_member(root_obj, "gateway");
+    }
+
+    /* E2: Reject malformed-present gateway.mode (must be string if present) */
+    if (gateway_obj && json_object_has_member(gateway_obj, "mode")) {
+        JsonNode *mode_node = json_object_get_member(gateway_obj, "mode");
+        if (!JSON_NODE_HOLDS_VALUE(mode_node) || json_node_get_value_type(mode_node) != G_TYPE_STRING) {
+            config->valid = FALSE;
+            config->error_code = GW_CFG_ERR_MODE_INVALID;
+            config->error = g_strdup("gateway.mode exists but is not a string");
+            return config;
+        }
     }
 
     /* Resolve mode */
@@ -306,18 +352,154 @@ GatewayConfig* gateway_config_load(const GatewayConfigContext *ctx) {
         return config;
     }
 
+    /* E6: Reject malformed-present port */
+    if (!is_valid_port_member(gateway_obj)) {
+        config->valid = FALSE;
+        config->error_code = GW_CFG_ERR_PORT_INVALID;
+        config->error = g_strdup("gateway.port exists but is not a valid integer");
+        return config;
+    }
+
     /* Resolve port */
     config->port = resolve_port(gateway_obj);
 
-    /* Resolve host (local mode always binds to loopback for MVP) */
+    /* L6: Resolve TLS enablement from gateway.tls or gateway.security.tls */
+    if (gateway_obj) {
+        if (json_object_has_member(gateway_obj, "tls")) {
+            JsonNode *tls_node = json_object_get_member(gateway_obj, "tls");
+            if (JSON_NODE_HOLDS_VALUE(tls_node)) {
+                GType tls_type = json_node_get_value_type(tls_node);
+                if (tls_type == G_TYPE_BOOLEAN) {
+                    config->tls_enabled = json_node_get_boolean(tls_node);
+                } else if (tls_type == G_TYPE_STRING) {
+                    const gchar *tls_str = json_node_get_string(tls_node);
+                    config->tls_enabled = (tls_str && g_strcmp0(tls_str, "true") == 0);
+                }
+            } else if (JSON_NODE_HOLDS_OBJECT(tls_node)) {
+                /* gateway.tls = { enabled: true } */
+                JsonObject *tls_obj = json_node_get_object(tls_node);
+                if (json_object_has_member(tls_obj, "enabled")) {
+                    JsonNode *enabled_node = json_object_get_member(tls_obj, "enabled");
+                    if (JSON_NODE_HOLDS_VALUE(enabled_node)) {
+                        GType enabled_type = json_node_get_value_type(enabled_node);
+                        if (enabled_type == G_TYPE_BOOLEAN) {
+                            config->tls_enabled = json_node_get_boolean(enabled_node);
+                        } else if (enabled_type == G_TYPE_STRING) {
+                            const gchar *enabled_str = json_node_get_string(enabled_node);
+                            config->tls_enabled = (enabled_str && g_strcmp0(enabled_str, "true") == 0);
+                        }
+                    }
+                }
+            }
+        }
+        /* Also check gateway.security.tls */
+        if (!config->tls_enabled && json_object_has_member(gateway_obj, "security")) {
+            JsonNode *sec_node = json_object_get_member(gateway_obj, "security");
+            if (JSON_NODE_HOLDS_OBJECT(sec_node)) {
+                JsonObject *sec_obj = json_node_get_object(sec_node);
+                if (json_object_has_member(sec_obj, "tls")) {
+                    JsonNode *tls_node = json_object_get_member(sec_obj, "tls");
+                    if (JSON_NODE_HOLDS_VALUE(tls_node)) {
+                        GType tls_type = json_node_get_value_type(tls_node);
+                        if (tls_type == G_TYPE_BOOLEAN) {
+                            config->tls_enabled = json_node_get_boolean(tls_node);
+                        } else if (tls_type == G_TYPE_STRING) {
+                            const gchar *tls_str = json_node_get_string(tls_node);
+                            config->tls_enabled = (tls_str && g_strcmp0(tls_str, "true") == 0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /* L6: Resolve host from config, not always loopback */
     g_free(config->host);
-    config->host = g_strdup(GATEWAY_DEFAULT_HOST);
+    config->host = NULL;
+    if (gateway_obj && json_object_has_member(gateway_obj, "host")) {
+        JsonNode *host_node = json_object_get_member(gateway_obj, "host");
+        if (JSON_NODE_HOLDS_VALUE(host_node) && json_node_get_value_type(host_node) == G_TYPE_STRING) {
+            const gchar *host_str = json_node_get_string(host_node);
+            if (host_str && host_str[0] != '\0') {
+                config->host = g_strdup(host_str);
+            }
+        }
+    }
+    /* Fallback: check gateway.bind as alternative host source */
+    if (!config->host && gateway_obj && json_object_has_member(gateway_obj, "bind")) {
+        JsonNode *bind_node = json_object_get_member(gateway_obj, "bind");
+        if (JSON_NODE_HOLDS_VALUE(bind_node) && json_node_get_value_type(bind_node) == G_TYPE_STRING) {
+            const gchar *bind_str = json_node_get_string(bind_node);
+            /* Reject wildcards and unspecified addresses - they are not valid client endpoints */
+            gboolean is_wildcard = (g_strcmp0(bind_str, "0.0.0.0") == 0 ||
+                                    g_strcmp0(bind_str, "::") == 0 ||
+                                    g_strcmp0(bind_str, "::0") == 0);
+            if (bind_str && bind_str[0] != '\0' && !is_wildcard) {
+                config->host = g_strdup(bind_str);
+            }
+        }
+    }
+    /* Final fallback to default loopback */
+    if (!config->host) {
+        config->host = g_strdup(GATEWAY_DEFAULT_HOST);
+    }
+
+    /* E3: Reject malformed-present gateway.auth (must be object if present) */
+    if (gateway_obj && json_object_has_member(gateway_obj, "auth")) {
+        JsonNode *auth_node = json_object_get_member(gateway_obj, "auth");
+        if (!JSON_NODE_HOLDS_OBJECT(auth_node)) {
+            config->valid = FALSE;
+            config->error_code = GW_CFG_ERR_AUTH_NOT_OBJECT;
+            config->error = g_strdup("gateway.auth exists but is not a JSON object");
+            return config;
+        }
+    }
 
     /* Resolve auth from gateway.auth.* + env overrides */
     JsonObject *auth_obj = NULL;
     if (gateway_obj && json_object_has_member(gateway_obj, "auth")) {
         auth_obj = json_object_get_object_member(gateway_obj, "auth");
     }
+    /* E4: Reject malformed-present gateway.auth.mode (must be string if present) */
+    if (auth_obj && json_object_has_member(auth_obj, "mode")) {
+        JsonNode *mode_node = json_object_get_member(auth_obj, "mode");
+        if (!JSON_NODE_HOLDS_VALUE(mode_node) || json_node_get_value_type(mode_node) != G_TYPE_STRING) {
+            config->valid = FALSE;
+            config->error_code = GW_CFG_ERR_AUTH_MODE_INVALID;
+            config->error = g_strdup("gateway.auth.mode exists but is not a string");
+            return config;
+        }
+    }
+
+    /* E5: Reject ambiguous auth when both token and password present with no explicit mode */
+    if (auth_obj) {
+        gboolean has_token = FALSE;
+        gboolean has_password = FALSE;
+        gboolean has_explicit_mode = json_object_has_member(auth_obj, "mode") &&
+            JSON_NODE_HOLDS_VALUE(json_object_get_member(auth_obj, "mode")) &&
+            json_node_get_value_type(json_object_get_member(auth_obj, "mode")) == G_TYPE_STRING;
+
+        if (json_object_has_member(auth_obj, "token")) {
+            JsonNode *tok_node = json_object_get_member(auth_obj, "token");
+            if (JSON_NODE_HOLDS_OBJECT(tok_node) || json_node_get_value_type(tok_node) == G_TYPE_STRING) {
+                has_token = TRUE;
+            }
+        }
+        if (json_object_has_member(auth_obj, "password")) {
+            JsonNode *pw_node = json_object_get_member(auth_obj, "password");
+            if (JSON_NODE_HOLDS_OBJECT(pw_node) || json_node_get_value_type(pw_node) == G_TYPE_STRING) {
+                has_password = TRUE;
+            }
+        }
+
+        if (has_token && has_password && !has_explicit_mode) {
+            config->valid = FALSE;
+            config->error_code = GW_CFG_ERR_AUTH_AMBIGUOUS;
+            config->error = g_strdup("Both token and password are configured but auth mode is not explicitly set. Set gateway.auth.mode to 'token' or 'password'");
+            return config;
+        }
+    }
+
     resolve_auth(auth_obj, config);
     if (!validate_auth(config)) return config;
 
@@ -346,8 +528,9 @@ void gateway_config_free(GatewayConfig *config) {
     g_free(config->mode);
     g_free(config->host);
     g_free(config->auth_mode);
-    g_free(config->token);
-    g_free(config->password);
+    /* E10: Zero sensitive credentials before free */
+    secure_clear_free(config->token);
+    secure_clear_free(config->password);
     g_free(config->control_ui_base_path);
     g_free(config->config_path);
     g_free(config->error);
@@ -361,12 +544,14 @@ gboolean gateway_config_is_local(const GatewayConfig *config) {
 
 gchar* gateway_config_http_url(const GatewayConfig *config) {
     if (!config) return NULL;
-    return g_strdup_printf("http://%s:%d", config->host, config->port);
+    const gchar *scheme = config->tls_enabled ? "https" : "http";
+    return g_strdup_printf("%s://%s:%d", scheme, config->host, config->port);
 }
 
 gchar* gateway_config_ws_url(const GatewayConfig *config) {
     if (!config) return NULL;
-    return g_strdup_printf("ws://%s:%d", config->host, config->port);
+    const gchar *scheme = config->tls_enabled ? "wss" : "ws";
+    return g_strdup_printf("%s://%s:%d", scheme, config->host, config->port);
 }
 
 gboolean gateway_config_equivalent(const GatewayConfig *a, const GatewayConfig *b) {
@@ -385,6 +570,9 @@ gboolean gateway_config_equivalent(const GatewayConfig *a, const GatewayConfig *
     /* host + port */
     if (g_strcmp0(a->host, b->host) != 0) return FALSE;
     if (a->port != b->port) return FALSE;
+
+    /* tls_enabled - TLS changes must trigger config reload */
+    if (a->tls_enabled != b->tls_enabled) return FALSE;
 
     /* auth_mode */
     if (g_strcmp0(a->auth_mode, b->auth_mode) != 0) return FALSE;
@@ -445,9 +633,10 @@ gchar* gateway_config_dashboard_url(const GatewayConfig *config) {
         }
     }
 
-    /* Build base URL */
-    g_autofree gchar *base = g_strdup_printf("http://%s:%d%s",
-        config->host, config->port,
+    /* Build base URL with correct scheme based on TLS */
+    const gchar *scheme = config->tls_enabled ? "https" : "http";
+    g_autofree gchar *base = g_strdup_printf("%s://%s:%d%s",
+        scheme, config->host, config->port,
         g_strcmp0(normalized, "/") == 0 ? "/" : normalized);
 
     /* Append token fragment if available and not a SecretRef */

--- a/apps/linux/src/gateway_config.h
+++ b/apps/linux/src/gateway_config.h
@@ -28,7 +28,13 @@ typedef enum {
     GW_CFG_ERR_NO_HOME,
     GW_CFG_ERR_PARSE,
     GW_CFG_ERR_NOT_OBJECT,
+    GW_CFG_ERR_GATEWAY_NOT_OBJECT,    /* E1 */
+    GW_CFG_ERR_MODE_INVALID,            /* E2 */
     GW_CFG_ERR_MODE_UNSUPPORTED,
+    GW_CFG_ERR_AUTH_NOT_OBJECT,         /* E3 */
+    GW_CFG_ERR_AUTH_MODE_INVALID,       /* E4 */
+    GW_CFG_ERR_AUTH_AMBIGUOUS,          /* E5 */
+    GW_CFG_ERR_PORT_INVALID,            /* E6 */
     GW_CFG_ERR_AUTH_MODE_UNSUPPORTED,
     GW_CFG_ERR_TOKEN_MISSING,
     GW_CFG_ERR_PASSWORD_MISSING,
@@ -46,6 +52,7 @@ typedef struct {
     gchar *mode;           /* gateway.mode: "local" or other (NULL treated as local) */
     gchar *host;           /* effective bind host (default 127.0.0.1) */
     gint port;             /* effective port (default 18789) */
+    gboolean tls_enabled;  /* L6: TLS enablement from gateway.tls or gateway.security.tls */
     gchar *auth_mode;      /* gateway.auth.mode: "token", "password", "none" */
     gchar *token;          /* resolved auth token (config + env override) */
     gchar *password;       /* resolved auth password (config + env override) */

--- a/apps/linux/src/gateway_http.c
+++ b/apps/linux/src/gateway_http.c
@@ -17,10 +17,17 @@
 
 static SoupSession *http_session = NULL;
 
+/* C1: Finite timeout for health probes (seconds) */
+#define HEALTH_PROBE_TIMEOUT_S 10
+
 void gateway_http_init(void) {
-    if (!http_session) {
-        http_session = soup_session_new();
-    }
+    if (http_session) return;
+    http_session = soup_session_new();
+    /* C1: Set finite timeout for health probes to prevent indefinite hangs */
+    g_object_set(G_OBJECT(http_session),
+                 "timeout", HEALTH_PROBE_TIMEOUT_S,
+                 "idle-timeout", HEALTH_PROBE_TIMEOUT_S,
+                 NULL);
 }
 
 void gateway_http_shutdown(void) {
@@ -87,11 +94,11 @@ static void on_network_event(SoupMessage *msg, GSocketClientEvent event,
     }
 }
 
-static void on_health_response(GObject *source, GAsyncResult *res, gpointer user_data) {
+static void on_health_response(GObject *source_object, GAsyncResult *res, gpointer user_data) {
     HealthCheckContext *ctx = (HealthCheckContext *)user_data;
     g_autoptr(GError) error = NULL;
 
-    GBytes *body = soup_session_send_and_read_finish(SOUP_SESSION(source), res, &error);
+    GBytes *body = soup_session_send_and_read_finish(SOUP_SESSION(source_object), res, &error);
 
     GatewayHealthResult result = {0};
 

--- a/apps/linux/src/gateway_protocol.c
+++ b/apps/linux/src/gateway_protocol.c
@@ -215,6 +215,52 @@ gchar* gateway_protocol_extract_challenge_nonce(const GatewayFrame *frame) {
     return NULL;
 }
 
+/* Static helpers for strict JSON type validation */
+
+static gboolean json_node_is_string_value(JsonNode *node) {
+    return JSON_NODE_HOLDS_VALUE(node) && json_node_get_value_type(node) == G_TYPE_STRING;
+}
+
+static gboolean json_node_is_numeric_value(JsonNode *node) {
+    if (!JSON_NODE_HOLDS_VALUE(node)) return FALSE;
+    GType t = json_node_get_value_type(node);
+    return t == G_TYPE_INT64 || t == G_TYPE_DOUBLE || t == G_TYPE_INT || t == G_TYPE_UINT;
+}
+
+static gboolean json_node_is_integer_value(JsonNode *node) {
+    if (!JSON_NODE_HOLDS_VALUE(node)) return FALSE;
+    GType t = json_node_get_value_type(node);
+    return t == G_TYPE_INT64 || t == G_TYPE_INT || t == G_TYPE_UINT;
+}
+
+static gboolean json_object_has_required_nonempty_string(JsonObject *obj, const gchar *key) {
+    if (!json_object_has_member(obj, key)) return FALSE;
+    JsonNode *node = json_object_get_member(obj, key);
+    if (!json_node_is_string_value(node)) return FALSE;
+    const gchar *val = json_node_get_string(node);
+    if (!val || val[0] == '\0') return FALSE;
+    return TRUE;
+}
+
+static gboolean json_object_has_required_positive_integer(JsonObject *obj, const gchar *key) {
+    if (!json_object_has_member(obj, key)) return FALSE;
+    JsonNode *node = json_object_get_member(obj, key);
+    if (!json_node_is_integer_value(node)) return FALSE;
+    gint64 val = json_node_get_int(node);
+    if (val < 1) return FALSE;
+    return TRUE;
+}
+
+static gboolean json_object_get_required_positive_number(JsonObject *obj, const gchar *key, gdouble *out) {
+    if (!json_object_has_member(obj, key)) return FALSE;
+    JsonNode *node = json_object_get_member(obj, key);
+    if (!json_node_is_numeric_value(node)) return FALSE;
+    gdouble val = json_node_get_double(node);
+    if (val <= 0) return FALSE;
+    *out = val;
+    return TRUE;
+}
+
 gboolean gateway_protocol_parse_hello_ok(const GatewayFrame *frame,
     gchar **out_auth_source,
     gdouble *out_tick_interval_ms)
@@ -225,12 +271,74 @@ gboolean gateway_protocol_parse_hello_ok(const GatewayFrame *frame,
 
     JsonObject *obj = json_node_get_object(frame->payload);
 
+    /* Require type field to be "hello-ok" per HelloOkSchema */
+    if (!json_object_has_member(obj, "type")) {
+        return FALSE;
+    }
+    const gchar *type_str = json_object_get_string_member(obj, "type");
+    if (g_strcmp0(type_str, "hello-ok") != 0) {
+        return FALSE;
+    }
+
+    /* protocol: required integer >= 1 (integer types only, no double) */
+    if (!json_object_has_required_positive_integer(obj, "protocol")) {
+        return FALSE;
+    }
+
+    /* server: required object with non-empty version and connId strings */
+    JsonNode *server_node = json_object_get_member(obj, "server");
+    if (!server_node || !JSON_NODE_HOLDS_OBJECT(server_node)) {
+        return FALSE;
+    }
+    JsonObject *server = json_node_get_object(server_node);
+    if (!json_object_has_required_nonempty_string(server, "version") ||
+        !json_object_has_required_nonempty_string(server, "connId")) {
+        return FALSE;
+    }
+
+    /* features: required object with methods and events arrays */
+    JsonNode *features_node = json_object_get_member(obj, "features");
+    if (!features_node || !JSON_NODE_HOLDS_OBJECT(features_node)) {
+        return FALSE;
+    }
+    JsonObject *features = json_node_get_object(features_node);
+    if (!json_object_has_member(features, "methods") ||
+        !json_object_has_member(features, "events")) {
+        return FALSE;
+    }
+    JsonNode *methods_node = json_object_get_member(features, "methods");
+    JsonNode *events_node = json_object_get_member(features, "events");
+    if (!JSON_NODE_HOLDS_ARRAY(methods_node) || !JSON_NODE_HOLDS_ARRAY(events_node)) {
+        return FALSE;
+    }
+
+    /* snapshot: required (can be any valid JSON, but must be present) */
+    if (!json_object_has_member(obj, "snapshot")) {
+        return FALSE;
+    }
+
     /* Policy is strictly required and must be an object */
     JsonNode *policy_node = json_object_get_member(obj, "policy");
     if (!policy_node || !JSON_NODE_HOLDS_OBJECT(policy_node)) {
         return FALSE;
     }
     JsonObject *policy = json_node_get_object(policy_node);
+
+    /* policy.maxPayload: required integer >= 1 (integer types only, no double) */
+    if (!json_object_has_required_positive_integer(policy, "maxPayload")) {
+        return FALSE;
+    }
+
+    /* policy.maxBufferedBytes: required integer >= 1 (integer types only, no double) */
+    if (!json_object_has_required_positive_integer(policy, "maxBufferedBytes")) {
+        return FALSE;
+    }
+
+    /* tickIntervalMs: required positive numeric per HelloOkSchema */
+    gdouble tick_ms;
+    if (!json_object_get_required_positive_number(policy, "tickIntervalMs", &tick_ms)) {
+        return FALSE;
+    }
 
     /* Auth is optional, but if present must be an object */
     JsonObject *auth = NULL;
@@ -250,10 +358,7 @@ gboolean gateway_protocol_parse_hello_ok(const GatewayFrame *frame,
     }
 
     if (out_tick_interval_ms) {
-        *out_tick_interval_ms = 30000.0;
-        if (json_object_has_member(policy, "tickIntervalMs")) {
-            *out_tick_interval_ms = json_object_get_double_member(policy, "tickIntervalMs");
-        }
+        *out_tick_interval_ms = tick_ms;
     }
 
     return TRUE;

--- a/apps/linux/src/gateway_rpc.c
+++ b/apps/linux/src/gateway_rpc.c
@@ -29,7 +29,7 @@ static GHashTable *pending_requests = NULL;
 /* Forward declarations */
 static void pending_rpc_request_free(PendingRpcRequest *req);
 static gboolean on_request_timeout(gpointer user_data);
-static void ws_send_rpc_frame(const gchar *request_id, const gchar *method,
+static gboolean ws_send_rpc_frame(const gchar *request_id, const gchar *method,
                               JsonNode *params_json);
 
 static void ensure_registry(void) {
@@ -86,7 +86,12 @@ gchar* gateway_rpc_request(const gchar *method,
                  "rpc request sent id=%s method=%s timeout=%u ms",
                  request_id, method, effective_timeout);
 
-    ws_send_rpc_frame(request_id, method, params_json);
+    /* D1: If send fails, remove pending request immediately and return NULL */
+    if (!ws_send_rpc_frame(request_id, method, params_json)) {
+        g_hash_table_remove(pending_requests, request_id);
+        g_free(request_id);
+        return NULL;
+    }
 
     return request_id;
 }
@@ -237,7 +242,8 @@ static gboolean on_request_timeout(gpointer user_data) {
     return G_SOURCE_REMOVE;
 }
 
-static void ws_send_rpc_frame(const gchar *request_id, const gchar *method,
+/* D1: Returns TRUE if the frame was successfully sent */
+static gboolean ws_send_rpc_frame(const gchar *request_id, const gchar *method,
                               JsonNode *params_json) {
     g_autoptr(JsonBuilder) builder = json_builder_new();
 
@@ -269,6 +275,9 @@ static void ws_send_rpc_frame(const gchar *request_id, const gchar *method,
     json_node_unref(root);
 
     if (json_str) {
-        gateway_ws_send_text(json_str);
+        if (!gateway_ws_send_text(json_str)) {
+            return FALSE;
+        }
     }
+    return TRUE;
 }

--- a/apps/linux/src/gateway_ws.c
+++ b/apps/linux/src/gateway_ws.c
@@ -95,6 +95,15 @@ static void ws_set_state(GatewayWsState new_state) {
     ws_publish_status();
 }
 
+static void secure_clear_free(gchar *str) {
+    if (!str) return;
+    volatile gchar *p = str;
+    while (*p) {
+        *p++ = '\0';
+    }
+    g_free(str);
+}
+
 static void ws_set_error(const gchar *error) {
     if (!ws_client) return;
     g_free(ws_client->last_error);
@@ -168,6 +177,17 @@ static void ws_schedule_reconnect(void) {
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY, "ws scheduling reconnect in %u ms", delay_ms);
     if (ws_client->reconnect_timer_id) g_source_remove(ws_client->reconnect_timer_id);
     ws_client->reconnect_timer_id = g_timeout_add(delay_ms, ws_on_reconnect_timer, NULL);
+}
+
+/* B3: Clamp tick interval to sane range */
+#define TICK_INTERVAL_MIN_MS   1000.0
+#define TICK_INTERVAL_MAX_MS   300000.0
+
+static gdouble clamp_tick_interval(gdouble tick_ms) {
+    if (tick_ms <= 0) return DEFAULT_TICK_INTERVAL_MS;
+    if (tick_ms < TICK_INTERVAL_MIN_MS) return TICK_INTERVAL_MIN_MS;
+    if (tick_ms > TICK_INTERVAL_MAX_MS) return TICK_INTERVAL_MAX_MS;
+    return tick_ms;
 }
 
 static void ws_start_keepalive(void) {
@@ -281,10 +301,11 @@ static void ws_handle_frame(const gchar *text) {
             if (frame->error) {
                 OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY, "ws auth rejected: code=%s msg=%s",
                           frame->code ? frame->code : "(none)", frame->error);
-                ws_client->reconnect_paused_for_auth = TRUE;
+                /* B2: Set error and status but don't pause reconnect permanently */
                 ws_set_error(frame->error);
                 ws_set_state(GATEWAY_WS_AUTH_FAILED);
                 ws_cleanup_connection();
+                /* Note: reconnect_paused_for_auth remains FALSE so refresh can recover */
             } else {
                 /* connect-ok */
                 gchar *auth_src = NULL;
@@ -298,7 +319,8 @@ static void ws_handle_frame(const gchar *text) {
                 } else {
                     g_free(ws_client->auth_source);
                     ws_client->auth_source = auth_src;
-                    ws_client->tick_interval_ms = tick_ms;
+                    /* B3: Clamp tick interval before use */
+                    ws_client->tick_interval_ms = clamp_tick_interval(tick_ms);
                     ws_client->rpc_ok = TRUE;
                     ws_client->backoff_ms = BACKOFF_INITIAL_MS;
                     ws_client->reconnect_paused_for_auth = FALSE;
@@ -336,8 +358,12 @@ static void ws_handle_frame(const gchar *text) {
 
 static void ws_handle_message(SoupWebsocketConnection *conn, SoupWebsocketDataType type,
                               GBytes *message, gpointer user_data) {
-    (void)conn;
     (void)user_data;
+    
+    /* B1: Ignore stale socket callbacks */
+    if (!ws_client) return;
+    if (conn != ws_client->ws_conn) return;
+    
     if (type != SOUP_WEBSOCKET_DATA_TEXT) return;
 
     gsize size = 0;
@@ -351,7 +377,10 @@ static void ws_handle_message(SoupWebsocketConnection *conn, SoupWebsocketDataTy
 static void ws_on_closed(SoupWebsocketConnection *conn, gpointer user_data) {
     (void)conn;
     (void)user_data;
+    
+    /* B1: Ignore stale socket callbacks */
     if (!ws_client) return;
+    if (conn != ws_client->ws_conn) return;
 
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY, "ws connection closed");
     ws_client->rpc_ok = FALSE;
@@ -367,9 +396,12 @@ static void ws_on_closed(SoupWebsocketConnection *conn, gpointer user_data) {
 }
 
 static void ws_on_error(SoupWebsocketConnection *conn, GError *error, gpointer user_data) {
-    (void)conn;
     (void)user_data;
+    
+    /* B1: Ignore stale socket callbacks */
     if (!ws_client) return;
+    if (conn != ws_client->ws_conn) return;
+    
     OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY, "ws error: %s", error ? error->message : "unknown");
     ws_set_error(error ? error->message : "Unknown WebSocket error");
 }
@@ -470,8 +502,8 @@ void gateway_ws_connect(const gchar *ws_url, const gchar *auth_mode,
 
     g_free(ws_client->url);
     g_free(ws_client->auth_mode);
-    g_free(ws_client->token);
-    g_free(ws_client->password);
+    secure_clear_free(ws_client->token);
+    secure_clear_free(ws_client->password);
     ws_client->url = g_strdup(ws_url);
     ws_client->auth_mode = g_strdup(auth_mode);
     ws_client->token = g_strdup(token);
@@ -503,8 +535,8 @@ void gateway_ws_shutdown(void) {
     g_clear_object(&ws_client->session);
     g_free(ws_client->url);
     g_free(ws_client->auth_mode);
-    g_free(ws_client->token);
-    g_free(ws_client->password);
+    secure_clear_free(ws_client->token);
+    secure_clear_free(ws_client->password);
     g_free(ws_client->auth_source);
     g_free(ws_client->last_error);
     g_free(ws_client);

--- a/apps/linux/src/section_channels.c
+++ b/apps/linux/src/section_channels.c
@@ -153,7 +153,8 @@ static void on_config_dialog_response(GObject *source, GAsyncResult *result, gpo
     }
     
     /* Get the edited channel subtree */
-    JsonObject *edited_channel_obj = json_node_get_object(json_node_copy(parsed_root));
+    /* I1: Properly manage JsonNode ownership - copy root for later transfer */
+    JsonNode *edited_channel_node = json_node_copy(parsed_root);
     g_object_unref(parser);
 
     if (channels_status_label)
@@ -211,18 +212,17 @@ static void on_config_dialog_response(GObject *source, GAsyncResult *result, gpo
     /* Create channels object if it doesn't exist or isn't an object */
     if (!channels_obj) {
         channels_obj = json_object_new();
-        json_object_set_member(root_obj, "channels", json_node_new(JSON_NODE_OBJECT));
-        json_node_set_object(json_object_get_member(root_obj, "channels"), channels_obj);
+        JsonNode *channels_node = json_node_new(JSON_NODE_OBJECT);
+        json_node_set_object(channels_node, channels_obj);
+        json_object_set_member(root_obj, "channels", channels_node);
     }
     
     /* Replace the specific channel with edited subtree */
     if (json_object_has_member(channels_obj, session->channel_id)) {
         json_object_remove_member(channels_obj, session->channel_id);
     }
-    json_object_set_member(channels_obj, session->channel_id, 
-                           json_node_new(JSON_NODE_OBJECT));
-    json_node_set_object(json_object_get_member(channels_obj, session->channel_id),
-                        edited_channel_obj);
+    /* I1: Transfer ownership of edited_channel_node to the channels object */
+    json_object_set_member(channels_obj, session->channel_id, edited_channel_node);
 
     /* Serialize the FULL updated config document */
     g_autofree gchar *full_raw_json = json_to_string(full_config_copy, FALSE);

--- a/apps/linux/src/section_cron.c
+++ b/apps/linux/src/section_cron.c
@@ -31,6 +31,8 @@ static gboolean cron_fetch_in_flight = FALSE;
 static gboolean cron_status_fetch_in_flight = FALSE;
 static gboolean cron_runs_fetch_in_flight = FALSE;
 static gint64 cron_last_fetch_us = 0;
+/* H1: Generation counter for stale response filtering */
+static guint cron_refresh_generation = 0;
 
 /* Forward declarations */
 static void cron_rebuild_list(void);
@@ -139,6 +141,31 @@ static void on_delete(GtkButton *btn, gpointer user_data) {
     adw_alert_dialog_choose(dialog, toplevel, NULL, on_delete_dialog_response, NULL);
 }
 
+/* G1: Helper to insert route before #token fragment */
+static gchar* dashboard_url_with_route(const gchar *base_url, const gchar *route) {
+    if (!base_url || !route) return NULL;
+    
+    /* Find fragment marker */
+    const gchar *fragment = strchr(base_url, '#');
+    if (fragment) {
+        /* Insert route before fragment */
+        gsize base_len = fragment - base_url;
+        /* Ensure base ends with / */
+        gboolean needs_slash = (base_len == 0 || base_url[base_len - 1] != '/');
+        return g_strdup_printf("%.*s%s%s%s",
+                              (int)base_len, base_url,
+                              needs_slash ? "/" : "",
+                              route, fragment);
+    } else {
+        /* No fragment, append route normally */
+        gboolean needs_slash = base_url[strlen(base_url) - 1] != '/';
+        return g_strdup_printf("%s%s%s",
+                              base_url,
+                              needs_slash ? "/" : "",
+                              route);
+    }
+}
+
 static void on_open_transcript(GtkButton *btn, gpointer user_data) {
     (void)user_data;
     const gchar *key = (const gchar *)g_object_get_data(G_OBJECT(btn), "session-key");
@@ -167,9 +194,12 @@ static void on_open_transcript(GtkButton *btn, gpointer user_data) {
     g_autofree gchar *url = gateway_config_dashboard_url(cfg);
     if (!url) return;
 
-    /* Dashboard route for session logs: /chat/:sessionKey */
-    g_autofree gchar *log_url = g_strdup_printf("%schat/%s", url, key);
-    g_app_info_launch_default_for_uri(log_url, NULL, NULL);
+    /* Dashboard route for session logs: chat/:sessionKey */
+    g_autofree gchar *route = g_strdup_printf("chat/%s", key);
+    g_autofree gchar *log_url = dashboard_url_with_route(url, route);
+    if (log_url) {
+        g_app_info_launch_default_for_uri(log_url, NULL, NULL);
+    }
 }
 
 /* ── Helpers ─────────────────────────────────────────────────────── */
@@ -836,9 +866,12 @@ static void cron_rebuild_list(void) {
 }
 
 static void on_cron_status_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    guint generation = GPOINTER_TO_UINT(user_data);
     cron_status_fetch_in_flight = FALSE;
     if (!cron_scheduler_banner) return;
+    
+    /* H1: Ignore stale responses from previous refresh cycles */
+    if (generation != cron_refresh_generation) return;
     
     if (response->ok) {
         gateway_cron_status_free(cron_status_cache);
@@ -848,9 +881,12 @@ static void on_cron_status_rpc_response(const GatewayRpcResponse *response, gpoi
 }
 
 static void on_cron_runs_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    guint generation = GPOINTER_TO_UINT(user_data);
     cron_runs_fetch_in_flight = FALSE;
     if (!cron_runs_box) return;
+    
+    /* H1: Ignore stale responses from previous refresh cycles */
+    if (generation != cron_refresh_generation) return;
     
     if (response->ok) {
         gateway_cron_runs_data_free(cron_runs_cache);
@@ -862,10 +898,13 @@ static void on_cron_runs_rpc_response(const GatewayRpcResponse *response, gpoint
 /* ── RPC callback ────────────────────────────────────────────────── */
 
 static void on_cron_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    guint generation = GPOINTER_TO_UINT(user_data);
     cron_fetch_in_flight = FALSE;
 
     if (!cron_list_box) return;
+
+    /* H1: Ignore stale responses from previous refresh cycles */
+    if (generation != cron_refresh_generation) return;
 
     if (!response->ok) {
         if (cron_status_label) {
@@ -910,14 +949,18 @@ static void cron_force_refresh(void) {
     if (!cron_list_box) return;
     if (!gateway_rpc_is_ready()) return;
 
+    /* H1: Increment generation to invalidate in-flight responses */
+    cron_refresh_generation++;
+    guint current_gen = cron_refresh_generation;
+
     cron_fetch_in_flight = TRUE;
     g_autofree gchar *req_id1 = gateway_rpc_request(
-        "cron.list", NULL, 0, on_cron_rpc_response, NULL);
+        "cron.list", NULL, 0, on_cron_rpc_response, GUINT_TO_POINTER(current_gen));
     if (!req_id1) cron_fetch_in_flight = FALSE;
 
     cron_status_fetch_in_flight = TRUE;
     g_autofree gchar *req_id2 = gateway_rpc_request(
-        "cron.status", NULL, 0, on_cron_status_rpc_response, NULL);
+        "cron.status", NULL, 0, on_cron_status_rpc_response, GUINT_TO_POINTER(current_gen));
     if (!req_id2) cron_status_fetch_in_flight = FALSE;
 
     cron_runs_fetch_in_flight = TRUE;
@@ -930,7 +973,7 @@ static void cron_force_refresh(void) {
     g_object_unref(b);
     
     g_autofree gchar *req_id3 = gateway_rpc_request(
-        "cron.runs", runs_params, 0, on_cron_runs_rpc_response, NULL);
+        "cron.runs", runs_params, 0, on_cron_runs_rpc_response, GUINT_TO_POINTER(current_gen));
     if (!req_id3) cron_runs_fetch_in_flight = FALSE;
     json_node_unref(runs_params);
 }

--- a/apps/linux/src/section_sessions.c
+++ b/apps/linux/src/section_sessions.c
@@ -173,6 +173,31 @@ static void on_session_delete(GtkButton *btn, gpointer user_data) {
     adw_alert_dialog_choose(dialog, toplevel, NULL, on_delete_dialog_response, NULL);
 }
 
+/* G1: Helper to insert route before #token fragment */
+static gchar* dashboard_url_with_route(const gchar *base_url, const gchar *route) {
+    if (!base_url || !route) return NULL;
+    
+    /* Find fragment marker */
+    const gchar *fragment = strchr(base_url, '#');
+    if (fragment) {
+        /* Insert route before fragment */
+        gsize base_len = fragment - base_url;
+        /* Ensure base ends with / */
+        gboolean needs_slash = (base_len == 0 || base_url[base_len - 1] != '/');
+        return g_strdup_printf("%.*s%s%s%s",
+                              (int)base_len, base_url,
+                              needs_slash ? "/" : "",
+                              route, fragment);
+    } else {
+        /* No fragment, append route normally */
+        gboolean needs_slash = base_url[strlen(base_url) - 1] != '/';
+        return g_strdup_printf("%s%s%s",
+                              base_url,
+                              needs_slash ? "/" : "",
+                              route);
+    }
+}
+
 static void on_session_log(GtkButton *btn, gpointer user_data) {
     (void)user_data;
     const gchar *key = (const gchar *)g_object_get_data(G_OBJECT(btn), "session-key");
@@ -200,9 +225,12 @@ static void on_session_log(GtkButton *btn, gpointer user_data) {
     g_autofree gchar *url = gateway_config_dashboard_url(cfg);
     if (!url) return;
 
-    /* Dashboard route for session logs: /chat/:sessionKey */
-    g_autofree gchar *log_url = g_strdup_printf("%schat/%s", url, key);
-    g_app_info_launch_default_for_uri(log_url, NULL, NULL);
+    /* Dashboard route for session logs: chat/:sessionKey */
+    g_autofree gchar *route = g_strdup_printf("chat/%s", key);
+    g_autofree gchar *log_url = dashboard_url_with_route(url, route);
+    if (log_url) {
+        g_app_info_launch_default_for_uri(log_url, NULL, NULL);
+    }
 }
 
 /* ── Helpers ─────────────────────────────────────────────────────── */
@@ -517,12 +545,13 @@ static GtkWidget* sessions_build(void) {
 
 static void sessions_refresh(void) {
     if (!sessions_list_box || sessions_fetch_in_flight) return;
-    if (!section_is_stale(&sessions_last_fetch_us)) return;
+    /* L7: Check readiness BEFORE freshness - disconnected state must win over cache */
     if (!gateway_rpc_is_ready()) {
         if (sessions_status_label)
             gtk_label_set_text(GTK_LABEL(sessions_status_label), "Gateway not connected");
         return;
     }
+    if (!section_is_stale(&sessions_last_fetch_us)) return;
 
     sessions_fetch_in_flight = TRUE;
     g_autofree gchar *req_id = gateway_rpc_request(

--- a/apps/linux/src/section_skills.c
+++ b/apps/linux/src/section_skills.c
@@ -540,12 +540,13 @@ static GtkWidget* skills_build(void) {
 
 static void skills_refresh(void) {
     if (!skills_list_box || skills_fetch_in_flight) return;
-    if (!section_is_stale(&skills_last_fetch_us)) return;
+    /* L7: Check readiness BEFORE freshness - disconnected state must win over cache */
     if (!gateway_rpc_is_ready()) {
         if (skills_status_label)
             gtk_label_set_text(GTK_LABEL(skills_status_label), "Gateway not connected");
         return;
     }
+    if (!section_is_stale(&skills_last_fetch_us)) return;
 
     skills_fetch_in_flight = TRUE;
     g_autofree gchar *req_id = gateway_rpc_request(

--- a/apps/linux/src/systemd.c
+++ b/apps/linux/src/systemd.c
@@ -31,6 +31,19 @@ static GDBusProxy *unit_proxy = NULL;
 static gchar *cached_unit_name = NULL;
 static guint properties_changed_signal_id = 0;
 
+/* B1: Cached service config for the currently targeted unit */
+static gchar *cached_previous_unit_name = NULL;
+
+static void clear_cached_service_config(const gchar *reason) {
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "clear_cached_service_config reason=%s", reason);
+    /* Clear the actual cached unit identity (the real service config cache) */
+    g_free(cached_unit_name);
+    cached_unit_name = NULL;
+    /* Also clear the previous unit tracking variable */
+    g_free(cached_previous_unit_name);
+    cached_previous_unit_name = NULL;
+}
+
 static void fetch_unit_properties(void);
 extern void systemd_refresh(void);
 static void clear_unit_subscription(const gchar *reason);
@@ -208,6 +221,26 @@ static DbusEnvResult systemd_try_dbus_effective_env(const gchar *unit,
         G_DBUS_CALL_FLAGS_NONE, 2000, NULL, &error);
 
     if (!get_unit_result) {
+        /* D3: Distinguish transient D-Bus errors from genuine "unit not loaded".
+         * Transient errors should return QUERY_FAILED, not UNIT_NOT_LOADED,
+         * to avoid falling back to unit-file parsing when D-Bus is unavailable.
+         */
+        gboolean is_transient_dbus_error = FALSE;
+        if (error) {
+            is_transient_dbus_error = (
+                g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN) ||
+                g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_NO_REPLY) ||
+                g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_DISCONNECTED) ||
+                g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_TIMED_OUT) ||
+                g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_NAME_HAS_NO_OWNER)
+            );
+        }
+        if (is_transient_dbus_error) {
+            OC_LOG_WARN(OPENCLAW_LOG_CAT_SYSTEMD,
+                        "GetUnit transient D-Bus error for '%s': %s",
+                        unit, error->message);
+            return DBUS_ENV_QUERY_FAILED;
+        }
         OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD,
                      "GetUnit failed for '%s' (unit not loaded, expected fallback): %s",
                      unit, error->message);
@@ -413,8 +446,16 @@ static void on_manager_signal(GDBusProxy *proxy, gchar *sender_name, gchar *sign
     }
 
     if (g_strcmp0(signal_name, "UnitNew") == 0 && parameters) {
+        /* J3: Validate variant type before parsing to prevent crash on malformed signal */
+        if (!g_variant_is_of_type(parameters, G_VARIANT_TYPE("(so)"))) {
+            OC_LOG_WARN(OPENCLAW_LOG_CAT_SYSTEMD, "on_manager_signal UnitNew: unexpected variant type %s", 
+                        g_variant_get_type_string(parameters));
+            return;
+        }
         const gchar *unit_name = NULL;
-        g_variant_get(parameters, "(&so)", &unit_name, NULL);
+        const gchar *object_path = NULL;  /* L5: Real variable instead of NULL */
+        g_variant_get(parameters, "(&so)", &unit_name, &object_path);
+        (void)object_path; /* Unused but required for correct parsing */
         if (unit_name) {
             const gchar *canonical = systemd_get_canonical_unit_name();
             if ((canonical && g_strcmp0(unit_name, canonical) == 0) || systemd_is_gateway_unit_name(unit_name)) {
@@ -441,9 +482,21 @@ static void on_manager_signal(GDBusProxy *proxy, gchar *sender_name, gchar *sign
 }
 
 static void publish_systemd_state(const gchar *active_state, const gchar *sub_state) {
+    const gchar *current_unit = systemd_get_canonical_unit_name();
+    
+    /* B1: Invalidate cached service config when unit changes */
+    if (cached_previous_unit_name && 
+        g_strcmp0(cached_previous_unit_name, current_unit) != 0) {
+        clear_cached_service_config("unit-retarget");
+    }
+    
     SystemdState sys_state = {0};
     sys_state.installed = TRUE;
-    sys_state.unit_name = g_strdup(systemd_get_canonical_unit_name());
+    sys_state.unit_name = g_strdup(current_unit);
+    
+    /* Update cached previous unit name */
+    g_free(cached_previous_unit_name);
+    cached_previous_unit_name = g_strdup(current_unit);
 
     if (active_state) {
         sys_state.active_state = g_strdup(active_state);
@@ -544,9 +597,33 @@ static void on_get_unit_ready(GObject *source_object, GAsyncResult *res, gpointe
     }
 
     // 3 (continued). Evaluate runtime state result
+    /* D1: Broaden D-Bus error classification to avoid misclassifying transient failures.
+     * These error codes indicate D-Bus problems, not "unit stopped":
+     * - SERVICE_UNKNOWN: systemd service not available (transient)
+     * - NO_REPLY: timeout waiting for response (transient network/D-Bus issue)
+     * - DISCONNECTED: D-Bus connection lost (transient)
+     * - TIMED_OUT: operation timed out (transient)
+     * - NAME_HAS_NO_OWNER: service name not claimed (systemd not ready yet)
+     */
     if (!result) {
-        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_ready !result proxy=%p error=%s",
-                  (void *)unit_proxy, error ? error->message : "(null)");
+        /* Check if it's a genuine D-Bus error vs unit not found */
+        gboolean is_transient_dbus_error = FALSE;
+        if (error) {
+            is_transient_dbus_error = (
+                g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN) ||
+                g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_NO_REPLY) ||
+                g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_DISCONNECTED) ||
+                g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_TIMED_OUT) ||
+                g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_NAME_HAS_NO_OWNER)
+            );
+        }
+        if (is_transient_dbus_error) {
+            OC_LOG_WARN(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_ready transient D-Bus error: %s", error->message);
+            /* Don't update state on transient D-Bus errors - preserve previous known state */
+            return;
+        }
+        /* Otherwise treat as unit not loaded/stopped */
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_ready !result (unit not loaded) proxy=%p", (void *)unit_proxy);
         // Drop the previous unit subscription when retargeting to an unloaded unit
         clear_unit_subscription("unit-unloaded");
 
@@ -597,6 +674,9 @@ static void on_get_unit_file_state_ready(GObject *source_object, GAsyncResult *r
         g_free(requested_unit_name);
     }
 
+    /* D2: Broaden D-Bus error classification in GetUnitFileState for consistency.
+     * Same transient error codes as in on_get_unit_ready.
+     */
     gboolean is_installed = FALSE;
     if (result) {
         const gchar *state_str = NULL;
@@ -604,11 +684,24 @@ static void on_get_unit_file_state_ready(GObject *source_object, GAsyncResult *r
         if (g_strcmp0(state_str, "not-found") != 0) {
             is_installed = TRUE;
         }
+    } else if (error) {
+        gboolean is_transient_dbus_error = (
+            g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN) ||
+            g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_NO_REPLY) ||
+            g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_DISCONNECTED) ||
+            g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_TIMED_OUT) ||
+            g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_NAME_HAS_NO_OWNER)
+        );
+        if (is_transient_dbus_error) {
+            OC_LOG_WARN(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_file_state_ready transient D-Bus error: %s", error->message);
+            /* Don't update state on transient D-Bus errors - preserve previous known state */
+            return;
+        }
     }
 
     // 2. If GetUnitFileState fails or state is "not-found", treat as not installed
     if (!is_installed) {
-        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_file_state_ready !is_installed proxy=%p",
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_SYSTEMD, "on_get_unit_file_state_ready !is_installed (unit not found) proxy=%p",
                   (void *)unit_proxy);
         // Drop the previous unit subscription if the selected unit is no longer installed
         clear_unit_subscription("unit-not-installed");

--- a/apps/linux/src/systemd_helpers.c
+++ b/apps/linux/src/systemd_helpers.c
@@ -21,9 +21,20 @@
 
 gboolean systemd_is_gateway_unit_name(const gchar *unit_name) {
     if (!unit_name) return FALSE;
-    return ((g_str_has_prefix(unit_name, "openclaw-gateway.") || g_str_has_prefix(unit_name, "openclaw-gateway-")) ||
-            (g_str_has_prefix(unit_name, "clawdbot-gateway.") || g_str_has_prefix(unit_name, "clawdbot-gateway-")) ||
-            (g_str_has_prefix(unit_name, "moltbot-gateway.") || g_str_has_prefix(unit_name, "moltbot-gateway-")));
+    
+    /* Match exact patterns: openclaw-gateway.service or openclaw-gateway-*.service */
+    if (g_strcmp0(unit_name, "openclaw-gateway.service") == 0) return TRUE;
+    if (g_str_has_prefix(unit_name, "openclaw-gateway-") && g_str_has_suffix(unit_name, ".service")) return TRUE;
+    
+    /* Legacy: clawdbot-gateway.service or clawdbot-gateway-*.service */
+    if (g_strcmp0(unit_name, "clawdbot-gateway.service") == 0) return TRUE;
+    if (g_str_has_prefix(unit_name, "clawdbot-gateway-") && g_str_has_suffix(unit_name, ".service")) return TRUE;
+    
+    /* Legacy: moltbot-gateway.service or moltbot-gateway-*.service */
+    if (g_strcmp0(unit_name, "moltbot-gateway.service") == 0) return TRUE;
+    if (g_str_has_prefix(unit_name, "moltbot-gateway-") && g_str_has_suffix(unit_name, ".service")) return TRUE;
+    
+    return FALSE;
 }
 
 gboolean systemd_is_gateway_unit(const gchar *filename, const gchar *contents) {
@@ -68,12 +79,35 @@ gchar* systemd_normalize_profile(const gchar *raw_profile) {
 
 GPtrArray* systemd_helpers_get_user_unit_paths(const gchar *home_dir) {
     GPtrArray *paths = g_ptr_array_new_with_free_func(g_free);
-    if (home_dir) {
-        g_ptr_array_add(paths, g_build_filename(home_dir, ".config", "systemd", "user", NULL));
-        g_ptr_array_add(paths, g_build_filename(home_dir, ".local", "share", "systemd", "user", NULL));
+
+    /* 1. XDG_RUNTIME_DIR/systemd/user if present */
+    const gchar *user_runtime = g_getenv("XDG_RUNTIME_DIR");
+    if (user_runtime && user_runtime[0] != '\0') {
+        gchar *runtime_path = g_build_filename(user_runtime, "systemd", "user", NULL);
+        g_ptr_array_add(paths, runtime_path);
     }
+
+    /* 2. XDG_CONFIG_HOME/systemd/user if present, otherwise ~/.config/systemd/user */
+    const gchar *user_config = g_getenv("XDG_CONFIG_HOME");
+    if (user_config && user_config[0] != '\0') {
+        gchar *config_path = g_build_filename(user_config, "systemd", "user", NULL);
+        g_ptr_array_add(paths, config_path);
+    } else if (home_dir) {
+        gchar *config_path = g_build_filename(home_dir, ".config", "systemd", "user", NULL);
+        g_ptr_array_add(paths, config_path);
+    }
+
+    /* 3. /etc/systemd/user before ~/.local/share/systemd/user */
     g_ptr_array_add(paths, g_strdup("/etc/systemd/user"));
     g_ptr_array_add(paths, g_strdup("/etc/xdg/systemd/user"));
+
+    /* 4. ~/.local/share/systemd/user */
+    if (home_dir) {
+        gchar *local_share_path = g_build_filename(home_dir, ".local", "share", "systemd", "user", NULL);
+        g_ptr_array_add(paths, local_share_path);
+    }
+
+    /* 5. System library paths */
     g_ptr_array_add(paths, g_strdup("/usr/lib/systemd/user"));
     g_ptr_array_add(paths, g_strdup("/usr/local/lib/systemd/user"));
     g_ptr_array_add(paths, g_strdup("/usr/share/systemd/user"));

--- a/apps/linux/src/tray.c
+++ b/apps/linux/src/tray.c
@@ -230,47 +230,70 @@ void tray_init(void) {
     g_subprocess_wait_async(helper_process, NULL, on_helper_exited, NULL);
 }
 
-static void send_to_helper(const gchar *cmd) {
-    if (!helper_stdin || !helper_process) {
-        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "send_to_helper skip stdin=%p process=%p",
-                  (void *)helper_stdin, (void *)helper_process);
-        return;
-    }
+static gboolean send_line_to_helper(const gchar *line, const gchar *log_line) {
+    if (!helper_stdin || !line) return FALSE;
+
     g_autoptr(GError) write_err = NULL;
     g_autoptr(GError) flush_err = NULL;
     gsize bytes_written = 0;
-    gboolean write_ok = g_output_stream_write_all(helper_stdin, cmd, strlen(cmd), &bytes_written, NULL, &write_err);
+    gboolean write_ok = g_output_stream_write_all(helper_stdin, line, strlen(line), &bytes_written, NULL, &write_err);
     gboolean flush_ok = g_output_stream_flush(helper_stdin, NULL, &flush_err);
     if (!write_ok || !flush_ok) {
-        OC_LOG_WARN(OPENCLAW_LOG_CAT_TRAY, "send_to_helper error write_ok=%d flush_ok=%d write_err=%s flush_err=%s stdin=%p",
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_TRAY, "send_line_to_helper error write_ok=%d flush_ok=%d write_err=%s flush_err=%s stdin=%p",
                   write_ok, flush_ok,
                   write_err ? write_err->message : "(none)",
                   flush_err ? flush_err->message : "(none)",
                   (void *)helper_stdin);
     } else {
-        OC_LOG_TRACE(OPENCLAW_LOG_CAT_TRAY, "send_to_helper ok bytes=%zu stdin=%p cmd='%.80s'",
-                  bytes_written, (void *)helper_stdin, cmd);
+        const gchar *log_str = log_line ? log_line : line;
+        OC_LOG_TRACE(OPENCLAW_LOG_CAT_TRAY, "send_line_to_helper ok bytes=%zu stdin=%p line='%s'",
+                  bytes_written, (void *)helper_stdin, log_str);
     }
+    return TRUE;
 }
 
-void tray_update_from_state(AppState state) {
-    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state entry state=%d helper_stdin=%p helper_process=%p",
-              state, (void *)helper_stdin, (void *)helper_process);
+static gchar* redact_dashboard_line_for_log(const gchar *line) {
+    if (!line) return NULL;
+    
+    /* Look for # fragment in DASHBOARD_URL line */
+    const gchar *hash = strchr(line, '#');
+    if (!hash) return NULL;  /* No fragment to redact - use original line */
+    
+    /* Build redacted version safely with g_strdup_printf */
+    return g_strdup_printf("%.*s#<redacted>\n", (int)(hash - line), line);
+}
 
-    if (!helper_stdin) {
-        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state skip (no stdin)");
-        return;
-    }
+void tray_update_from_state(const AppState state) {
+    if (!helper_stdin) return;
     
-    const char *status_str = state_get_current_string();
-    g_autofree gchar *cmd = g_strdup_printf("STATE:%s\n", status_str);
-    OC_LOG_TRACE(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state pre-send-state cmd='%.80s'", cmd);
-    send_to_helper(cmd);
+    /* Get systemd state via correct API */
+    SystemdState *sys = state_get_systemd();
     
-    // Determine action sensitivities based on strict 8-case state
+    /* A1: Compute service controllability - required for correct Stop/Restart gating.
+     * A service is controllable only if:
+     * - The unit is installed (we found a unit file)
+     * - Systemd is available (not in container/no D-Bus scenarios)
+     * - User has permission (implied by unit being in user unit path)
+     */
+    gboolean service_controllable = sys && sys->installed && !sys->systemd_unavailable;
+    
+    /* A2: Single authoritative STATE emission showing human-readable status.
+     * tray_helper.c uses this for the status menu item label.
+     */
+    const gchar *status_str = state_get_current_string();
+    g_autofree gchar *status_line = g_strdup_printf("STATE:%s\n", status_str);
+    send_line_to_helper(status_line, NULL);
+    
+    OC_LOG_TRACE(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state state=%s controllable=%d", 
+                 status_str, service_controllable);
+    
+    /* A3: Compute action sensitivities from BOTH app state AND service controllability.
+     * Stop/Restart are only sensitive if the service is actually controllable.
+     */
     gboolean can_start = FALSE;
     gboolean can_stop = FALSE;
     gboolean can_restart = FALSE;
+    gboolean can_open_dashboard = FALSE;
     
     switch (state) {
         case STATE_NEEDS_SETUP:
@@ -278,57 +301,68 @@ void tray_update_from_state(AppState state) {
         case STATE_USER_SYSTEMD_UNAVAILABLE:
         case STATE_SYSTEM_UNSUPPORTED:
         case STATE_CONFIG_INVALID:
+            /* No actions possible in these states */
             break;
         case STATE_STOPPED:
         case STATE_ERROR:
-            can_start = TRUE;
+            can_start = service_controllable;
             break;
         case STATE_STARTING:
-            can_stop = TRUE;
+            can_stop = service_controllable;
             break;
         case STATE_STOPPING:
+            /* In stopping state, no actions until settled */
             break;
         case STATE_RUNNING:
         case STATE_RUNNING_WITH_WARNING:
         case STATE_DEGRADED:
-            can_stop = TRUE;
-            can_restart = TRUE;
+            can_stop = service_controllable;
+            can_restart = service_controllable;
+            can_open_dashboard = TRUE;
             break;
     }
     
-    g_autofree gchar *cmd_start = g_strdup_printf("SENSITIVE:START:%d\n", can_start ? 1 : 0);
-    g_autofree gchar *cmd_stop = g_strdup_printf("SENSITIVE:STOP:%d\n", can_stop ? 1 : 0);
-    g_autofree gchar *cmd_restart = g_strdup_printf("SENSITIVE:RESTART:%d\n", can_restart ? 1 : 0);
+    /* A4: Send DASHBOARD_URL first (if available) with redacted logging.
+     * Send real URL to helper but redact token fragment in logs.
+     */
+    if (can_open_dashboard) {
+        GatewayConfig *cfg = gateway_client_get_config();
+        if (cfg) {
+            g_autofree gchar *url = gateway_config_dashboard_url(cfg);
+            if (url) {
+                g_autofree gchar *dashboard_line = g_strdup_printf("DASHBOARD_URL:%s\n", url);
+                gchar *redacted_for_log = redact_dashboard_line_for_log(dashboard_line);
+                send_line_to_helper(dashboard_line, redacted_for_log);
+                g_free(redacted_for_log);
+            }
+        }
+    }
     
-    OC_LOG_TRACE(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state pre-send-sensitive");
-    send_to_helper(cmd_start);
-    send_to_helper(cmd_stop);
-    send_to_helper(cmd_restart);
+    /* A5: Send SENSITIVE commands in exact format expected by tray_helper.c.
+     * Format: SENSITIVE:ACTION:0|1 (tray_helper.c parses with g_strsplit(line, ":", 3))
+     * Supported actions: START, STOP, RESTART, OPEN_DASHBOARD
+     */
+    g_autofree gchar *sensitive_start = g_strdup_printf("SENSITIVE:START:%d\n", can_start ? 1 : 0);
+    g_autofree gchar *sensitive_stop = g_strdup_printf("SENSITIVE:STOP:%d\n", can_stop ? 1 : 0);
+    g_autofree gchar *sensitive_restart = g_strdup_printf("SENSITIVE:RESTART:%d\n", can_restart ? 1 : 0);
+    g_autofree gchar *sensitive_dashboard = g_strdup_printf("SENSITIVE:OPEN_DASHBOARD:%d\n", can_open_dashboard ? 1 : 0);
+    
+    send_line_to_helper(sensitive_start, NULL);
+    send_line_to_helper(sensitive_stop, NULL);
+    send_line_to_helper(sensitive_restart, NULL);
+    send_line_to_helper(sensitive_dashboard, NULL);
 
-    /* Send runtime mode label */
+    /* A6: Send runtime mode label if available.
+     * tray_helper.c supports RUNTIME:<label> for the runtime menu item.
+     */
     RuntimeMode rm = state_get_runtime_mode();
     TrayDisplayModel tdm;
     HealthState *health = state_get_health();
     tray_display_model_build(state, rm, health, &tdm);
     if (tdm.runtime_label) {
-        g_autofree gchar *cmd_runtime = g_strdup_printf("RUNTIME:%s\n", tdm.runtime_label);
-        send_to_helper(cmd_runtime);
+        g_autofree gchar *runtime_line = g_strdup_printf("RUNTIME:%s\n", tdm.runtime_label);
+        send_line_to_helper(runtime_line, NULL);
     }
-
-    /* Send dashboard URL availability */
-    GatewayConfig *cfg = gateway_client_get_config();
-    if (cfg) {
-        g_autofree gchar *url = gateway_config_dashboard_url(cfg);
-        if (url) {
-            g_autofree gchar *cmd_url = g_strdup_printf("DASHBOARD_URL:%s\n", url);
-            send_to_helper(cmd_url);
-        }
-    }
-
-    /* Send Open Dashboard sensitivity */
-    g_autofree gchar *cmd_dash = g_strdup_printf("SENSITIVE:OPEN_DASHBOARD:%d\n",
-        tdm.open_dashboard_sensitive ? 1 : 0);
-    send_to_helper(cmd_dash);
 
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state exit");
 }

--- a/apps/linux/tests/test_gateway.c
+++ b/apps/linux/tests/test_gateway.c
@@ -576,7 +576,20 @@ static void test_protocol_parse_event(void) {
 }
 
 static void test_protocol_parse_response_ok(void) {
-    const gchar *json = "{\"type\":\"res\",\"id\":\"req-1\",\"payload\":{\"auth\":{\"source\":\"token\"},\"policy\":{\"tickIntervalMs\":25000}}}";
+    /* Valid hello-ok response per HelloOkSchema */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"auth\":{\"source\":\"token\"},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":25000}"
+        "}"
+        "}";
     GatewayFrame *frame = gateway_protocol_parse_frame(json);
     g_assert_nonnull(frame);
     g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
@@ -595,8 +608,19 @@ static void test_protocol_parse_response_ok(void) {
 }
 
 static void test_protocol_parse_response_ok_no_auth(void) {
-    /* Valid hello-ok but missing auth block entirely */
-    const gchar *json = "{\"type\":\"res\",\"id\":\"req-1\",\"payload\":{\"policy\":{\"tickIntervalMs\":25000}}}";
+    /* Valid hello-ok but missing auth block entirely - auth is optional per schema */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":25000}"
+        "}"
+        "}";
     GatewayFrame *frame = gateway_protocol_parse_frame(json);
     g_assert_nonnull(frame);
     g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
@@ -613,8 +637,19 @@ static void test_protocol_parse_response_ok_no_auth(void) {
 }
 
 static void test_protocol_parse_response_malformed_policy(void) {
-    /* Valid JSON, but policy is not an object */
-    const gchar *json = "{\"type\":\"res\",\"id\":\"req-1\",\"payload\":{\"policy\":\"invalid\"}}";
+    /* Valid JSON frame, but policy is not an object - missing required schema fields too */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":\"invalid\""
+        "}"
+        "}";
     GatewayFrame *frame = gateway_protocol_parse_frame(json);
     g_assert_nonnull(frame);
     
@@ -625,8 +660,20 @@ static void test_protocol_parse_response_malformed_policy(void) {
 }
 
 static void test_protocol_parse_response_malformed_auth(void) {
-    /* Valid JSON, but auth is not an object */
-    const gchar *json = "{\"type\":\"res\",\"id\":\"req-1\",\"payload\":{\"auth\":\"invalid\",\"policy\":{\"tickIntervalMs\":25000}}}";
+    /* Valid JSON frame, but auth is not an object */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"auth\":\"invalid\","
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":25000}"
+        "}"
+        "}";
     GatewayFrame *frame = gateway_protocol_parse_frame(json);
     g_assert_nonnull(frame);
     
@@ -822,6 +869,784 @@ static void test_protocol_build_connect_version_platform_always_present(void) {
     g_free(json);
 }
 
+/* ── Regression tests for L6: TLS and host correctness ── */
+
+static void test_config_tls_disabled_uses_http_ws(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"tls\":false}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    g_assert_false(config->tls_enabled);
+    
+    g_autofree gchar *http_url = gateway_config_http_url(config);
+    g_autofree gchar *ws_url = gateway_config_ws_url(config);
+    g_assert_cmpstr(http_url, ==, "http://127.0.0.1:18789");
+    g_assert_cmpstr(ws_url, ==, "ws://127.0.0.1:18789");
+    
+    gateway_config_free(config);
+
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_tls_enabled_uses_https_wss(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"tls\":true}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    g_assert_true(config->tls_enabled);
+    
+    g_autofree gchar *http_url = gateway_config_http_url(config);
+    g_autofree gchar *ws_url = gateway_config_ws_url(config);
+    g_autofree gchar *dash_url = gateway_config_dashboard_url(config);
+    g_assert_cmpstr(http_url, ==, "https://127.0.0.1:18789");
+    g_assert_cmpstr(ws_url, ==, "wss://127.0.0.1:18789");
+    g_assert_cmpstr(dash_url, ==, "https://127.0.0.1:18789/#token=tok");
+    
+    gateway_config_free(config);
+
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_host_from_config(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"host\":\"192.168.1.100\"}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    g_assert_cmpstr(config->host, ==, "192.168.1.100");
+    
+    g_autofree gchar *http_url = gateway_config_http_url(config);
+    g_assert_cmpstr(http_url, ==, "http://192.168.1.100:18789");
+    
+    gateway_config_free(config);
+
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_bind_fallback_ignores_0_0_0_0(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    /* 0.0.0.0 should be ignored and fall back to loopback */
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"bind\":\"0.0.0.0\"}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    /* 0.0.0.0 should fall back to default loopback */
+    g_assert_cmpstr(config->host, ==, "127.0.0.1");
+    
+    gateway_config_free(config);
+
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_tls_object_form(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    /* gateway.tls = { enabled: true } */
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"tls\":{\"enabled\":true}}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    g_assert_true(config->tls_enabled);
+    
+    gateway_config_free(config);
+
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_tls_from_security_block(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    /* gateway.security.tls = true */
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"security\":{\"tls\":true}}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    g_assert_true(config->tls_enabled);
+    
+    gateway_config_free(config);
+
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+/* ── Regression tests for hello-ok validation (BLOCKER B) ── */
+
+static void test_protocol_parse_hello_ok_valid(void) {
+    /* Valid hello-ok response per HelloOkSchema - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":30000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    gchar *auth_source = NULL;
+    gdouble tick_interval_ms = 0;
+    g_assert_true(gateway_protocol_parse_hello_ok(frame, &auth_source, &tick_interval_ms));
+    g_assert_cmpfloat(tick_interval_ms, ==, 30000.0);
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_missing_type(void) {
+    /* hello-ok without type field should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":30000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_wrong_type(void) {
+    /* hello-ok with wrong type value should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"goodbye\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":30000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_zero_tick_interval(void) {
+    /* hello-ok with tickIntervalMs=0 should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":0}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_negative_tick_interval(void) {
+    /* hello-ok with negative tickIntervalMs should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":-1000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_missing_tick_interval(void) {
+    /* hello-ok without tickIntervalMs should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_missing_server_version(void) {
+    /* hello-ok missing server.version should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":25000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_missing_server_conn_id(void) {
+    /* hello-ok missing server.connId should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":25000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_features_methods_not_array(void) {
+    /* hello-ok with features.methods not an array should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":\"bad\",\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":25000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_features_events_not_array(void) {
+    /* hello-ok with features.events not an array should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":{}},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":25000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_tick_interval_wrong_type(void) {
+    /* hello-ok with tickIntervalMs as string should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":\"30000\"}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_max_payload_wrong_type(void) {
+    /* hello-ok with maxPayload as string should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":\"1000000\",\"maxBufferedBytes\":5000000,\"tickIntervalMs\":25000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_max_buffered_wrong_type(void) {
+    /* hello-ok with maxBufferedBytes as string should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":\"5000000\",\"tickIntervalMs\":25000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_protocol_string_rejected(void) {
+    /* hello-ok with protocol as string should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":\"1\","
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":25000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_protocol_double_rejected(void) {
+    /* hello-ok with protocol as double should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1.5,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":25000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_max_payload_double_rejected(void) {
+    /* hello-ok with maxPayload as double should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000.5,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":25000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_max_buffered_double_rejected(void) {
+    /* hello-ok with maxBufferedBytes as double should fail - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000.5,\"tickIntervalMs\":25000}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    g_assert_false(gateway_protocol_parse_hello_ok(frame, NULL, NULL));
+    
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_hello_ok_tick_interval_double_accepted(void) {
+    /* hello-ok with tickIntervalMs as double should succeed and preserve value - wrapped in res frame */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":25000.5}"
+        "}"
+        "}";
+    
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_null(frame->error);
+
+    gdouble tick_interval_ms = 0;
+    g_assert_true(gateway_protocol_parse_hello_ok(frame, NULL, &tick_interval_ms));
+    g_assert_cmpfloat(tick_interval_ms, ==, 25000.5);
+    
+    gateway_frame_free(frame);
+}
+
+/* ── Regression tests for URL route fragment preservation ── */
+
+/* Helper that mirrors dashboard_url_with_route logic from section_sessions.c */
+static gchar* test_dashboard_url_with_route(const gchar *base_url, const gchar *route) {
+    if (!base_url || !route) return NULL;
+    
+    const gchar *fragment = strchr(base_url, '#');
+    if (fragment) {
+        gsize base_len = fragment - base_url;
+        gboolean needs_slash = (base_len == 0 || base_url[base_len - 1] != '/');
+        return g_strdup_printf("%.*s%s%s%s",
+                              (int)base_len, base_url,
+                              needs_slash ? "/" : "",
+                              route, fragment);
+    } else {
+        gboolean needs_slash = base_url[strlen(base_url) - 1] != '/';
+        return g_strdup_printf("%s%s%s",
+                              base_url,
+                              needs_slash ? "/" : "",
+                              route);
+    }
+}
+
+static void test_dashboard_url_with_route_preserves_fragment(void) {
+    /* Base URL with token fragment */
+    g_autofree gchar *url1 = test_dashboard_url_with_route(
+        "http://127.0.0.1:18789/#token=abc123", "chat/session-1");
+    g_assert_cmpstr(url1, ==, "http://127.0.0.1:18789/chat/session-1#token=abc123");
+    
+    /* Base URL with path and fragment */
+    g_autofree gchar *url2 = test_dashboard_url_with_route(
+        "http://127.0.0.1:18789/ui/#token=xyz789", "chat/session-2");
+    g_assert_cmpstr(url2, ==, "http://127.0.0.1:18789/ui/chat/session-2#token=xyz789");
+}
+
+static void test_dashboard_url_with_route_without_fragment(void) {
+    /* Base URL with trailing slash, no fragment */
+    g_autofree gchar *url1 = test_dashboard_url_with_route(
+        "http://127.0.0.1:18789/", "chat/session-1");
+    g_assert_cmpstr(url1, ==, "http://127.0.0.1:18789/chat/session-1");
+    
+    /* Base URL without trailing slash, no fragment */
+    g_autofree gchar *url2 = test_dashboard_url_with_route(
+        "http://127.0.0.1:18789", "chat/session-1");
+    g_assert_cmpstr(url2, ==, "http://127.0.0.1:18789/chat/session-1");
+}
+
+/* ── Regression tests for config equivalence with TLS ── */
+
+static void test_config_equivalent_tls_differs(void) {
+    /* Two configs identical except TLS setting should NOT be equivalent */
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path1 = g_build_filename(tmpdir, "config1.json", NULL);
+    g_autofree gchar *config_path2 = g_build_filename(tmpdir, "config2.json", NULL);
+    
+    g_file_set_contents(config_path1,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"host\":\"127.0.0.1\",\"port\":18789,\"tls\":false}}", -1, NULL);
+    g_file_set_contents(config_path2,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"host\":\"127.0.0.1\",\"port\":18789,\"tls\":true}}", -1, NULL);
+    
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path1, TRUE);
+    GatewayConfig *cfg1 = gateway_config_load(NULL);
+    g_assert_nonnull(cfg1);
+    g_assert_true(cfg1->valid);
+    g_assert_false(cfg1->tls_enabled);
+    
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path2, TRUE);
+    GatewayConfig *cfg2 = gateway_config_load(NULL);
+    g_assert_nonnull(cfg2);
+    g_assert_true(cfg2->valid);
+    g_assert_true(cfg2->tls_enabled);
+    
+    /* TLS differs, should NOT be equivalent */
+    g_assert_false(gateway_config_equivalent(cfg1, cfg2));
+    
+    gateway_config_free(cfg1);
+    gateway_config_free(cfg2);
+    g_unlink(config_path1);
+    g_unlink(config_path2);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_equivalent_tls_same(void) {
+    /* Two identical configs including TLS should be equivalent */
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path1 = g_build_filename(tmpdir, "config1.json", NULL);
+    g_autofree gchar *config_path2 = g_build_filename(tmpdir, "config2.json", NULL);
+    
+    g_file_set_contents(config_path1,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"host\":\"127.0.0.1\",\"port\":18789,\"tls\":true}}", -1, NULL);
+    g_file_set_contents(config_path2,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"host\":\"127.0.0.1\",\"port\":18789,\"tls\":true}}", -1, NULL);
+    
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path1, TRUE);
+    GatewayConfig *cfg1 = gateway_config_load(NULL);
+    g_assert_nonnull(cfg1);
+    g_assert_true(cfg1->valid);
+    
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path2, TRUE);
+    GatewayConfig *cfg2 = gateway_config_load(NULL);
+    g_assert_nonnull(cfg2);
+    g_assert_true(cfg2->valid);
+    
+    /* Identical configs should be equivalent */
+    g_assert_true(gateway_config_equivalent(cfg1, cfg2));
+    
+    gateway_config_free(cfg1);
+    gateway_config_free(cfg2);
+    g_unlink(config_path1);
+    g_unlink(config_path2);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+/* ── Regression tests for gateway.bind safety ── */
+
+static void test_config_bind_ipv4_literal_used(void) {
+    /* A specific IPv4 bind address should be usable as host fallback */
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"bind\":\"192.168.1.50\"}}", -1, NULL);
+    
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+    
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    /* bind = specific IPv4 should be used as host */
+    g_assert_cmpstr(config->host, ==, "192.168.1.50");
+    
+    gateway_config_free(config);
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_bind_ipv6_unspecified_rejected(void) {
+    /* IPv6 unspecified address :: should be rejected and fall back to loopback */
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"bind\":\"::\"}}", -1, NULL);
+    
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+    
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    /* :: should fall back to default loopback */
+    g_assert_cmpstr(config->host, ==, "127.0.0.1");
+    
+    gateway_config_free(config);
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
 int main(int argc, char **argv) {
     g_test_init(&argc, &argv, NULL);
 
@@ -868,6 +1693,50 @@ int main(int argc, char **argv) {
     g_test_add_func("/gateway/protocol/build_connect_password_mode", test_protocol_build_connect_password_mode);
     g_test_add_func("/gateway/protocol/build_connect_none_mode", test_protocol_build_connect_none_mode);
     g_test_add_func("/gateway/protocol/build_connect_version_platform_always_present", test_protocol_build_connect_version_platform_always_present);
+
+    /* hello-ok validation tests (BLOCKER B) */
+    g_test_add_func("/gateway/protocol/parse_hello_ok_valid", test_protocol_parse_hello_ok_valid);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_missing_type", test_protocol_parse_hello_ok_missing_type);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_wrong_type", test_protocol_parse_hello_ok_wrong_type);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_zero_tick_interval", test_protocol_parse_hello_ok_zero_tick_interval);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_negative_tick_interval", test_protocol_parse_hello_ok_negative_tick_interval);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_missing_tick_interval", test_protocol_parse_hello_ok_missing_tick_interval);
+
+    /* hello-ok strict type validation tests (BLOCKER 2) */
+    g_test_add_func("/gateway/protocol/parse_hello_ok_missing_server_version", test_protocol_parse_hello_ok_missing_server_version);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_missing_server_conn_id", test_protocol_parse_hello_ok_missing_server_conn_id);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_features_methods_not_array", test_protocol_parse_hello_ok_features_methods_not_array);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_features_events_not_array", test_protocol_parse_hello_ok_features_events_not_array);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_tick_interval_wrong_type", test_protocol_parse_hello_ok_tick_interval_wrong_type);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_max_payload_wrong_type", test_protocol_parse_hello_ok_max_payload_wrong_type);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_max_buffered_wrong_type", test_protocol_parse_hello_ok_max_buffered_wrong_type);
+
+    /* hello-ok integer-only validation tests */
+    g_test_add_func("/gateway/protocol/parse_hello_ok_protocol_string_rejected", test_protocol_parse_hello_ok_protocol_string_rejected);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_protocol_double_rejected", test_protocol_parse_hello_ok_protocol_double_rejected);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_max_payload_double_rejected", test_protocol_parse_hello_ok_max_payload_double_rejected);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_max_buffered_double_rejected", test_protocol_parse_hello_ok_max_buffered_double_rejected);
+    g_test_add_func("/gateway/protocol/parse_hello_ok_tick_interval_double_accepted", test_protocol_parse_hello_ok_tick_interval_double_accepted);
+
+    /* L6: TLS and host correctness regression tests */
+    g_test_add_func("/gateway/config/tls_disabled_uses_http_ws", test_config_tls_disabled_uses_http_ws);
+    g_test_add_func("/gateway/config/tls_enabled_uses_https_wss", test_config_tls_enabled_uses_https_wss);
+    g_test_add_func("/gateway/config/host_from_config", test_config_host_from_config);
+    g_test_add_func("/gateway/config/bind_fallback_ignores_0_0_0_0", test_config_bind_fallback_ignores_0_0_0_0);
+    g_test_add_func("/gateway/config/tls_object_form", test_config_tls_object_form);
+    g_test_add_func("/gateway/config/tls_from_security_block", test_config_tls_from_security_block);
+
+    /* URL route fragment preservation tests */
+    g_test_add_func("/gateway/url_route/preserves_fragment", test_dashboard_url_with_route_preserves_fragment);
+    g_test_add_func("/gateway/url_route/without_fragment", test_dashboard_url_with_route_without_fragment);
+
+    /* Config equivalence TLS tests */
+    g_test_add_func("/gateway/config/equiv_tls_differs", test_config_equivalent_tls_differs);
+    g_test_add_func("/gateway/config/equiv_tls_same", test_config_equivalent_tls_same);
+
+    /* gateway.bind safety tests */
+    g_test_add_func("/gateway/config/bind_ipv4_literal_used", test_config_bind_ipv4_literal_used);
+    g_test_add_func("/gateway/config/bind_ipv6_unspecified_rejected", test_config_bind_ipv6_unspecified_rejected);
 
     return g_test_run();
 }


### PR DESCRIPTION
Strengthen the Linux companion across config resolution, transport handling, systemd integration, tray/helper IPC, dashboard routing, and protocol validation.

* preserve active config_path on equivalent config refreshes
* reject malformed gateway/auth/mode/port config shapes
* reject ambiguous auth without explicit mode
* correct legacy moltbot config fallback naming
* resolve effective host and TLS into HTTP/WS/dashboard URLs
* include tls_enabled in config equivalence
* zero token/password before free in config and WS lifecycle
* add finite timeout to HTTP health probes
* fail RPC requests fast when WS send is rejected
* ignore stale WebSocket callbacks from superseded transports
* keep reconnect recoverable after auth rejection
* clamp negotiated tick interval before use
* strictly validate hello-ok payload shape and types
* fix JsonNode ownership in Channels config-save flow
* preserve dashboard token fragment when adding transcript routes
* prevent stale Cron RPC responses from overwriting newer refreshes
* surface Sessions/Skills disconnect state before freshness TTL
* distinguish transient D-Bus failures from real unloaded/not-installed states
* invalidate cached service config on unit retarget
* fix UnitNew parsing to avoid null output pointer misuse
* reorder systemd user-unit search paths and tighten legacy unit matching
* restore exact tray helper line protocol, dashboard URL emission, and redacted dashboard logging
* add regression tests for hello-ok validation, TLS/host resolution, config equivalence, bind safety, and dashboard route composition