### PR TITLE
refactor(linux): deduplicate dashboard route URL helper (#56)

### DIFF
--- a/apps/linux/src/gateway_config.c
+++ b/apps/linux/src/gateway_config.c
@@ -647,3 +647,35 @@ gchar* gateway_config_dashboard_url(const GatewayConfig *config) {
 
     return g_strdup(base);
 }
+
+/*
+ * Build a dashboard URL with a specific route inserted before the fragment.
+ *
+ * If base_url contains a '#' fragment marker, the route is inserted before it.
+ * Otherwise, the route is appended to the base URL. Handles slash normalization.
+ *
+ * Returns NULL if base_url or route is NULL.
+ */
+gchar* gateway_config_dashboard_url_with_route(const gchar *base_url, const gchar *route) {
+    if (!base_url || !route) return NULL;
+
+    /* Find fragment marker */
+    const gchar *fragment = strchr(base_url, '#');
+    if (fragment) {
+        /* Insert route before fragment */
+        gsize base_len = fragment - base_url;
+        /* Ensure base ends with / */
+        gboolean needs_slash = (base_len == 0 || base_url[base_len - 1] != '/');
+        return g_strdup_printf("%.*s%s%s%s",
+                              (int)base_len, base_url,
+                              needs_slash ? "/" : "",
+                              route, fragment);
+    } else {
+        /* No fragment, append route normally */
+        gboolean needs_slash = base_url[strlen(base_url) - 1] != '/';
+        return g_strdup_printf("%s%s%s",
+                              base_url,
+                              needs_slash ? "/" : "",
+                              route);
+    }
+}

--- a/apps/linux/src/gateway_config.h
+++ b/apps/linux/src/gateway_config.h
@@ -72,5 +72,6 @@ gchar* gateway_config_http_url(const GatewayConfig *config);
 gchar* gateway_config_ws_url(const GatewayConfig *config);
 gboolean gateway_config_equivalent(const GatewayConfig *a, const GatewayConfig *b);
 gchar* gateway_config_dashboard_url(const GatewayConfig *config);
+gchar* gateway_config_dashboard_url_with_route(const gchar *base_url, const gchar *route);
 
 #endif /* OPENCLAW_LINUX_GATEWAY_CONFIG_H */

--- a/apps/linux/src/section_cron.c
+++ b/apps/linux/src/section_cron.c
@@ -141,31 +141,6 @@ static void on_delete(GtkButton *btn, gpointer user_data) {
     adw_alert_dialog_choose(dialog, toplevel, NULL, on_delete_dialog_response, NULL);
 }
 
-/* G1: Helper to insert route before #token fragment */
-static gchar* dashboard_url_with_route(const gchar *base_url, const gchar *route) {
-    if (!base_url || !route) return NULL;
-    
-    /* Find fragment marker */
-    const gchar *fragment = strchr(base_url, '#');
-    if (fragment) {
-        /* Insert route before fragment */
-        gsize base_len = fragment - base_url;
-        /* Ensure base ends with / */
-        gboolean needs_slash = (base_len == 0 || base_url[base_len - 1] != '/');
-        return g_strdup_printf("%.*s%s%s%s",
-                              (int)base_len, base_url,
-                              needs_slash ? "/" : "",
-                              route, fragment);
-    } else {
-        /* No fragment, append route normally */
-        gboolean needs_slash = base_url[strlen(base_url) - 1] != '/';
-        return g_strdup_printf("%s%s%s",
-                              base_url,
-                              needs_slash ? "/" : "",
-                              route);
-    }
-}
-
 static void on_open_transcript(GtkButton *btn, gpointer user_data) {
     (void)user_data;
     const gchar *key = (const gchar *)g_object_get_data(G_OBJECT(btn), "session-key");
@@ -197,7 +172,7 @@ static void on_open_transcript(GtkButton *btn, gpointer user_data) {
 
     /* Dashboard route for session logs: chat/:sessionKey */
     g_autofree gchar *route = g_strdup_printf("chat/%s", key);
-    g_autofree gchar *log_url = dashboard_url_with_route(url, route);
+    g_autofree gchar *log_url = gateway_config_dashboard_url_with_route(url, route);
     if (log_url) {
         g_app_info_launch_default_for_uri(log_url, NULL, NULL);
     }

--- a/apps/linux/src/section_sessions.c
+++ b/apps/linux/src/section_sessions.c
@@ -173,31 +173,6 @@ static void on_session_delete(GtkButton *btn, gpointer user_data) {
     adw_alert_dialog_choose(dialog, toplevel, NULL, on_delete_dialog_response, NULL);
 }
 
-/* G1: Helper to insert route before #token fragment */
-static gchar* dashboard_url_with_route(const gchar *base_url, const gchar *route) {
-    if (!base_url || !route) return NULL;
-    
-    /* Find fragment marker */
-    const gchar *fragment = strchr(base_url, '#');
-    if (fragment) {
-        /* Insert route before fragment */
-        gsize base_len = fragment - base_url;
-        /* Ensure base ends with / */
-        gboolean needs_slash = (base_len == 0 || base_url[base_len - 1] != '/');
-        return g_strdup_printf("%.*s%s%s%s",
-                              (int)base_len, base_url,
-                              needs_slash ? "/" : "",
-                              route, fragment);
-    } else {
-        /* No fragment, append route normally */
-        gboolean needs_slash = base_url[strlen(base_url) - 1] != '/';
-        return g_strdup_printf("%s%s%s",
-                              base_url,
-                              needs_slash ? "/" : "",
-                              route);
-    }
-}
-
 static void on_session_log(GtkButton *btn, gpointer user_data) {
     (void)user_data;
     const gchar *key = (const gchar *)g_object_get_data(G_OBJECT(btn), "session-key");
@@ -228,7 +203,7 @@ static void on_session_log(GtkButton *btn, gpointer user_data) {
 
     /* Dashboard route for session logs: chat/:sessionKey */
     g_autofree gchar *route = g_strdup_printf("chat/%s", key);
-    g_autofree gchar *log_url = dashboard_url_with_route(url, route);
+    g_autofree gchar *log_url = gateway_config_dashboard_url_with_route(url, route);
     if (log_url) {
         g_app_info_launch_default_for_uri(log_url, NULL, NULL);
     }

--- a/apps/linux/tests/test_gateway.c
+++ b/apps/linux/tests/test_gateway.c
@@ -1480,47 +1480,26 @@ static void test_protocol_parse_hello_ok_tick_interval_double_accepted(void) {
 
 /* ── Regression tests for URL route fragment preservation ── */
 
-/* Helper that mirrors dashboard_url_with_route logic from section_sessions.c */
-static gchar* test_dashboard_url_with_route(const gchar *base_url, const gchar *route) {
-    if (!base_url || !route) return NULL;
-    
-    const gchar *fragment = strchr(base_url, '#');
-    if (fragment) {
-        gsize base_len = fragment - base_url;
-        gboolean needs_slash = (base_len == 0 || base_url[base_len - 1] != '/');
-        return g_strdup_printf("%.*s%s%s%s",
-                              (int)base_len, base_url,
-                              needs_slash ? "/" : "",
-                              route, fragment);
-    } else {
-        gboolean needs_slash = base_url[strlen(base_url) - 1] != '/';
-        return g_strdup_printf("%s%s%s",
-                              base_url,
-                              needs_slash ? "/" : "",
-                              route);
-    }
-}
-
 static void test_dashboard_url_with_route_preserves_fragment(void) {
     /* Base URL with token fragment */
-    g_autofree gchar *url1 = test_dashboard_url_with_route(
+    g_autofree gchar *url1 = gateway_config_dashboard_url_with_route(
         "http://127.0.0.1:18789/#token=abc123", "chat/session-1");
     g_assert_cmpstr(url1, ==, "http://127.0.0.1:18789/chat/session-1#token=abc123");
     
     /* Base URL with path and fragment */
-    g_autofree gchar *url2 = test_dashboard_url_with_route(
+    g_autofree gchar *url2 = gateway_config_dashboard_url_with_route(
         "http://127.0.0.1:18789/ui/#token=xyz789", "chat/session-2");
     g_assert_cmpstr(url2, ==, "http://127.0.0.1:18789/ui/chat/session-2#token=xyz789");
 }
 
 static void test_dashboard_url_with_route_without_fragment(void) {
     /* Base URL with trailing slash, no fragment */
-    g_autofree gchar *url1 = test_dashboard_url_with_route(
+    g_autofree gchar *url1 = gateway_config_dashboard_url_with_route(
         "http://127.0.0.1:18789/", "chat/session-1");
     g_assert_cmpstr(url1, ==, "http://127.0.0.1:18789/chat/session-1");
     
     /* Base URL without trailing slash, no fragment */
-    g_autofree gchar *url2 = test_dashboard_url_with_route(
+    g_autofree gchar *url2 = gateway_config_dashboard_url_with_route(
         "http://127.0.0.1:18789", "chat/session-1");
     g_assert_cmpstr(url2, ==, "http://127.0.0.1:18789/chat/session-1");
 }


### PR DESCRIPTION
Move dashboard route composition into gateway_config as a shared public utility and remove duplicated local implementations from section_cron and section_sessions.

Update route-composition regression tests to call the production helper directly instead of mirroring the logic in a local test function.

This keeps dashboard URL behavior unchanged while reducing duplication, improving cohesion, and ensuring tests validate the real implementation.
