### PR TITLE
refactor(linux): unify typed JSON access (#66)

### DIFF
--- a/apps/linux/src/chat_blocks.c
+++ b/apps/linux/src/chat_blocks.c
@@ -5,16 +5,9 @@
  */
 
 #include "chat_blocks.h"
+#include "json_access.h"
 
 #include <string.h>
-
-static const gchar* chat_blocks_string_member(JsonObject *obj, const gchar *member) {
-    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
-    JsonNode *node = json_object_get_member(obj, member);
-    if (!node || !JSON_NODE_HOLDS_VALUE(node)) return NULL;
-    if (json_node_get_value_type(node) != G_TYPE_STRING) return NULL;
-    return json_node_get_string(node);
-}
 
 void chat_block_free(ChatBlock *block) {
     if (!block) return;
@@ -33,22 +26,22 @@ static ChatBlock* chat_block_new(ChatBlockType type, const gchar *text) {
 
 static void append_block_from_object(GPtrArray *out, JsonObject *obj) {
     g_autofree gchar *type = NULL;
-    type = g_strdup(chat_blocks_string_member(obj, "type"));
+    type = g_strdup(oc_json_string_member(obj, "type"));
 
     if (!type) {
         return;
     }
 
     if (g_strcmp0(type, "text") == 0 || g_strcmp0(type, "output_text") == 0) {
-        const gchar *text = chat_blocks_string_member(obj, "text");
+        const gchar *text = oc_json_string_member(obj, "text");
         g_ptr_array_add(out, chat_block_new(CHAT_BLOCK_TEXT, text ? text : ""));
         return;
     }
 
     if (g_strcmp0(type, "thinking") == 0 || g_strcmp0(type, "reasoning") == 0) {
-        const gchar *text = chat_blocks_string_member(obj, "text");
+        const gchar *text = oc_json_string_member(obj, "text");
         if (!text) {
-            text = chat_blocks_string_member(obj, "thinking");
+            text = oc_json_string_member(obj, "thinking");
         }
         g_ptr_array_add(out, chat_block_new(CHAT_BLOCK_THINKING, text ? text : ""));
         return;
@@ -56,7 +49,7 @@ static void append_block_from_object(GPtrArray *out, JsonObject *obj) {
 
     if (g_strcmp0(type, "tool_use") == 0) {
         ChatBlock *b = chat_block_new(CHAT_BLOCK_TOOL_USE, "");
-        b->tool_name = g_strdup(chat_blocks_string_member(obj, "name"));
+        b->tool_name = g_strdup(oc_json_string_member(obj, "name"));
         if (json_object_has_member(obj, "input")) {
             JsonNode *input = json_object_get_member(obj, "input");
             if (JSON_NODE_HOLDS_VALUE(input) && json_node_get_value_type(input) == G_TYPE_STRING) {

--- a/apps/linux/src/gateway_config.c
+++ b/apps/linux/src/gateway_config.c
@@ -21,6 +21,7 @@
  */
 
 #include "gateway_config.h"
+#include "json_access.h"
 #include "log.h"
 #include <json-glib/json-glib.h>
 #include <string.h>
@@ -134,7 +135,7 @@ static void resolve_auth(JsonObject *auth_obj, GatewayConfig *config) {
 
     if (auth_obj) {
         if (json_object_has_member(auth_obj, "mode")) {
-            const gchar *mode = json_object_get_string_member(auth_obj, "mode");
+            const gchar *mode = oc_json_string_member(auth_obj, "mode");
             if (mode && mode[0] != '\0') {
                 cfg_auth_mode = g_strdup(mode);
             }
@@ -365,7 +366,7 @@ GatewayConfig* gateway_config_load(const GatewayConfigContext *ctx) {
 
     JsonObject *gateway_obj = NULL;
     if (json_object_has_member(root_obj, "gateway")) {
-        gateway_obj = json_object_get_object_member(root_obj, "gateway");
+        gateway_obj = oc_json_object_member(root_obj, "gateway");
     }
 
     /* E2: Reject malformed-present gateway.mode (must be string if present) */
@@ -381,7 +382,7 @@ GatewayConfig* gateway_config_load(const GatewayConfigContext *ctx) {
 
     /* Resolve mode */
     if (gateway_obj && json_object_has_member(gateway_obj, "mode")) {
-        const gchar *mode = json_object_get_string_member(gateway_obj, "mode");
+        const gchar *mode = oc_json_string_member(gateway_obj, "mode");
         if (mode && mode[0] != '\0') {
             config->mode = g_strdup(mode);
         }
@@ -507,7 +508,7 @@ GatewayConfig* gateway_config_load(const GatewayConfigContext *ctx) {
     /* Resolve auth from gateway.auth.* + env overrides */
     JsonObject *auth_obj = NULL;
     if (gateway_obj && json_object_has_member(gateway_obj, "auth")) {
-        auth_obj = json_object_get_object_member(gateway_obj, "auth");
+        auth_obj = oc_json_object_member(gateway_obj, "auth");
     }
     /* E4: Reject malformed-present gateway.auth.mode (must be string if present) */
     if (auth_obj && json_object_has_member(auth_obj, "mode")) {
@@ -554,9 +555,9 @@ GatewayConfig* gateway_config_load(const GatewayConfigContext *ctx) {
 
     /* Resolve controlUi.basePath */
     if (gateway_obj && json_object_has_member(gateway_obj, "controlUi")) {
-        JsonObject *cui_obj = json_object_get_object_member(gateway_obj, "controlUi");
+        JsonObject *cui_obj = oc_json_object_member(gateway_obj, "controlUi");
         if (cui_obj && json_object_has_member(cui_obj, "basePath")) {
-            const gchar *bp = json_object_get_string_member(cui_obj, "basePath");
+            const gchar *bp = oc_json_string_member(cui_obj, "basePath");
             if (bp && bp[0] != '\0') {
                 config->control_ui_base_path = g_strdup(bp);
             }

--- a/apps/linux/src/gateway_data.c
+++ b/apps/linux/src/gateway_data.c
@@ -12,17 +12,22 @@
  */
 
 #include "gateway_data.h"
+#include "json_access.h"
 #include <string.h>
 
 /* ── Helpers ─────────────────────────────────────────────────────── */
 
 static gchar* json_get_string_or_null(JsonObject *obj, const gchar *member) {
-    if (!obj || !json_object_has_member(obj, member)) return NULL;
-    JsonNode *node = json_object_get_member(obj, member);
-    if (!node || json_node_is_null(node)) return NULL;
-    if (json_node_get_value_type(node) != G_TYPE_STRING) return NULL;
-    const gchar *val = json_node_get_string(node);
+    const gchar *val = oc_json_string_member(obj, member);
     return val ? g_strdup(val) : NULL;
+}
+
+static const gchar* json_array_get_string_element_typed(JsonArray *arr, guint index) {
+    if (!arr) return NULL;
+    JsonNode *node = json_array_get_element(arr, index);
+    if (!node || !JSON_NODE_HOLDS_VALUE(node)) return NULL;
+    if (json_node_get_value_type(node) != G_TYPE_STRING) return NULL;
+    return json_node_get_string(node);
 }
 
 static gint64 json_get_int64_or_zero(JsonObject *obj, const gchar *member) {
@@ -134,22 +139,29 @@ GatewayChannelsData* gateway_data_parse_channels(JsonNode *payload) {
     data->ts = json_get_int64_or_zero(root, "ts");
 
     /* channelOrder: string[] */
-    JsonArray *order_arr = NULL;
-    if (json_object_has_member(root, "channelOrder")) {
-        JsonNode *n = json_object_get_member(root, "channelOrder");
-        if (n && JSON_NODE_HOLDS_ARRAY(n))
-            order_arr = json_node_get_array(n);
-    }
+    JsonArray *order_arr = oc_json_array_member(root, "channelOrder");
 
     if (order_arr) {
         guint len = json_array_get_length(order_arr);
-        data->n_channel_order = (gint)len;
-        data->channel_order = g_new0(gchar*, len + 1);
+        guint valid_len = 0;
+
         for (guint i = 0; i < len; i++) {
-            const gchar *s = json_array_get_string_element(order_arr, i);
-            data->channel_order[i] = g_strdup(s ? s : "");
+            if (json_array_get_string_element_typed(order_arr, i)) {
+                valid_len++;
+            }
         }
-        data->channel_order[len] = NULL;
+
+        if (valid_len > 0) {
+            data->n_channel_order = (gint)valid_len;
+            data->channel_order = g_new0(gchar*, valid_len + 1);
+            guint out_i = 0;
+            for (guint i = 0; i < len; i++) {
+                const gchar *s = json_array_get_string_element_typed(order_arr, i);
+                if (!s) continue;
+                data->channel_order[out_i++] = g_strdup(s);
+            }
+            data->channel_order[valid_len] = NULL;
+        }
     }
 
     /* channelLabels: Record<string, string> */

--- a/apps/linux/src/gateway_http.c
+++ b/apps/linux/src/gateway_http.c
@@ -10,6 +10,7 @@
  */
 
 #include "gateway_http.h"
+#include "json_access.h"
 #include "log.h"
 #include <libsoup/soup.h>
 #include <json-glib/json-glib.h>
@@ -192,9 +193,7 @@ static void on_health_response(GObject *source_object, GAsyncResult *res, gpoint
     result.probe_result = HTTP_PROBE_OK;
     result.healthy = json_node_get_boolean(ok_node);
 
-    if (json_object_has_member(obj, "version")) {
-        result.version = g_strdup(json_object_get_string_member(obj, "version"));
-    }
+    result.version = g_strdup(oc_json_string_member(obj, "version"));
 
     g_bytes_unref(body);
 

--- a/apps/linux/src/gateway_protocol.c
+++ b/apps/linux/src/gateway_protocol.c
@@ -13,23 +13,9 @@
  */
 
 #include "gateway_protocol.h"
+#include "json_access.h"
 #include "log.h"
 #include <string.h>
-
-static const gchar* json_object_get_member_string_typed(JsonObject *obj, const gchar *member) {
-    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
-    JsonNode *node = json_object_get_member(obj, member);
-    if (!node || !JSON_NODE_HOLDS_VALUE(node)) return NULL;
-    if (json_node_get_value_type(node) != G_TYPE_STRING) return NULL;
-    return json_node_get_string(node);
-}
-
-static JsonObject* json_object_get_member_object_typed(JsonObject *obj, const gchar *member) {
-    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
-    JsonNode *node = json_object_get_member(obj, member);
-    if (!node || !JSON_NODE_HOLDS_OBJECT(node)) return NULL;
-    return json_node_get_object(node);
-}
 
 GatewayFrame* gateway_protocol_parse_frame(const gchar *json_str) {
     if (!json_str) return NULL;
@@ -51,32 +37,32 @@ GatewayFrame* gateway_protocol_parse_frame(const gchar *json_str) {
         return NULL;
     }
 
-    const gchar *type_str = json_object_get_member_string_typed(obj, "type");
+    const gchar *type_str = oc_json_string_member(obj, "type");
     if (!type_str) return NULL;
 
     GatewayFrame *frame = g_new0(GatewayFrame, 1);
 
     if (g_strcmp0(type_str, "req") == 0) {
         frame->type = GATEWAY_FRAME_REQ;
-        frame->id = g_strdup(json_object_get_member_string_typed(obj, "id"));
-        frame->method = g_strdup(json_object_get_member_string_typed(obj, "method"));
+        frame->id = g_strdup(oc_json_string_member(obj, "id"));
+        frame->method = g_strdup(oc_json_string_member(obj, "method"));
         if (json_object_has_member(obj, "params"))
             frame->payload = json_node_copy(json_object_get_member(obj, "params"));
     } else if (g_strcmp0(type_str, "res") == 0) {
         frame->type = GATEWAY_FRAME_RES;
-        frame->id = g_strdup(json_object_get_member_string_typed(obj, "id"));
+        frame->id = g_strdup(oc_json_string_member(obj, "id"));
         if (json_object_has_member(obj, "error")) {
-            JsonObject *err_obj = json_object_get_member_object_typed(obj, "error");
+            JsonObject *err_obj = oc_json_object_member(obj, "error");
             if (err_obj) {
-                frame->code = g_strdup(json_object_get_member_string_typed(err_obj, "code"));
-                frame->error = g_strdup(json_object_get_member_string_typed(err_obj, "message"));
+                frame->code = g_strdup(oc_json_string_member(err_obj, "code"));
+                frame->error = g_strdup(oc_json_string_member(err_obj, "message"));
             }
         }
         if (json_object_has_member(obj, "payload"))
             frame->payload = json_node_copy(json_object_get_member(obj, "payload"));
     } else if (g_strcmp0(type_str, "event") == 0) {
         frame->type = GATEWAY_FRAME_EVENT;
-        frame->event_type = g_strdup(json_object_get_member_string_typed(obj, "event"));
+        frame->event_type = g_strdup(oc_json_string_member(obj, "event"));
         if (json_object_has_member(obj, "payload"))
             frame->payload = json_node_copy(json_object_get_member(obj, "payload"));
     } else {
@@ -215,7 +201,7 @@ gchar* gateway_protocol_extract_challenge_nonce(const GatewayFrame *frame) {
     if (!frame->payload || !JSON_NODE_HOLDS_OBJECT(frame->payload)) return NULL;
 
     JsonObject *obj = json_node_get_object(frame->payload);
-    const gchar *nonce = json_object_get_member_string_typed(obj, "nonce");
+    const gchar *nonce = oc_json_string_member(obj, "nonce");
     if (nonce && nonce[0] != '\0') {
         return g_strdup(nonce);
     }
@@ -282,7 +268,7 @@ gboolean gateway_protocol_parse_hello_ok(const GatewayFrame *frame,
     if (!json_object_has_member(obj, "type")) {
         return FALSE;
     }
-    const gchar *type_str = json_object_get_member_string_typed(obj, "type");
+    const gchar *type_str = oc_json_string_member(obj, "type");
     if (g_strcmp0(type_str, "hello-ok") != 0) {
         return FALSE;
     }
@@ -360,7 +346,7 @@ gboolean gateway_protocol_parse_hello_ok(const GatewayFrame *frame,
     if (out_auth_source) {
         *out_auth_source = NULL;
         if (auth) {
-            *out_auth_source = g_strdup(json_object_get_member_string_typed(auth, "source"));
+            *out_auth_source = g_strdup(oc_json_string_member(auth, "source"));
         }
     }
 

--- a/apps/linux/src/json_access.h
+++ b/apps/linux/src/json_access.h
@@ -1,0 +1,42 @@
+/*
+ * json_access.h
+ *
+ * Tiny typed JSON access helpers for Linux-side ingress/parsing boundaries.
+ */
+
+#ifndef OPENCLAW_JSON_ACCESS_H
+#define OPENCLAW_JSON_ACCESS_H
+
+#include <json-glib/json-glib.h>
+
+static inline const gchar* oc_json_string_member(JsonObject *obj, const gchar *member) {
+    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
+    JsonNode *node = json_object_get_member(obj, member);
+    if (!node || !JSON_NODE_HOLDS_VALUE(node)) return NULL;
+    if (json_node_get_value_type(node) != G_TYPE_STRING) return NULL;
+    return json_node_get_string(node);
+}
+
+static inline JsonObject* oc_json_object_member(JsonObject *obj, const gchar *member) {
+    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
+    JsonNode *node = json_object_get_member(obj, member);
+    if (!node || !JSON_NODE_HOLDS_OBJECT(node)) return NULL;
+    return json_node_get_object(node);
+}
+
+static inline JsonArray* oc_json_array_member(JsonObject *obj, const gchar *member) {
+    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
+    JsonNode *node = json_object_get_member(obj, member);
+    if (!node || !JSON_NODE_HOLDS_ARRAY(node)) return NULL;
+    return json_node_get_array(node);
+}
+
+static inline gboolean oc_json_bool_member(JsonObject *obj, const gchar *member, gboolean fallback) {
+    if (!obj || !member || !json_object_has_member(obj, member)) return fallback;
+    JsonNode *node = json_object_get_member(obj, member);
+    if (!node || !JSON_NODE_HOLDS_VALUE(node)) return fallback;
+    if (json_node_get_value_type(node) != G_TYPE_BOOLEAN) return fallback;
+    return json_node_get_boolean(node);
+}
+
+#endif

--- a/apps/linux/src/section_agents.c
+++ b/apps/linux/src/section_agents.c
@@ -10,6 +10,7 @@
 
 #include "format_utils.h"
 #include "gateway_rpc.h"
+#include "json_access.h"
 
 typedef struct {
     gchar *id;
@@ -73,15 +74,6 @@ static gint agents_selected_index = -1;
 static gchar *agents_selected_agent_id = NULL;
 static gboolean agents_fetch_in_flight = FALSE;
 static gint64 agents_last_fetch_us = 0;
-
-static const gchar* agents_json_string_member(JsonObject *obj, const gchar *member) {
-    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
-    JsonNode *node = json_object_get_member(obj, member);
-    if (!node || !JSON_NODE_HOLDS_VALUE(node) || json_node_get_value_type(node) != G_TYPE_STRING) {
-        return NULL;
-    }
-    return json_node_get_string(node);
-}
 
 static const gchar* agents_selected_agent_model(void) {
     if (!agents_cache || agents_selected_index < 0 || (guint)agents_selected_index >= agents_cache->len) {
@@ -383,8 +375,8 @@ static void on_agents_list_response(const GatewayRpcResponse *response, gpointer
                 if (!n || !JSON_NODE_HOLDS_OBJECT(n)) continue;
                 JsonObject *ao = json_node_get_object(n);
                 AgentRow *row = g_new0(AgentRow, 1);
-                row->id = g_strdup(agents_json_string_member(ao, "id"));
-                row->name = g_strdup(agents_json_string_member(ao, "name"));
+                row->id = g_strdup(oc_json_string_member(ao, "id"));
+                row->name = g_strdup(oc_json_string_member(ao, "name"));
                 if (!row->id || row->id[0] == '\0') {
                     agent_row_free(row);
                     continue;
@@ -393,23 +385,23 @@ static void on_agents_list_response(const GatewayRpcResponse *response, gpointer
                     JsonNode *identity_node = json_object_get_member(ao, "identity");
                     if (identity_node && JSON_NODE_HOLDS_OBJECT(identity_node)) {
                         JsonObject *identity = json_node_get_object(identity_node);
-                        const gchar *identity_name = agents_json_string_member(identity, "name");
+                        const gchar *identity_name = oc_json_string_member(identity, "name");
                         if ((!row->name || row->name[0] == '\0') && identity_name) {
                             g_free(row->name);
                             row->name = g_strdup(identity_name);
                         }
-                        row->emoji = g_strdup(agents_json_string_member(identity, "emoji"));
-                        row->avatar = g_strdup(agents_json_string_member(identity, "avatar"));
-                        if (!row->avatar) row->avatar = g_strdup(agents_json_string_member(identity, "avatarUrl"));
+                        row->emoji = g_strdup(oc_json_string_member(identity, "emoji"));
+                        row->avatar = g_strdup(oc_json_string_member(identity, "avatar"));
+                        if (!row->avatar) row->avatar = g_strdup(oc_json_string_member(identity, "avatarUrl"));
                     }
                 }
-                row->workspace = g_strdup(agents_json_string_member(ao, "workspace"));
-                if (!row->avatar) row->avatar = g_strdup(agents_json_string_member(ao, "avatar"));
+                row->workspace = g_strdup(oc_json_string_member(ao, "workspace"));
+                if (!row->avatar) row->avatar = g_strdup(oc_json_string_member(ao, "avatar"));
                 if (json_object_has_member(ao, "model")) {
                     JsonNode *model_node = json_object_get_member(ao, "model");
                     if (model_node && JSON_NODE_HOLDS_OBJECT(model_node)) {
                         JsonObject *model = json_node_get_object(model_node);
-                        row->model = g_strdup(agents_json_string_member(model, "primary"));
+                        row->model = g_strdup(oc_json_string_member(model, "primary"));
                     } else if (model_node && JSON_NODE_HOLDS_VALUE(model_node) &&
                                json_node_get_value_type(model_node) == G_TYPE_STRING) {
                         row->model = g_strdup(json_node_get_string(model_node));
@@ -475,8 +467,8 @@ static void on_agents_models_response(const GatewayRpcResponse *response, gpoint
                 m->id = g_strdup(json_node_get_string(idn));
             }
         }
-        const gchar *name = agents_json_string_member(mo, "name");
-        const gchar *provider = agents_json_string_member(mo, "provider");
+        const gchar *name = oc_json_string_member(mo, "name");
+        const gchar *provider = oc_json_string_member(mo, "provider");
         m->label = g_strdup_printf("%s (%s)",
                                    name ? name : "model",
                                    provider ? provider : "provider");

--- a/apps/linux/src/section_channels.c
+++ b/apps/linux/src/section_channels.c
@@ -15,6 +15,7 @@
 #include "gateway_data.h"
 #include "gateway_mutations.h"
 #include "gateway_config.h"
+#include "json_access.h"
 #include "section_controller.h"
 #include "test_seams.h"
 #include <adwaita.h>
@@ -276,7 +277,7 @@ static void on_config_get_done(const GatewayRpcResponse *response, gpointer user
         g_free(channel_id);
         return;
     }
-    const gchar *hash = json_object_get_string_member(root_obj, "hash");
+    const gchar *hash = oc_json_string_member(root_obj, "hash");
 
     /* Extract the full config object - config.get returns {hash, config: {...}} */
     JsonObject *full_config_obj = NULL;
@@ -428,9 +429,7 @@ static void on_web_login_wait_done(const GatewayRpcResponse *response, gpointer 
             gtk_label_set_text(GTK_LABEL(channels_status_label), "Login successful!");
         } else {
             const gchar *msg = "Login incomplete or timed out";
-            if (json_object_has_member(payload_obj, "message")) {
-                msg = json_object_get_string_member(payload_obj, "message");
-            }
+            msg = oc_json_string_member(payload_obj, "message");
             g_autofree gchar *status_msg = g_strdup_printf("Login status: %s", msg ? msg : "unknown");
             gtk_label_set_text(GTK_LABEL(channels_status_label), status_msg);
         }

--- a/apps/linux/src/section_chat.c
+++ b/apps/linux/src/section_chat.c
@@ -12,6 +12,7 @@
 #include "gateway_data.h"
 #include "gateway_rpc.h"
 #include "gateway_ws.h"
+#include "json_access.h"
 #include "markdown_render.h"
 #include "session_filter.h"
 
@@ -72,20 +73,6 @@ static gboolean chat_guard_agent_change = FALSE;
 static gboolean chat_guard_model_change = FALSE;
 static gboolean chat_guard_session_change = FALSE;
 
-static const gchar* chat_json_string_member(JsonObject *obj, const gchar *member) {
-    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
-    JsonNode *node = json_object_get_member(obj, member);
-    if (!node || !JSON_NODE_HOLDS_VALUE(node) || json_node_get_value_type(node) != G_TYPE_STRING) return NULL;
-    return json_node_get_string(node);
-}
-
-static JsonObject* chat_json_object_member(JsonObject *obj, const gchar *member) {
-    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
-    JsonNode *node = json_object_get_member(obj, member);
-    if (!node || !JSON_NODE_HOLDS_OBJECT(node)) return NULL;
-    return json_node_get_object(node);
-}
-
 static void chat_agent_choice_free(ChatAgentChoice *a) {
     if (!a) return;
     g_free(a->id);
@@ -119,7 +106,7 @@ static void chat_clear_messages_ui(void) {
 static gchar* chat_text_from_chat_event_message(JsonNode *message_node) {
     if (!message_node || !JSON_NODE_HOLDS_OBJECT(message_node)) return NULL;
     JsonObject *message = json_node_get_object(message_node);
-    const gchar *text = chat_json_string_member(message, "text");
+    const gchar *text = oc_json_string_member(message, "text");
     return text ? g_strdup(text) : NULL;
 }
 
@@ -160,7 +147,7 @@ static void chat_append_line(const gchar *text, const gchar *css_class) {
 }
 
 static void chat_render_message_object(JsonObject *msg_obj, gboolean is_pending) {
-    const gchar *role = chat_json_string_member(msg_obj, "role");
+    const gchar *role = oc_json_string_member(msg_obj, "role");
     if (!role || role[0] == '\0') {
         role = "assistant";
     }
@@ -589,8 +576,8 @@ static void on_models_response(const GatewayRpcResponse *response, gpointer user
                         m->id = g_strdup(json_node_get_string(idn));
                     }
                 }
-                const gchar *provider = chat_json_string_member(mo, "provider");
-                const gchar *name = chat_json_string_member(mo, "name");
+                const gchar *provider = oc_json_string_member(mo, "provider");
+                const gchar *name = oc_json_string_member(mo, "name");
                 m->label = g_strdup_printf("%s (%s)",
                                            name ? name : m->id,
                                            provider ? provider : "provider");
@@ -624,7 +611,7 @@ static void on_agents_response(const GatewayRpcResponse *response, gpointer user
     }
 
     JsonObject *obj = json_node_get_object(response->payload);
-    default_id = chat_json_string_member(obj, "defaultId");
+    default_id = oc_json_string_member(obj, "defaultId");
     JsonNode *an = json_object_get_member(obj, "agents");
     if (an && JSON_NODE_HOLDS_ARRAY(an)) {
         JsonArray *arr = json_node_get_array(an);
@@ -633,18 +620,18 @@ static void on_agents_response(const GatewayRpcResponse *response, gpointer user
             if (!n || !JSON_NODE_HOLDS_OBJECT(n)) continue;
             JsonObject *ao = json_node_get_object(n);
             ChatAgentChoice *a = g_new0(ChatAgentChoice, 1);
-            const gchar *id = chat_json_string_member(ao, "id");
+            const gchar *id = oc_json_string_member(ao, "id");
             if (!id || id[0] == '\0') {
                 chat_agent_choice_free(a);
                 continue;
             }
             a->id = g_strdup(id);
-            const gchar *name = chat_json_string_member(ao, "name");
+            const gchar *name = oc_json_string_member(ao, "name");
             if (!name && json_object_has_member(ao, "identity")) {
                 JsonNode *identity_node = json_object_get_member(ao, "identity");
                 if (identity_node && JSON_NODE_HOLDS_OBJECT(identity_node)) {
                     JsonObject *identity = json_node_get_object(identity_node);
-                    name = chat_json_string_member(identity, "name");
+                    name = oc_json_string_member(identity, "name");
                 }
             }
             a->name = g_strdup(name ? name : a->id);
@@ -762,14 +749,14 @@ static void on_chat_event(const gchar *event_type, const JsonNode *payload, gpoi
     if (!payload || json_node_get_node_type((JsonNode *)payload) != JSON_NODE_OBJECT) return;
 
     JsonObject *obj = json_node_get_object((JsonNode *)payload);
-    const gchar *session_key = chat_json_string_member(obj, "sessionKey");
-    const gchar *run_id = chat_json_string_member(obj, "runId");
+    const gchar *session_key = oc_json_string_member(obj, "sessionKey");
+    const gchar *run_id = oc_json_string_member(obj, "runId");
     if (!session_key || session_key[0] == '\0') return;
 
     if (g_strcmp0(event_type, "chat") == 0) {
         if (!chat_stream_claim_or_match_owner(session_key, run_id)) return;
 
-        const gchar *state = chat_json_string_member(obj, "state");
+        const gchar *state = oc_json_string_member(obj, "state");
         JsonNode *message_node = json_object_get_member(obj, "message");
         if (g_strcmp0(state, "delta") == 0) {
             g_autofree gchar *delta = chat_text_from_chat_event_message(message_node);
@@ -807,8 +794,8 @@ static void on_chat_event(const gchar *event_type, const JsonNode *payload, gpoi
         return;
     }
 
-    const gchar *stream = chat_json_string_member(obj, "stream");
-    JsonObject *data_obj = chat_json_object_member(obj, "data");
+    const gchar *stream = oc_json_string_member(obj, "stream");
+    JsonObject *data_obj = oc_json_object_member(obj, "data");
     if (!stream) return;
 
     if (g_strcmp0(stream, "assistant") == 0 ||
@@ -819,7 +806,7 @@ static void on_chat_event(const gchar *event_type, const JsonNode *payload, gpoi
 
     if (g_strcmp0(stream, "assistant") == 0) {
         if (!data_obj) return;
-        const gchar *full_text = chat_json_string_member(data_obj, "text");
+        const gchar *full_text = oc_json_string_member(data_obj, "text");
         if (full_text) {
             g_free(chat_pending_assistant_text);
             chat_pending_assistant_text = g_strdup(full_text);
@@ -842,7 +829,7 @@ static void on_chat_event(const gchar *event_type, const JsonNode *payload, gpoi
 
     if (g_strcmp0(stream, "lifecycle") == 0) {
         if (!data_obj) return;
-        const gchar *phase = chat_json_string_member(data_obj, "phase");
+        const gchar *phase = oc_json_string_member(data_obj, "phase");
         if (g_strcmp0(phase, "start") == 0) {
             if (chat_pending_is_for_selected_session()) {
                 gtk_label_set_text(GTK_LABEL(chat_status_label), "Assistant started");

--- a/apps/linux/src/section_control_room.c
+++ b/apps/linux/src/section_control_room.c
@@ -10,6 +10,7 @@
 
 #include "gateway_mutations.h"
 #include "gateway_rpc.h"
+#include "json_access.h"
 #include "readiness.h"
 #include "state.h"
 
@@ -19,24 +20,6 @@ static GtkWidget *control_nodes_box = NULL;
 static GtkWidget *control_details_label = NULL;
 static GtkWidget *control_cron_job_entry = NULL;
 static GtkWidget *control_abort_session_entry = NULL;
-
-static const gchar* control_json_string_member(JsonObject *obj, const gchar *member) {
-    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
-    JsonNode *node = json_object_get_member(obj, member);
-    if (!node || !JSON_NODE_HOLDS_VALUE(node) || json_node_get_value_type(node) != G_TYPE_STRING) {
-        return NULL;
-    }
-    return json_node_get_string(node);
-}
-
-static gboolean control_json_bool_member(JsonObject *obj, const gchar *member, gboolean fallback) {
-    if (!obj || !member || !json_object_has_member(obj, member)) return fallback;
-    JsonNode *node = json_object_get_member(obj, member);
-    if (!node || !JSON_NODE_HOLDS_VALUE(node) || json_node_get_value_type(node) != G_TYPE_BOOLEAN) {
-        return fallback;
-    }
-    return json_node_get_boolean(node);
-}
 
 static gboolean control_fetch_in_flight = FALSE;
 static gint64 control_last_fetch_us = 0;
@@ -183,16 +166,16 @@ static void on_control_nodes_response(const GatewayRpcResponse *response, gpoint
             JsonNode *n = json_array_get_element(nodes, i);
             if (!n || !JSON_NODE_HOLDS_OBJECT(n)) continue;
             JsonObject *node = json_node_get_object(n);
-            const gchar *node_id = control_json_string_member(node, "nodeId");
+            const gchar *node_id = oc_json_string_member(node, "nodeId");
             if (!node_id) node_id = "unknown";
-            const gchar *name = control_json_string_member(node, "displayName");
+            const gchar *name = oc_json_string_member(node, "displayName");
             if (!name) name = node_id;
-            gboolean connected = control_json_bool_member(node, "connected", FALSE);
-            const gchar *platform = control_json_string_member(node, "platform");
+            gboolean connected = oc_json_bool_member(node, "connected", FALSE);
+            const gchar *platform = oc_json_string_member(node, "platform");
             if (!platform) platform = "?";
-            const gchar *version = control_json_string_member(node, "version");
+            const gchar *version = oc_json_string_member(node, "version");
             if (!version) version = "?";
-            gboolean paired = control_json_bool_member(node, "paired", FALSE);
+            gboolean paired = oc_json_bool_member(node, "paired", FALSE);
             g_autofree gchar *line = g_strdup_printf("%s (%s) — %s | %s %s | %s",
                                                      name,
                                                      node_id,

--- a/apps/linux/src/section_logs.c
+++ b/apps/linux/src/section_logs.c
@@ -9,21 +9,13 @@
 #include <adwaita.h>
 
 #include "gateway_rpc.h"
+#include "json_access.h"
 
 static GtkWidget *logs_status_label = NULL;
 static GtkWidget *logs_text_view = NULL;
 static GtkWidget *logs_filter_entry = NULL;
 static gboolean logs_fetch_in_flight = FALSE;
 static gint64 logs_last_fetch_us = 0;
-
-static const gchar* logs_json_string_member(JsonObject *obj, const gchar *member) {
-    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
-    JsonNode *node = json_object_get_member(obj, member);
-    if (!node || !JSON_NODE_HOLDS_VALUE(node) || json_node_get_value_type(node) != G_TYPE_STRING) {
-        return NULL;
-    }
-    return json_node_get_string(node);
-}
 
 static void logs_trigger_fetch(gboolean force);
 
@@ -85,7 +77,7 @@ static void on_logs_tail_response(const GatewayRpcResponse *response, gpointer u
             }
         }
     } else {
-        const gchar *text = logs_json_string_member(obj, "text");
+        const gchar *text = oc_json_string_member(obj, "text");
         if (text) {
             g_string_append(out, text);
             shown = 1;

--- a/apps/linux/src/section_usage.c
+++ b/apps/linux/src/section_usage.c
@@ -10,6 +10,7 @@
 
 #include "format_utils.h"
 #include "gateway_rpc.h"
+#include "json_access.h"
 
 static GtkWidget *usage_status_label = NULL;
 static GtkWidget *usage_summary_label = NULL;
@@ -21,15 +22,6 @@ static gboolean usage_fetch_in_flight = FALSE;
 static gint64 usage_last_fetch_us = 0;
 
 static gint usage_selected_days = 30;
-
-static const gchar* usage_json_string_member(JsonObject *obj, const gchar *member) {
-    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
-    JsonNode *node = json_object_get_member(obj, member);
-    if (!node || !JSON_NODE_HOLDS_VALUE(node) || json_node_get_value_type(node) != G_TYPE_STRING) {
-        return NULL;
-    }
-    return json_node_get_string(node);
-}
 
 static void usage_clear_retros(void) {
     if (!usage_retros_box) return;
@@ -73,7 +65,7 @@ static void on_usage_sessions_response(const GatewayRpcResponse *response, gpoin
         if (!n || !JSON_NODE_HOLDS_OBJECT(n)) continue;
         JsonObject *row = json_node_get_object(n);
 
-        const gchar *key = usage_json_string_member(row, "key");
+        const gchar *key = oc_json_string_member(row, "key");
         if (!key) key = "(session)";
         JsonObject *usage = NULL;
         if (json_object_has_member(row, "usage")) {
@@ -183,12 +175,12 @@ static void on_usage_status_response(const GatewayRpcResponse *response, gpointe
             JsonNode *n = json_array_get_element(providers, i);
             if (!n || !JSON_NODE_HOLDS_OBJECT(n)) continue;
             JsonObject *p = json_node_get_object(n);
-            const gchar *name = usage_json_string_member(p, "displayName");
-            if (!name) name = usage_json_string_member(p, "provider");
+            const gchar *name = oc_json_string_member(p, "displayName");
+            if (!name) name = oc_json_string_member(p, "provider");
             if (!name) name = "provider";
-            const gchar *plan = usage_json_string_member(p, "plan");
+            const gchar *plan = oc_json_string_member(p, "plan");
             guint windows = 0;
-            const gchar *provider_error = usage_json_string_member(p, "error");
+            const gchar *provider_error = oc_json_string_member(p, "error");
             JsonNode *wn = json_object_get_member(p, "windows");
             if (wn && JSON_NODE_HOLDS_ARRAY(wn)) {
                 JsonArray *wa = json_node_get_array(wn);

--- a/apps/linux/src/section_workflows.c
+++ b/apps/linux/src/section_workflows.c
@@ -10,20 +10,12 @@
 
 #include "gateway_data.h"
 #include "gateway_rpc.h"
+#include "json_access.h"
 
 static GtkWidget *workflows_status_label = NULL;
 static GtkWidget *workflows_list_box = NULL;
 static gboolean workflows_fetch_in_flight = FALSE;
 static gint64 workflows_last_fetch_us = 0;
-
-static const gchar* workflows_json_string_member(JsonObject *obj, const gchar *member) {
-    if (!obj || !member || !json_object_has_member(obj, member)) return NULL;
-    JsonNode *node = json_object_get_member(obj, member);
-    if (!node || !JSON_NODE_HOLDS_VALUE(node) || json_node_get_value_type(node) != G_TYPE_STRING) {
-        return NULL;
-    }
-    return json_node_get_string(node);
-}
 
 static void workflows_clear(void) {
     if (!workflows_list_box) return;
@@ -57,7 +49,7 @@ static void workflows_render_from_config(const GatewayConfigSnapshot *cfg) {
             JsonNode *n = json_array_get_element(arr, i);
             if (!n || !JSON_NODE_HOLDS_OBJECT(n)) continue;
             JsonObject *b = json_node_get_object(n);
-            const gchar *agent_id = workflows_json_string_member(b, "agentId");
+            const gchar *agent_id = oc_json_string_member(b, "agentId");
             if (!agent_id) agent_id = "(agent)";
             const gchar *channel = "?";
             const gchar *peer_kind = "any";
@@ -66,14 +58,14 @@ static void workflows_render_from_config(const GatewayConfigSnapshot *cfg) {
                 JsonNode *mn = json_object_get_member(b, "match");
                 if (mn && JSON_NODE_HOLDS_OBJECT(mn)) {
                     JsonObject *match = json_node_get_object(mn);
-                    const gchar *channel_member = workflows_json_string_member(match, "channel");
+                    const gchar *channel_member = oc_json_string_member(match, "channel");
                     if (channel_member) channel = channel_member;
                     if (json_object_has_member(match, "peer")) {
                         JsonNode *pn = json_object_get_member(match, "peer");
                         if (pn && JSON_NODE_HOLDS_OBJECT(pn)) {
                             JsonObject *peer = json_node_get_object(pn);
-                            const gchar *kind_member = workflows_json_string_member(peer, "kind");
-                            const gchar *id_member = workflows_json_string_member(peer, "id");
+                            const gchar *kind_member = oc_json_string_member(peer, "kind");
+                            const gchar *id_member = oc_json_string_member(peer, "id");
                             if (kind_member) peer_kind = kind_member;
                             if (id_member) peer_id = id_member;
                         }

--- a/apps/linux/src/test_seams.c
+++ b/apps/linux/src/test_seams.c
@@ -8,6 +8,7 @@
  */
 
 #include "test_seams.h"
+#include "json_access.h"
 #include <string.h>
 
 /* ── Cron sessionTarget mapping (from section_cron.c) ───────────────
@@ -69,7 +70,7 @@ int web_login_start_payload_has_qr(JsonObject *payload_obj,
      */
     const gchar *qr_data_url = NULL;
     if (json_object_has_member(payload_obj, "qrDataUrl")) {
-        qr_data_url = json_object_get_string_member(payload_obj, "qrDataUrl");
+        qr_data_url = oc_json_string_member(payload_obj, "qrDataUrl");
     }
 
     if (out_qr_data_url) *out_qr_data_url = qr_data_url;

--- a/apps/linux/tests/test_gateway_data.c
+++ b/apps/linux/tests/test_gateway_data.c
@@ -79,6 +79,20 @@ static void test_channels_parse_basic(void) {
     json_node_unref(node);
 }
 
+static void test_channels_mixed_type_channel_order_elements(void) {
+    JsonNode *node = parse_json(
+        "{\"channelOrder\": [\"alpha\", 1, {\"bad\":true}, \"beta\"], \"channels\": {}}"
+    );
+    GatewayChannelsData *data = gateway_data_parse_channels(node);
+    ASSERT(data != NULL, "ch_mixed_order: parsed");
+    ASSERT(data->n_channel_order == 2, "ch_mixed_order: keeps only valid string ids");
+    ASSERT(g_strcmp0(data->channel_order[0], "alpha") == 0, "ch_mixed_order: first valid preserved");
+    ASSERT(g_strcmp0(data->channel_order[1], "beta") == 0, "ch_mixed_order: second valid preserved");
+    ASSERT(data->n_channels == 2, "ch_mixed_order: channel list aligns to valid ids");
+    gateway_channels_data_free(data);
+    json_node_unref(node);
+}
+
 static void test_channels_parse_empty(void) {
     JsonNode *node = parse_json("{}");
     GatewayChannelsData *data = gateway_data_parse_channels(node);
@@ -1164,6 +1178,7 @@ int main(void) {
     test_channels_parse_null();
     /* Channels — negative */
     test_channels_wrong_type_channel_order();
+    test_channels_mixed_type_channel_order_elements();
     test_channels_labels_wrong_type();
     test_channels_accounts_not_array();
     test_channels_non_object_payload();

--- a/apps/linux/tests/test_seams.c
+++ b/apps/linux/tests/test_seams.c
@@ -8,6 +8,7 @@
 
 #include <glib.h>
 #include <string.h>
+#include <json-glib/json-glib.h>
 #include "../src/test_seams.h"
 
 /* ── Ancestor Walk Tests (Task 10) ── */
@@ -58,6 +59,38 @@ static void test_monitor_skip_dir_changed(void) {
     g_assert_false(skip);
 }
 
+/* ── QR Payload Typed Access Tests ── */
+
+static JsonNode* parse_json_node(const gchar *json_str) {
+    g_autoptr(JsonParser) parser = json_parser_new();
+    g_assert_true(json_parser_load_from_data(parser, json_str, -1, NULL));
+    JsonNode *root = json_parser_get_root(parser);
+    g_assert_nonnull(root);
+    g_assert_true(JSON_NODE_HOLDS_OBJECT(root));
+    return json_node_copy(root);
+}
+
+static void test_web_login_start_payload_has_qr_valid_string(void) {
+    JsonNode *node = parse_json_node("{\"qrDataUrl\":\"data:image/png;base64,abc\"}");
+    JsonObject *obj = json_node_get_object(node);
+    const gchar *out_qr = NULL;
+    int has_qr = web_login_start_payload_has_qr(obj, &out_qr);
+    g_assert_cmpint(has_qr, ==, 1);
+    g_assert_nonnull(out_qr);
+    g_assert_cmpstr(out_qr, ==, "data:image/png;base64,abc");
+    json_node_unref(node);
+}
+
+static void test_web_login_start_payload_has_qr_wrong_type(void) {
+    JsonNode *node = parse_json_node("{\"qrDataUrl\": 123}");
+    JsonObject *obj = json_node_get_object(node);
+    const gchar *out_qr = (const gchar *)0x1;
+    int has_qr = web_login_start_payload_has_qr(obj, &out_qr);
+    g_assert_cmpint(has_qr, ==, 0);
+    g_assert_null(out_qr);
+    json_node_unref(node);
+}
+
 static void test_monitor_skip_file_monitor_needed_but_missing(void) {
     gboolean skip = config_monitor_can_skip_rearm(
         "/etc/openclaw", "/etc/openclaw",
@@ -88,6 +121,10 @@ int main(int argc, char **argv) {
     g_test_add_func("/seams/monitor_skip/dir_changed", test_monitor_skip_dir_changed);
     g_test_add_func("/seams/monitor_skip/file_monitor_needed_but_missing", test_monitor_skip_file_monitor_needed_but_missing);
     g_test_add_func("/seams/monitor_skip/file_monitor_not_needed_but_exists", test_monitor_skip_file_monitor_not_needed_but_exists);
+
+    /* QR payload typed-access tests */
+    g_test_add_func("/seams/web_login_start_payload_has_qr/valid_string", test_web_login_start_payload_has_qr_valid_string);
+    g_test_add_func("/seams/web_login_start_payload_has_qr/wrong_type", test_web_login_start_payload_has_qr_wrong_type);
 
     return g_test_run();
 }


### PR DESCRIPTION
Add a shared Linux-local JSON access helper surface and migrate boundary parsers and UI consumers to use it consistently. Replace duplicated local typed access helpers across chat, gateway, config, channels, logs, usage, workflows, agents, and control-room code paths.

Harden gateway, config, data, and seam parsing by routing optional string, object, array, and bool reads through a single typed contract. Preserve fail-closed handling for required discriminators while making malformed optional fields degrade predictably.

Tighten channel parsing semantics by compacting mixed-type channelOrder arrays to valid string ids only, and extend regression coverage for mixed-type channel ordering and malformed qrDataUrl payloads.