### PR TITLE
fix(linux): harden JSON string ingress validation (#64)

### DIFF
--- a/apps/linux/src/chat_blocks.c
+++ b/apps/linux/src/chat_blocks.c
@@ -8,6 +8,14 @@
 
 #include <string.h>
 
+static const gchar* chat_blocks_string_member(JsonObject *obj, const gchar *member) {
+    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
+    JsonNode *node = json_object_get_member(obj, member);
+    if (!node || !JSON_NODE_HOLDS_VALUE(node)) return NULL;
+    if (json_node_get_value_type(node) != G_TYPE_STRING) return NULL;
+    return json_node_get_string(node);
+}
+
 void chat_block_free(ChatBlock *block) {
     if (!block) return;
     g_free(block->text);
@@ -25,32 +33,22 @@ static ChatBlock* chat_block_new(ChatBlockType type, const gchar *text) {
 
 static void append_block_from_object(GPtrArray *out, JsonObject *obj) {
     g_autofree gchar *type = NULL;
-    if (json_object_has_member(obj, "type")) {
-        JsonNode *tn = json_object_get_member(obj, "type");
-        if (tn && json_node_get_value_type(tn) == G_TYPE_STRING) {
-            type = g_strdup(json_node_get_string(tn));
-        }
-    }
+    type = g_strdup(chat_blocks_string_member(obj, "type"));
 
     if (!type) {
         return;
     }
 
     if (g_strcmp0(type, "text") == 0 || g_strcmp0(type, "output_text") == 0) {
-        const gchar *text = NULL;
-        if (json_object_has_member(obj, "text")) {
-            text = json_object_get_string_member(obj, "text");
-        }
+        const gchar *text = chat_blocks_string_member(obj, "text");
         g_ptr_array_add(out, chat_block_new(CHAT_BLOCK_TEXT, text ? text : ""));
         return;
     }
 
     if (g_strcmp0(type, "thinking") == 0 || g_strcmp0(type, "reasoning") == 0) {
-        const gchar *text = NULL;
-        if (json_object_has_member(obj, "text")) {
-            text = json_object_get_string_member(obj, "text");
-        } else if (json_object_has_member(obj, "thinking")) {
-            text = json_object_get_string_member(obj, "thinking");
+        const gchar *text = chat_blocks_string_member(obj, "text");
+        if (!text) {
+            text = chat_blocks_string_member(obj, "thinking");
         }
         g_ptr_array_add(out, chat_block_new(CHAT_BLOCK_THINKING, text ? text : ""));
         return;
@@ -58,9 +56,7 @@ static void append_block_from_object(GPtrArray *out, JsonObject *obj) {
 
     if (g_strcmp0(type, "tool_use") == 0) {
         ChatBlock *b = chat_block_new(CHAT_BLOCK_TOOL_USE, "");
-        if (json_object_has_member(obj, "name")) {
-            b->tool_name = g_strdup(json_object_get_string_member(obj, "name"));
-        }
+        b->tool_name = g_strdup(chat_blocks_string_member(obj, "name"));
         if (json_object_has_member(obj, "input")) {
             JsonNode *input = json_object_get_member(obj, "input");
             if (JSON_NODE_HOLDS_VALUE(input) && json_node_get_value_type(input) == G_TYPE_STRING) {

--- a/apps/linux/src/gateway_protocol.c
+++ b/apps/linux/src/gateway_protocol.c
@@ -16,6 +16,21 @@
 #include "log.h"
 #include <string.h>
 
+static const gchar* json_object_get_member_string_typed(JsonObject *obj, const gchar *member) {
+    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
+    JsonNode *node = json_object_get_member(obj, member);
+    if (!node || !JSON_NODE_HOLDS_VALUE(node)) return NULL;
+    if (json_node_get_value_type(node) != G_TYPE_STRING) return NULL;
+    return json_node_get_string(node);
+}
+
+static JsonObject* json_object_get_member_object_typed(JsonObject *obj, const gchar *member) {
+    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
+    JsonNode *node = json_object_get_member(obj, member);
+    if (!node || !JSON_NODE_HOLDS_OBJECT(node)) return NULL;
+    return json_node_get_object(node);
+}
+
 GatewayFrame* gateway_protocol_parse_frame(const gchar *json_str) {
     if (!json_str) return NULL;
 
@@ -36,38 +51,32 @@ GatewayFrame* gateway_protocol_parse_frame(const gchar *json_str) {
         return NULL;
     }
 
-    const gchar *type_str = json_object_get_string_member(obj, "type");
+    const gchar *type_str = json_object_get_member_string_typed(obj, "type");
     if (!type_str) return NULL;
 
     GatewayFrame *frame = g_new0(GatewayFrame, 1);
 
     if (g_strcmp0(type_str, "req") == 0) {
         frame->type = GATEWAY_FRAME_REQ;
-        if (json_object_has_member(obj, "id"))
-            frame->id = g_strdup(json_object_get_string_member(obj, "id"));
-        if (json_object_has_member(obj, "method"))
-            frame->method = g_strdup(json_object_get_string_member(obj, "method"));
+        frame->id = g_strdup(json_object_get_member_string_typed(obj, "id"));
+        frame->method = g_strdup(json_object_get_member_string_typed(obj, "method"));
         if (json_object_has_member(obj, "params"))
             frame->payload = json_node_copy(json_object_get_member(obj, "params"));
     } else if (g_strcmp0(type_str, "res") == 0) {
         frame->type = GATEWAY_FRAME_RES;
-        if (json_object_has_member(obj, "id"))
-            frame->id = g_strdup(json_object_get_string_member(obj, "id"));
+        frame->id = g_strdup(json_object_get_member_string_typed(obj, "id"));
         if (json_object_has_member(obj, "error")) {
-            JsonObject *err_obj = json_object_get_object_member(obj, "error");
+            JsonObject *err_obj = json_object_get_member_object_typed(obj, "error");
             if (err_obj) {
-                if (json_object_has_member(err_obj, "code"))
-                    frame->code = g_strdup(json_object_get_string_member(err_obj, "code"));
-                if (json_object_has_member(err_obj, "message"))
-                    frame->error = g_strdup(json_object_get_string_member(err_obj, "message"));
+                frame->code = g_strdup(json_object_get_member_string_typed(err_obj, "code"));
+                frame->error = g_strdup(json_object_get_member_string_typed(err_obj, "message"));
             }
         }
         if (json_object_has_member(obj, "payload"))
             frame->payload = json_node_copy(json_object_get_member(obj, "payload"));
     } else if (g_strcmp0(type_str, "event") == 0) {
         frame->type = GATEWAY_FRAME_EVENT;
-        if (json_object_has_member(obj, "event"))
-            frame->event_type = g_strdup(json_object_get_string_member(obj, "event"));
+        frame->event_type = g_strdup(json_object_get_member_string_typed(obj, "event"));
         if (json_object_has_member(obj, "payload"))
             frame->payload = json_node_copy(json_object_get_member(obj, "payload"));
     } else {
@@ -206,11 +215,9 @@ gchar* gateway_protocol_extract_challenge_nonce(const GatewayFrame *frame) {
     if (!frame->payload || !JSON_NODE_HOLDS_OBJECT(frame->payload)) return NULL;
 
     JsonObject *obj = json_node_get_object(frame->payload);
-    if (json_object_has_member(obj, "nonce")) {
-        const gchar *nonce = json_object_get_string_member(obj, "nonce");
-        if (nonce && nonce[0] != '\0') {
-            return g_strdup(nonce);
-        }
+    const gchar *nonce = json_object_get_member_string_typed(obj, "nonce");
+    if (nonce && nonce[0] != '\0') {
+        return g_strdup(nonce);
     }
     return NULL;
 }
@@ -275,7 +282,7 @@ gboolean gateway_protocol_parse_hello_ok(const GatewayFrame *frame,
     if (!json_object_has_member(obj, "type")) {
         return FALSE;
     }
-    const gchar *type_str = json_object_get_string_member(obj, "type");
+    const gchar *type_str = json_object_get_member_string_typed(obj, "type");
     if (g_strcmp0(type_str, "hello-ok") != 0) {
         return FALSE;
     }
@@ -352,8 +359,8 @@ gboolean gateway_protocol_parse_hello_ok(const GatewayFrame *frame,
 
     if (out_auth_source) {
         *out_auth_source = NULL;
-        if (auth && json_object_has_member(auth, "source")) {
-            *out_auth_source = g_strdup(json_object_get_string_member(auth, "source"));
+        if (auth) {
+            *out_auth_source = g_strdup(json_object_get_member_string_typed(auth, "source"));
         }
     }
 

--- a/apps/linux/src/section_chat.c
+++ b/apps/linux/src/section_chat.c
@@ -160,9 +160,10 @@ static void chat_append_line(const gchar *text, const gchar *css_class) {
 }
 
 static void chat_render_message_object(JsonObject *msg_obj, gboolean is_pending) {
-    const gchar *role = json_object_has_member(msg_obj, "role")
-                            ? json_object_get_string_member(msg_obj, "role")
-                            : "assistant";
+    const gchar *role = chat_json_string_member(msg_obj, "role");
+    if (!role || role[0] == '\0') {
+        role = "assistant";
+    }
 
     g_autofree gchar *role_title = g_strdup_printf("%s%s", role, is_pending ? " (streaming)" : "");
     GtkWidget *role_label = gtk_label_new(role_title);

--- a/apps/linux/tests/test_chat_blocks.c
+++ b/apps/linux/tests/test_chat_blocks.c
@@ -75,6 +75,38 @@ static void test_plain_text_extraction(void) {
     json_node_unref(n);
 }
 
+static void test_malformed_string_fields(void) {
+    JsonNode *n = parse_json(
+        "["
+        "{\"type\":123,\"text\":\"hi\"},"
+        "{\"type\":\"text\",\"text\":123},"
+        "{\"type\":\"thinking\",\"thinking\":123},"
+        "{\"type\":\"tool_use\",\"name\":123,\"input\":{}}"
+        "]"
+    );
+
+    g_autoptr(GPtrArray) blocks = chat_blocks_extract(n);
+    g_assert_cmpint((gint)blocks->len, ==, 3);
+
+    ChatBlock *b0 = g_ptr_array_index(blocks, 0);
+    ChatBlock *b1 = g_ptr_array_index(blocks, 1);
+    ChatBlock *b2 = g_ptr_array_index(blocks, 2);
+
+    g_assert_cmpint(b0->type, ==, CHAT_BLOCK_TEXT);
+    g_assert_cmpstr(b0->text, ==, "");
+
+    g_assert_cmpint(b1->type, ==, CHAT_BLOCK_THINKING);
+    g_assert_cmpstr(b1->text, ==, "");
+
+    g_assert_cmpint(b2->type, ==, CHAT_BLOCK_TOOL_USE);
+    g_assert_cmpstr(b2->tool_name, ==, "tool");
+    g_assert_nonnull(b2->tool_input);
+    g_assert_true(g_str_has_prefix(b2->text, "tool("));
+    g_assert_true(g_str_has_suffix(b2->text, ")"));
+
+    json_node_unref(n);
+}
+
 int main(int argc, char **argv) {
     g_test_init(&argc, &argv, NULL);
 
@@ -82,6 +114,7 @@ int main(int argc, char **argv) {
     g_test_add_func("/chat_blocks/legacy_string", test_legacy_plain_string);
     g_test_add_func("/chat_blocks/structured", test_structured_blocks);
     g_test_add_func("/chat_blocks/plain_text", test_plain_text_extraction);
+    g_test_add_func("/chat_blocks/malformed_string_fields", test_malformed_string_fields);
 
     return g_test_run();
 }

--- a/apps/linux/tests/test_gateway.c
+++ b/apps/linux/tests/test_gateway.c
@@ -595,6 +595,60 @@ static void test_protocol_parse_event(void) {
     gateway_frame_free(frame);
 }
 
+static void test_protocol_parse_type_non_string_rejected(void) {
+    const gchar *json = "{\"type\":123,\"id\":\"x\"}";
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_null(frame);
+}
+
+static void test_protocol_parse_optional_strings_invalid_ignored(void) {
+    const gchar *json = "{\"type\":\"req\",\"id\":123,\"method\":456,\"params\":{}}";
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_REQ);
+    g_assert_null(frame->id);
+    g_assert_null(frame->method);
+    g_assert_nonnull(frame->payload);
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_event_name_invalid_ignored(void) {
+    const gchar *json = "{\"type\":\"event\",\"event\":123,\"payload\":{\"nonce\":\"abc123\"}}";
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_EVENT);
+    g_assert_null(frame->event_type);
+
+    gchar *nonce = gateway_protocol_extract_challenge_nonce(frame);
+    g_assert_null(nonce);
+
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_response_error_strings_invalid_ignored(void) {
+    const gchar *json = "{\"type\":\"res\",\"id\":\"req-5\",\"error\":{\"code\":123,\"message\":456}}";
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+    g_assert_cmpstr(frame->id, ==, "req-5");
+    g_assert_null(frame->code);
+    g_assert_null(frame->error);
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_challenge_nonce_non_string_ignored(void) {
+    const gchar *json = "{\"type\":\"event\",\"event\":\"connect.challenge\",\"payload\":{\"nonce\":123}}";
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_EVENT);
+    g_assert_cmpstr(frame->event_type, ==, "connect.challenge");
+
+    gchar *nonce = gateway_protocol_extract_challenge_nonce(frame);
+    g_assert_null(nonce);
+
+    gateway_frame_free(frame);
+}
+
 static void test_protocol_parse_response_ok(void) {
     /* Valid hello-ok response per HelloOkSchema */
     const gchar *json = "{"
@@ -649,6 +703,36 @@ static void test_protocol_parse_response_ok_no_auth(void) {
     gdouble tick_ms = 0;
     gboolean ok = gateway_protocol_parse_hello_ok(frame, &auth_source, &tick_ms);
     
+    g_assert_true(ok);
+    g_assert_null(auth_source);
+    g_assert_cmpfloat_with_epsilon(tick_ms, 25000.0, 0.1);
+
+    gateway_frame_free(frame);
+}
+
+static void test_protocol_parse_response_ok_auth_source_wrong_type(void) {
+    /* Valid hello-ok with malformed auth.source should still parse and return NULL auth_source */
+    const gchar *json = "{"
+        "\"type\":\"res\","
+        "\"id\":\"req-1\","
+        "\"payload\":{"
+            "\"type\":\"hello-ok\","
+            "\"protocol\":1,"
+            "\"server\":{\"version\":\"1.0.0\",\"connId\":\"abc123\"},"
+            "\"features\":{\"methods\":[],\"events\":[]},"
+            "\"snapshot\":{},"
+            "\"auth\":{\"source\":123},"
+            "\"policy\":{\"maxPayload\":1000000,\"maxBufferedBytes\":5000000,\"tickIntervalMs\":25000}"
+        "}"
+        "}";
+    GatewayFrame *frame = gateway_protocol_parse_frame(json);
+    g_assert_nonnull(frame);
+    g_assert_cmpint(frame->type, ==, GATEWAY_FRAME_RES);
+
+    gchar *auth_source = (gchar *)0xdeadbeef; /* Ensure it is overwritten to NULL */
+    gdouble tick_ms = 0;
+    gboolean ok = gateway_protocol_parse_hello_ok(frame, &auth_source, &tick_ms);
+
     g_assert_true(ok);
     g_assert_null(auth_source);
     g_assert_cmpfloat_with_epsilon(tick_ms, 25000.0, 0.1);
@@ -2036,6 +2120,7 @@ int main(int argc, char **argv) {
     g_test_add_func("/gateway/protocol/parse_event", test_protocol_parse_event);
     g_test_add_func("/gateway/protocol/parse_response_ok", test_protocol_parse_response_ok);
     g_test_add_func("/gateway/protocol/parse_response_ok_no_auth", test_protocol_parse_response_ok_no_auth);
+    g_test_add_func("/gateway/protocol/parse_response_ok_auth_source_wrong_type", test_protocol_parse_response_ok_auth_source_wrong_type);
     g_test_add_func("/gateway/protocol/parse_response_malformed_policy", test_protocol_parse_response_malformed_policy);
     g_test_add_func("/gateway/protocol/parse_response_malformed_auth", test_protocol_parse_response_malformed_auth);
     g_test_add_func("/gateway/protocol/parse_response_error", test_protocol_parse_response_error);
@@ -2044,6 +2129,11 @@ int main(int argc, char **argv) {
     g_test_add_func("/gateway/protocol/parse_request", test_protocol_parse_request);
     g_test_add_func("/gateway/protocol/parse_invalid", test_protocol_parse_invalid);
     g_test_add_func("/gateway/protocol/parse_tick_event", test_protocol_parse_tick_event);
+    g_test_add_func("/gateway/protocol/parse_type_non_string_rejected", test_protocol_parse_type_non_string_rejected);
+    g_test_add_func("/gateway/protocol/parse_optional_strings_invalid_ignored", test_protocol_parse_optional_strings_invalid_ignored);
+    g_test_add_func("/gateway/protocol/parse_event_name_invalid_ignored", test_protocol_parse_event_name_invalid_ignored);
+    g_test_add_func("/gateway/protocol/parse_response_error_strings_invalid_ignored", test_protocol_parse_response_error_strings_invalid_ignored);
+    g_test_add_func("/gateway/protocol/parse_challenge_nonce_non_string_ignored", test_protocol_parse_challenge_nonce_non_string_ignored);
     g_test_add_func("/gateway/protocol/build_connect_token_mode", test_protocol_build_connect_token_mode);
     g_test_add_func("/gateway/protocol/build_connect_password_mode", test_protocol_build_connect_password_mode);
     g_test_add_func("/gateway/protocol/build_connect_none_mode", test_protocol_build_connect_none_mode);


### PR DESCRIPTION
Add typed-string validation to Linux gateway protocol parsing and chat block extraction so malformed payload fields are rejected or safely ignored instead of being read through permissive string accessors.

Update protocol parsing to require a valid string frame type, treat optional string metadata as absent when malformed, ignore malformed challenge nonces, and preserve successful hello-ok parsing when auth.source has the wrong type. Update chat rendering to default invalid message roles to "assistant".

Expand regression coverage for malformed payload handling in gateway and chat block tests, including non-string required frame type rejection, malformed optional request/event/error fields, malformed challenge nonce, malformed hello-ok auth.source, and malformed chat block type/text/thinking/tool name handling.

This strengthens Linux companion boundary safety while preserving valid payload behavior.
