### PR TITLE
linux: improve runtime feedback and config editing (#68)

### DIFF
--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -26,6 +26,7 @@
 #include "onboarding.h"
 #include "gateway_rpc.h"
 #include "gateway_data.h"
+#include "gateway_mutations.h"
 #include "section_channels.h"
 #include "section_skills.h"
 #include "section_sessions.h"
@@ -73,10 +74,16 @@ static const SectionMeta section_meta[SECTION_COUNT] = {
 static GtkWidget *main_window = NULL;
 static GtkWidget *content_stack = NULL;
 static GtkWidget *sidebar_list = NULL;
+static GtkWidget *shell_gateway_status_label = NULL;
+static GtkWidget *shell_gateway_status_dot = NULL;
+static GtkWidget *shell_service_status_label = NULL;
+static GtkWidget *shell_service_status_dot = NULL;
 static guint refresh_timer_id = 0;
 static AppSection active_section = SECTION_DASHBOARD;
 static gboolean last_rpc_ready = FALSE;
 static AppState last_app_state = STATE_NEEDS_SETUP;
+static gboolean shell_seen_gateway_connected = FALSE;
+static gboolean app_css_installed = FALSE;
 
 /* Section content widgets that need updating */
 static GtkWidget *section_pages[SECTION_COUNT] = {0};
@@ -100,6 +107,8 @@ static void refresh_config_content(void);
 static void refresh_diagnostics_content(void);
 static void refresh_environment_content(void);
 static void refresh_debug_content(void);
+static void refresh_shell_status_footer(void);
+static void ensure_app_css_loaded(void);
 static void on_sidebar_row_activated(GtkListBox *box, GtkListBoxRow *row, gpointer user_data);
 static void on_window_destroy(GtkWindow *window, gpointer user_data);
 
@@ -126,10 +135,13 @@ static GtkWidget* build_sidebar_row(AppSection section) {
 }
 
 static GtkWidget* build_sidebar(void) {
+    GtkWidget *sidebar_shell = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+
     GtkWidget *scrolled = gtk_scrolled_window_new();
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
                                    GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
     gtk_widget_set_size_request(scrolled, 200, -1);
+    gtk_widget_set_vexpand(scrolled, TRUE);
 
     sidebar_list = gtk_list_box_new();
     gtk_list_box_set_selection_mode(GTK_LIST_BOX(sidebar_list), GTK_SELECTION_SINGLE);
@@ -144,7 +156,128 @@ static GtkWidget* build_sidebar(void) {
                      G_CALLBACK(on_sidebar_row_activated), NULL);
 
     gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), sidebar_list);
-    return scrolled;
+    gtk_box_append(GTK_BOX(sidebar_shell), scrolled);
+
+    GtkWidget *footer_sep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_box_append(GTK_BOX(sidebar_shell), footer_sep);
+
+    GtkWidget *footer = gtk_box_new(GTK_ORIENTATION_VERTICAL, 4);
+    gtk_widget_set_margin_start(footer, 10);
+    gtk_widget_set_margin_end(footer, 10);
+    gtk_widget_set_margin_top(footer, 8);
+    gtk_widget_set_margin_bottom(footer, 8);
+
+    GtkWidget *gateway_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
+    shell_gateway_status_dot = gtk_label_new("●");
+    gtk_widget_add_css_class(shell_gateway_status_dot, "status-dot");
+    gtk_box_append(GTK_BOX(gateway_row), shell_gateway_status_dot);
+    shell_gateway_status_label = gtk_label_new("Gateway: Connecting");
+    gtk_label_set_xalign(GTK_LABEL(shell_gateway_status_label), 0.0);
+    gtk_widget_set_hexpand(shell_gateway_status_label, TRUE);
+    gtk_box_append(GTK_BOX(gateway_row), shell_gateway_status_label);
+    gtk_box_append(GTK_BOX(footer), gateway_row);
+
+    GtkWidget *service_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
+    shell_service_status_dot = gtk_label_new("●");
+    gtk_widget_add_css_class(shell_service_status_dot, "status-dot");
+    gtk_box_append(GTK_BOX(service_row), shell_service_status_dot);
+    shell_service_status_label = gtk_label_new("Service: Inactive");
+    gtk_label_set_xalign(GTK_LABEL(shell_service_status_label), 0.0);
+    gtk_widget_set_hexpand(shell_service_status_label, TRUE);
+    gtk_box_append(GTK_BOX(service_row), shell_service_status_label);
+    gtk_box_append(GTK_BOX(footer), service_row);
+
+    gtk_box_append(GTK_BOX(sidebar_shell), footer);
+    return sidebar_shell;
+}
+
+static void clear_status_dot_classes(GtkWidget *dot) {
+    if (!dot) return;
+    gtk_widget_remove_css_class(dot, "connected");
+    gtk_widget_remove_css_class(dot, "disconnected");
+    gtk_widget_remove_css_class(dot, "connecting");
+    gtk_widget_remove_css_class(dot, "service-inactive");
+}
+
+static void refresh_shell_status_footer(void) {
+    if (!shell_gateway_status_label || !shell_gateway_status_dot ||
+        !shell_service_status_label || !shell_service_status_dot) {
+        return;
+    }
+
+    SystemdState *sys = state_get_systemd();
+    HealthState *health = state_get_health();
+
+    gboolean service_active = (sys && sys->active);
+    gboolean gateway_connected = (health && health->http_ok && health->ws_connected);
+    if (gateway_connected) {
+        shell_seen_gateway_connected = TRUE;
+    }
+
+    const char *gateway_label = "Gateway: Connecting";
+
+    clear_status_dot_classes(shell_gateway_status_dot);
+    clear_status_dot_classes(shell_service_status_dot);
+
+    if (!service_active) {
+        gateway_label = "Gateway: Service inactive";
+        gtk_widget_add_css_class(shell_gateway_status_dot, "service-inactive");
+    } else if (gateway_connected) {
+        gateway_label = "Gateway: Connected";
+        gtk_widget_add_css_class(shell_gateway_status_dot, "connected");
+    } else if (shell_seen_gateway_connected) {
+        gateway_label = "Gateway: Disconnected";
+        gtk_widget_add_css_class(shell_gateway_status_dot, "disconnected");
+    } else {
+        gateway_label = "Gateway: Connecting";
+        gtk_widget_add_css_class(shell_gateway_status_dot, "connecting");
+    }
+
+    gtk_label_set_text(GTK_LABEL(shell_gateway_status_label), gateway_label);
+
+    if (service_active) {
+        gtk_widget_add_css_class(shell_service_status_dot, "connected");
+        gtk_label_set_text(GTK_LABEL(shell_service_status_label), "Service: Active");
+    } else {
+        gtk_widget_add_css_class(shell_service_status_dot, "service-inactive");
+        gtk_label_set_text(GTK_LABEL(shell_service_status_label), "Service: Inactive");
+    }
+}
+
+static void ensure_app_css_loaded(void) {
+    if (app_css_installed) return;
+
+    const char *css =
+        ".status-dot {"
+        "  font-size: 12px;"
+        "  font-weight: 700;"
+        "}"
+        ".status-dot.connected { color: #33d17a; }"
+        ".status-dot.disconnected { color: #e01b24; }"
+        ".status-dot.service-inactive { color: #77767b; }"
+        ".status-dot.connecting {"
+        "  color: #e5a50a;"
+        "  animation: openclaw-pulse 1.1s ease-in-out infinite;"
+        "}"
+        "@keyframes openclaw-pulse {"
+        "  0% { opacity: 0.35; }"
+        "  50% { opacity: 1; }"
+        "  100% { opacity: 0.35; }"
+        "}";
+
+    GtkCssProvider *provider = gtk_css_provider_new();
+    gtk_css_provider_load_from_string(provider, css);
+
+    GdkDisplay *display = gdk_display_get_default();
+    if (display) {
+        gtk_style_context_add_provider_for_display(
+            display,
+            GTK_STYLE_PROVIDER(provider),
+            GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+        app_css_installed = TRUE;
+    }
+
+    g_object_unref(provider);
 }
 
 /* ── Content stack ── */
@@ -891,8 +1024,21 @@ static GtkWidget *cfg_modified_label = NULL;
 static GtkWidget *cfg_warning_label = NULL;
 static GtkWidget *cfg_issues_label = NULL;
 static GtkWidget *cfg_json_view = NULL;
+static GtkWidget *cfg_validation_label = NULL;
 static GtkWidget *cfg_copy_btn = NULL;
+static GtkWidget *cfg_reload_btn = NULL;
+static GtkWidget *cfg_save_btn = NULL;
 static guint cfg_copy_reset_id = 0;
+static gboolean cfg_programmatic_change = FALSE;
+static gboolean cfg_editor_dirty = FALSE;
+static gboolean cfg_editor_valid = TRUE;
+static gboolean cfg_request_in_flight = FALSE;
+static gboolean cfg_initial_load_requested = FALSE;
+static gchar *cfg_baseline_text = NULL;
+static gchar *cfg_baseline_hash = NULL;
+
+static gchar* cfg_editor_get_text(void);
+static void cfg_request_reload(void);
 
 static void on_cfg_open_file(GtkButton *b, gpointer d) {
     (void)b; (void)d;
@@ -923,10 +1069,8 @@ static gboolean reset_cfg_copy_label(gpointer data) {
 
 static void on_cfg_copy_json(GtkButton *b, gpointer d) {
     (void)b; (void)d;
-    GatewayConfig *cfg = gateway_client_get_config();
-    if (!cfg || !cfg->config_path) return;
-    g_autofree gchar *contents = NULL;
-    if (!g_file_get_contents(cfg->config_path, &contents, NULL, NULL)) return;
+    g_autofree gchar *contents = cfg_editor_get_text();
+    if (!contents) return;
 
     GdkClipboard *cb = gdk_display_get_clipboard(gdk_display_get_default());
     gdk_clipboard_set_text(cb, contents);
@@ -949,6 +1093,167 @@ static gchar* cfg_get_modified_text(const char *path) {
 
     g_autoptr(GDateTime) local = g_date_time_to_local(dt);
     return g_date_time_format(local, "%Y-%m-%d %H:%M:%S");
+}
+
+static gchar* cfg_editor_get_text(void) {
+    if (!cfg_json_view) return g_strdup("");
+    GtkTextBuffer *buf = gtk_text_view_get_buffer(GTK_TEXT_VIEW(cfg_json_view));
+    GtkTextIter start;
+    GtkTextIter end;
+    gtk_text_buffer_get_bounds(buf, &start, &end);
+    return gtk_text_buffer_get_text(buf, &start, &end, FALSE);
+}
+
+static void cfg_refresh_buttons(void) {
+    if (cfg_reload_btn) {
+        gtk_widget_set_sensitive(cfg_reload_btn, !cfg_request_in_flight);
+    }
+    if (cfg_save_btn) {
+        gtk_widget_set_sensitive(cfg_save_btn,
+            !cfg_request_in_flight && cfg_editor_dirty && cfg_editor_valid);
+    }
+}
+
+static gboolean cfg_validate_and_track(const gchar *text) {
+    g_autoptr(JsonParser) parser = json_parser_new();
+    g_autoptr(GError) err = NULL;
+    gboolean valid = json_parser_load_from_data(parser, text ? text : "", -1, &err);
+
+    if (valid) {
+        JsonNode *root = json_parser_get_root(parser);
+        valid = (root && JSON_NODE_HOLDS_OBJECT(root));
+        if (!valid && cfg_validation_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Validation: root value must be a JSON object");
+        }
+    } else if (cfg_validation_label) {
+        g_autofree gchar *msg = g_strdup_printf("Validation: %s",
+            err && err->message ? err->message : "invalid JSON");
+        gtk_label_set_text(GTK_LABEL(cfg_validation_label), msg);
+    }
+
+    if (valid && cfg_validation_label) {
+        gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Validation: JSON is valid");
+    }
+
+    cfg_editor_valid = valid;
+    cfg_editor_dirty = (g_strcmp0(text ? text : "", cfg_baseline_text ? cfg_baseline_text : "") != 0);
+    cfg_refresh_buttons();
+    return valid;
+}
+
+static void on_cfg_buffer_changed(GtkTextBuffer *buffer, gpointer user_data) {
+    (void)buffer;
+    (void)user_data;
+    if (cfg_programmatic_change) return;
+    g_autofree gchar *text = cfg_editor_get_text();
+    cfg_validate_and_track(text);
+}
+
+static void on_cfg_get_done(const GatewayRpcResponse *response, gpointer user_data) {
+    (void)user_data;
+    cfg_request_in_flight = FALSE;
+
+    if (!response || !response->ok) {
+        if (cfg_validation_label) {
+            g_autofree gchar *msg = g_strdup_printf("Load failed: %s",
+                response && response->error_msg ? response->error_msg : "unknown error");
+            gtk_label_set_text(GTK_LABEL(cfg_validation_label), msg);
+        }
+        cfg_refresh_buttons();
+        return;
+    }
+
+    GatewayConfigSnapshot *snapshot = gateway_data_parse_config_get(response->payload);
+    if (!snapshot || !snapshot->config) {
+        if (cfg_validation_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Load failed: invalid config response");
+        }
+        gateway_config_snapshot_free(snapshot);
+        cfg_refresh_buttons();
+        return;
+    }
+
+    JsonNode *node = json_node_new(JSON_NODE_OBJECT);
+    json_node_set_object(node, snapshot->config);
+    g_autofree gchar *pretty = json_to_string(node, TRUE);
+    json_node_unref(node);
+
+    g_free(cfg_baseline_text);
+    cfg_baseline_text = g_strdup(pretty ? pretty : "{}");
+    g_free(cfg_baseline_hash);
+    cfg_baseline_hash = g_strdup(snapshot->hash);
+
+    if (cfg_json_view) {
+        GtkTextBuffer *buf = gtk_text_view_get_buffer(GTK_TEXT_VIEW(cfg_json_view));
+        cfg_programmatic_change = TRUE;
+        gtk_text_buffer_set_text(buf, cfg_baseline_text, -1);
+        cfg_programmatic_change = FALSE;
+    }
+
+    cfg_editor_dirty = FALSE;
+    cfg_validate_and_track(cfg_baseline_text);
+    cfg_refresh_buttons();
+    gateway_config_snapshot_free(snapshot);
+}
+
+static void cfg_request_reload(void) {
+    if (cfg_request_in_flight) return;
+    cfg_request_in_flight = TRUE;
+    cfg_refresh_buttons();
+    g_autofree gchar *rid = mutation_config_get(NULL, on_cfg_get_done, NULL);
+    if (!rid) {
+        cfg_request_in_flight = FALSE;
+        if (cfg_validation_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Failed to request config.get");
+        }
+        cfg_refresh_buttons();
+    }
+}
+
+static void on_cfg_reload(GtkButton *b, gpointer d) {
+    (void)b;
+    (void)d;
+    cfg_request_reload();
+}
+
+static void on_cfg_save_done(const GatewayRpcResponse *response, gpointer user_data) {
+    (void)user_data;
+    cfg_request_in_flight = FALSE;
+    if (!response || !response->ok) {
+        if (cfg_validation_label) {
+            g_autofree gchar *msg = g_strdup_printf("Save failed: %s",
+                response && response->error_msg ? response->error_msg : "unknown error");
+            gtk_label_set_text(GTK_LABEL(cfg_validation_label), msg);
+        }
+        cfg_refresh_buttons();
+        return;
+    }
+
+    if (cfg_validation_label) {
+        gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Save successful. Reloading baseline…");
+    }
+    cfg_request_reload();
+}
+
+static void on_cfg_save(GtkButton *b, gpointer d) {
+    (void)b;
+    (void)d;
+    if (cfg_request_in_flight) return;
+
+    g_autofree gchar *text = cfg_editor_get_text();
+    if (!cfg_validate_and_track(text)) return;
+    if (!cfg_editor_dirty) return;
+
+    cfg_request_in_flight = TRUE;
+    cfg_refresh_buttons();
+    g_autofree gchar *rid = mutation_config_set(text, cfg_baseline_hash, on_cfg_save_done, NULL);
+    if (!rid) {
+        cfg_request_in_flight = FALSE;
+        if (cfg_validation_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Failed to request config.set");
+        }
+        cfg_refresh_buttons();
+    }
 }
 
 static GtkWidget* build_config_section(void) {
@@ -1030,11 +1335,12 @@ static GtkWidget* build_config_section(void) {
 
     GtkTextBuffer *json_buf = gtk_text_buffer_new(NULL);
     cfg_json_view = gtk_text_view_new_with_buffer(json_buf);
-    gtk_text_view_set_editable(GTK_TEXT_VIEW(cfg_json_view), FALSE);
-    gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(cfg_json_view), FALSE);
+    gtk_text_view_set_editable(GTK_TEXT_VIEW(cfg_json_view), TRUE);
+    gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(cfg_json_view), TRUE);
     gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(cfg_json_view), GTK_WRAP_WORD_CHAR);
     gtk_text_view_set_monospace(GTK_TEXT_VIEW(cfg_json_view), TRUE);
     gtk_widget_set_vexpand(cfg_json_view, TRUE);
+    g_signal_connect(json_buf, "changed", G_CALLBACK(on_cfg_buffer_changed), NULL);
 
     GtkWidget *json_scrolled = gtk_scrolled_window_new();
     gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(json_scrolled), cfg_json_view);
@@ -1042,15 +1348,32 @@ static GtkWidget* build_config_section(void) {
     gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(json_scrolled), 200);
     gtk_box_append(GTK_BOX(page), json_scrolled);
 
-    /* 6. Copy action */
+    cfg_validation_label = gtk_label_new("Validation: loading config…");
+    gtk_widget_add_css_class(cfg_validation_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(cfg_validation_label), 0.0);
+    gtk_widget_set_margin_top(cfg_validation_label, 6);
+    gtk_box_append(GTK_BOX(page), cfg_validation_label);
+
+    /* 6. Reload / save / copy actions */
     GtkWidget *copy_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
     gtk_widget_set_margin_top(copy_row, 6);
+
+    cfg_reload_btn = gtk_button_new_with_label("Reload");
+    g_signal_connect(cfg_reload_btn, "clicked", G_CALLBACK(on_cfg_reload), NULL);
+    gtk_box_append(GTK_BOX(copy_row), cfg_reload_btn);
+
+    cfg_save_btn = gtk_button_new_with_label("Save");
+    gtk_widget_add_css_class(cfg_save_btn, "suggested-action");
+    g_signal_connect(cfg_save_btn, "clicked", G_CALLBACK(on_cfg_save), NULL);
+    gtk_box_append(GTK_BOX(copy_row), cfg_save_btn);
 
     cfg_copy_btn = gtk_button_new_with_label("Copy Config JSON");
     g_signal_connect(cfg_copy_btn, "clicked", G_CALLBACK(on_cfg_copy_json), NULL);
     gtk_box_append(GTK_BOX(copy_row), cfg_copy_btn);
 
     gtk_box_append(GTK_BOX(page), copy_row);
+
+    cfg_refresh_buttons();
 
     return page;
 }
@@ -1092,14 +1415,12 @@ static void refresh_config_content(void) {
     g_autofree gchar *mod_label = g_strdup_printf("Last modified: %s", mod_text);
     gtk_label_set_text(GTK_LABEL(cfg_modified_label), mod_label);
 
-    /* 5. Raw JSON */
-    if (cfg_json_view && path) {
-        g_autofree gchar *contents = NULL;
-        if (g_file_get_contents(path, &contents, NULL, NULL)) {
-            GtkTextBuffer *buf = gtk_text_view_get_buffer(GTK_TEXT_VIEW(cfg_json_view));
-            gtk_text_buffer_set_text(buf, contents, -1);
-        }
+    if (!cfg_initial_load_requested && gateway_rpc_is_ready()) {
+        cfg_initial_load_requested = TRUE;
+        cfg_request_reload();
     }
+
+    cfg_refresh_buttons();
 }
 
 /* ══════════════════════════════════════════════════════════════════
@@ -1539,6 +1860,7 @@ static gboolean on_refresh_tick(gpointer user_data) {
         refresh_environment_content();
         section_instances_refresh_local();
         refresh_debug_content();
+        refresh_shell_status_footer();
         /* RPC-backed sections refresh on activation + TTL, not every tick */
         refresh_active_rpc_section(active_section);
         
@@ -1562,6 +1884,11 @@ static void on_window_destroy(GtkWindow *window, gpointer user_data) {
     main_window = NULL;
     content_stack = NULL;
     sidebar_list = NULL;
+    shell_gateway_status_label = NULL;
+    shell_gateway_status_dot = NULL;
+    shell_service_status_label = NULL;
+    shell_service_status_dot = NULL;
+    shell_seen_gateway_connected = FALSE;
 
     dash_headline_label = NULL;
     dash_runtime_label = NULL;
@@ -1608,11 +1935,21 @@ static void on_window_destroy(GtkWindow *window, gpointer user_data) {
     cfg_warning_label = NULL;
     cfg_issues_label = NULL;
     cfg_json_view = NULL;
+    cfg_validation_label = NULL;
     if (cfg_copy_reset_id > 0) {
         g_source_remove(cfg_copy_reset_id);
         cfg_copy_reset_id = 0;
     }
     cfg_copy_btn = NULL;
+    cfg_reload_btn = NULL;
+    cfg_save_btn = NULL;
+    cfg_programmatic_change = FALSE;
+    cfg_editor_dirty = FALSE;
+    cfg_editor_valid = TRUE;
+    cfg_request_in_flight = FALSE;
+    cfg_initial_load_requested = FALSE;
+    g_clear_pointer(&cfg_baseline_text, g_free);
+    g_clear_pointer(&cfg_baseline_hash, g_free);
 
     if (diag_copy_reset_id > 0) {
         g_source_remove(diag_copy_reset_id);
@@ -1650,6 +1987,8 @@ void app_window_show(void) {
 
     GApplication *app = g_application_get_default();
     if (!app) return;
+
+    ensure_app_css_loaded();
 
     main_window = adw_application_window_new(GTK_APPLICATION(app));
     gtk_window_set_title(GTK_WINDOW(main_window), "OpenClaw");
@@ -1696,6 +2035,7 @@ void app_window_show(void) {
     refresh_environment_content();
     section_instances_refresh_local();
     refresh_debug_content();
+    refresh_shell_status_footer();
     last_rpc_ready = gateway_rpc_is_ready();
     last_app_state = state_get_current();
     /* RPC-backed sections will fetch on first sidebar activation */
@@ -1719,6 +2059,21 @@ void app_window_navigate_to(AppSection section) {
             gtk_list_box_select_row(GTK_LIST_BOX(sidebar_list), row);
         }
     }
+    refresh_active_rpc_section(active_section);
+}
+
+void app_window_refresh_snapshot(void) {
+    invalidate_all_rpc_sections();
+
+    refresh_dashboard_content();
+    refresh_general_content();
+    refresh_config_content();
+    refresh_diagnostics_content();
+    refresh_environment_content();
+    section_instances_refresh_local();
+    refresh_debug_content();
+    refresh_shell_status_footer();
+
     refresh_active_rpc_section(active_section);
 }
 

--- a/apps/linux/src/app_window.h
+++ b/apps/linux/src/app_window.h
@@ -42,3 +42,4 @@ typedef enum {
 void app_window_show(void);
 void app_window_navigate_to(AppSection section);
 gboolean app_window_is_visible(void);
+void app_window_refresh_snapshot(void);

--- a/apps/linux/src/gateway_mutations.c
+++ b/apps/linux/src/gateway_mutations.c
@@ -131,6 +131,7 @@ gchar* mutation_skills_update_api_key(const gchar *skill_key, const gchar *api_k
 gchar* mutation_sessions_patch(const gchar *session_key,
                                const gchar *thinking_level,
                                const gchar *verbose_level,
+                               const gchar *model,
                                GatewayRpcCallback cb, gpointer data) {
     JsonBuilder *b = json_builder_new();
     json_builder_begin_object(b);
@@ -143,6 +144,10 @@ gchar* mutation_sessions_patch(const gchar *session_key,
     if (verbose_level) {
         json_builder_set_member_name(b, "verboseLevel");
         json_builder_add_string_value(b, verbose_level);
+    }
+    if (model) {
+        json_builder_set_member_name(b, "model");
+        json_builder_add_string_value(b, model);
     }
     json_builder_end_object(b);
     JsonNode *params = json_builder_get_root(b);

--- a/apps/linux/src/gateway_mutations.h
+++ b/apps/linux/src/gateway_mutations.h
@@ -50,6 +50,7 @@ gchar* mutation_skills_update_api_key(const gchar *skill_key, const gchar *api_k
 gchar* mutation_sessions_patch(const gchar *session_key,
                                const gchar *thinking_level,
                                const gchar *verbose_level,
+                               const gchar *model,
                                GatewayRpcCallback cb, gpointer data);
 
 gchar* mutation_sessions_reset(const gchar *session_key,

--- a/apps/linux/src/notify.c
+++ b/apps/linux/src/notify.c
@@ -64,3 +64,28 @@ void notify_on_transition(AppState old_state, AppState new_state) {
         OC_LOG_DEBUG(OPENCLAW_LOG_CAT_NOTIFY, "notify_on_transition no-send");
     }
 }
+
+void notify_on_gateway_connection_transition(gboolean connected) {
+    GApplication *app = g_application_get_default();
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_NOTIFY,
+                 "notify_on_gateway_connection_transition connected=%d app=%p registered=%d",
+                 connected,
+                 (void *)app,
+                 app ? g_application_get_is_registered(app) : 0);
+
+    if (!app || !g_application_get_is_registered(app)) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_NOTIFY,
+                     "notify_on_gateway_connection_transition skip (not registered)");
+        return;
+    }
+
+    const char *title = connected ? "Gateway Connected" : "Gateway Disconnected";
+    const char *body = connected
+                           ? "OpenClaw gateway connection is established."
+                           : "OpenClaw gateway connection was lost.";
+
+    g_autoptr(GNotification) notification = g_notification_new(title);
+    g_notification_set_body(notification, body);
+    g_application_send_notification(app, "openclaw-gateway-connection", notification);
+}

--- a/apps/linux/src/onboarding.c
+++ b/apps/linux/src/onboarding.c
@@ -74,6 +74,10 @@ static GtkWidget *onboard_indicator = NULL;
 typedef struct {
     AppState state;
     OnboardingRoute route;
+    OnboardingStageState stage_configuration;
+    OnboardingStageState stage_service_gateway;
+    OnboardingStageState stage_connection;
+    gboolean operational_ready;
     gboolean config_valid;
     gboolean setup_detected;
     gboolean sys_installed;
@@ -148,6 +152,67 @@ static void on_close_clicked(GtkButton *btn, gpointer data) {
     }
 }
 
+static const char* stage_icon(OnboardingStageState state) {
+    switch (state) {
+        case ONBOARDING_STAGE_COMPLETE: return "\u2705";
+        case ONBOARDING_STAGE_IN_PROGRESS: return "\u23F3";
+        case ONBOARDING_STAGE_PENDING:
+        default: return "\u25CB";
+    }
+}
+
+static const char* stage_detail_for_config(OnboardingStageState state) {
+    switch (state) {
+        case ONBOARDING_STAGE_COMPLETE: return "Configuration validated";
+        case ONBOARDING_STAGE_IN_PROGRESS: return "Resolving configuration issues";
+        case ONBOARDING_STAGE_PENDING:
+        default: return "Configuration not ready yet";
+    }
+}
+
+static const char* stage_detail_for_service(OnboardingStageState state) {
+    switch (state) {
+        case ONBOARDING_STAGE_COMPLETE: return "Service installed and active";
+        case ONBOARDING_STAGE_IN_PROGRESS: return "Service install or activation in progress";
+        case ONBOARDING_STAGE_PENDING:
+        default: return "Service setup pending";
+    }
+}
+
+static const char* stage_detail_for_connection(OnboardingStageState state) {
+    switch (state) {
+        case ONBOARDING_STAGE_COMPLETE: return "Gateway connection established";
+        case ONBOARDING_STAGE_IN_PROGRESS: return "Waiting for stable connection";
+        case ONBOARDING_STAGE_PENDING:
+        default: return "Connection not attempted yet";
+    }
+}
+
+static GtkWidget* build_stage_row(const char *label, OnboardingStageState state, const char *detail) {
+    GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_margin_top(row, 2);
+
+    GtkWidget *icon = gtk_label_new(stage_icon(state));
+    gtk_box_append(GTK_BOX(row), icon);
+
+    GtkWidget *text_col = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
+    gtk_widget_set_hexpand(text_col, TRUE);
+
+    GtkWidget *title = gtk_label_new(label);
+    gtk_widget_add_css_class(title, "heading");
+    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
+    gtk_box_append(GTK_BOX(text_col), title);
+
+    GtkWidget *detail_lbl = gtk_label_new(detail);
+    gtk_widget_add_css_class(detail_lbl, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(detail_lbl), 0.0);
+    gtk_label_set_wrap(GTK_LABEL(detail_lbl), TRUE);
+    gtk_box_append(GTK_BOX(text_col), detail_lbl);
+
+    gtk_box_append(GTK_BOX(row), text_col);
+    return row;
+}
+
 /* ── Page builders ── */
 
 static GtkWidget* build_welcome_page(GtkWidget *carousel) {
@@ -215,6 +280,9 @@ static GtkWidget* build_gateway_page(GtkWidget *carousel) {
     ReadinessInfo ri;
     readiness_evaluate(current, health, sys, &ri);
 
+    OnboardingStageProgress progress;
+    readiness_build_onboarding_progress(current, health, sys, &progress);
+
     /* State-aware guidance text */
     GtkWidget *explanation = gtk_label_new(NULL);
     if (current == STATE_NEEDS_SETUP) {
@@ -233,6 +301,28 @@ static GtkWidget* build_gateway_page(GtkWidget *carousel) {
     gtk_label_set_wrap(GTK_LABEL(explanation), TRUE);
     gtk_label_set_xalign(GTK_LABEL(explanation), 0.0);
     gtk_box_append(GTK_BOX(page), explanation);
+
+    GtkWidget *stage_heading = gtk_label_new("Setup progress");
+    gtk_widget_add_css_class(stage_heading, "heading");
+    gtk_label_set_xalign(GTK_LABEL(stage_heading), 0.0);
+    gtk_widget_set_margin_top(stage_heading, 12);
+    gtk_box_append(GTK_BOX(page), stage_heading);
+
+    GtkWidget *stages = gtk_box_new(GTK_ORIENTATION_VERTICAL, 4);
+    gtk_widget_set_margin_top(stages, 4);
+    gtk_box_append(GTK_BOX(stages),
+                   build_stage_row("Configuration",
+                                   progress.configuration,
+                                   stage_detail_for_config(progress.configuration)));
+    gtk_box_append(GTK_BOX(stages),
+                   build_stage_row("Service / Gateway",
+                                   progress.service_gateway,
+                                   stage_detail_for_service(progress.service_gateway)));
+    gtk_box_append(GTK_BOX(stages),
+                   build_stage_row("Connection",
+                                   progress.connection,
+                                   stage_detail_for_connection(progress.connection)));
+    gtk_box_append(GTK_BOX(page), stages);
 
     if (ri.next_action) {
         GtkWidget *action_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
@@ -527,9 +617,28 @@ void onboarding_refresh(void) {
     ReadinessInfo ri;
     readiness_evaluate(current, health, sys, &ri);
 
+    OnboardingStageProgress progress;
+    readiness_build_onboarding_progress(current, health, sys, &progress);
+
+    if (progress.operational_ready) {
+        write_seen_version(ONBOARDING_CURRENT_VERSION);
+        if (onboard_window) {
+            gtk_window_destroy(GTK_WINDOW(onboard_window));
+        }
+        app_window_show();
+        g_free(profile);
+        g_free(state_dir);
+        g_free(config_path);
+        return;
+    }
+
     OnboardingRenderSnapshot new_snap = {
         .state = current,
         .route = route,
+        .stage_configuration = progress.configuration,
+        .stage_service_gateway = progress.service_gateway,
+        .stage_connection = progress.connection,
+        .operational_ready = progress.operational_ready,
         .config_valid = health->config_valid,
         .setup_detected = health->setup_detected,
         .sys_installed = sys->installed,
@@ -546,6 +655,10 @@ void onboarding_refresh(void) {
     if (onboard_has_render_snapshot &&
         onboard_last_snapshot.state == new_snap.state &&
         onboard_last_snapshot.route == new_snap.route &&
+        onboard_last_snapshot.stage_configuration == new_snap.stage_configuration &&
+        onboard_last_snapshot.stage_service_gateway == new_snap.stage_service_gateway &&
+        onboard_last_snapshot.stage_connection == new_snap.stage_connection &&
+        onboard_last_snapshot.operational_ready == new_snap.operational_ready &&
         onboard_last_snapshot.config_valid == new_snap.config_valid &&
         onboard_last_snapshot.setup_detected == new_snap.setup_detected &&
         onboard_last_snapshot.sys_installed == new_snap.sys_installed &&

--- a/apps/linux/src/readiness.c
+++ b/apps/linux/src/readiness.c
@@ -130,3 +130,48 @@ void readiness_evaluate(AppState state, const HealthState *health,
         break;
     }
 }
+
+void readiness_build_onboarding_progress(AppState state,
+                                         const HealthState *health,
+                                         const SystemdState *sys,
+                                         OnboardingStageProgress *out) {
+    if (!out) return;
+
+    out->configuration = ONBOARDING_STAGE_PENDING;
+    out->service_gateway = ONBOARDING_STAGE_PENDING;
+    out->connection = ONBOARDING_STAGE_PENDING;
+    out->operational_ready = (state == STATE_RUNNING || state == STATE_RUNNING_WITH_WARNING);
+
+    gboolean config_complete = (health && health->config_valid);
+    gboolean service_installed = (sys && sys->installed);
+    gboolean service_active = (sys && sys->active);
+    gboolean connection_complete = (health && health->http_ok && health->ws_connected &&
+                                    health->rpc_ok && health->auth_ok);
+
+    if (config_complete) {
+        out->configuration = ONBOARDING_STAGE_COMPLETE;
+    } else if (state == STATE_CONFIG_INVALID || state == STATE_NEEDS_ONBOARDING ||
+               state == STATE_NEEDS_GATEWAY_INSTALL || state == STATE_STARTING ||
+               state == STATE_DEGRADED || state == STATE_RUNNING ||
+               state == STATE_RUNNING_WITH_WARNING) {
+        out->configuration = ONBOARDING_STAGE_IN_PROGRESS;
+    }
+
+    if (!config_complete) {
+        out->service_gateway = ONBOARDING_STAGE_PENDING;
+    } else if (service_installed && service_active) {
+        out->service_gateway = ONBOARDING_STAGE_COMPLETE;
+    } else if (service_installed) {
+        out->service_gateway = ONBOARDING_STAGE_IN_PROGRESS;
+    } else {
+        out->service_gateway = ONBOARDING_STAGE_PENDING;
+    }
+
+    if (!(service_installed && service_active)) {
+        out->connection = ONBOARDING_STAGE_PENDING;
+    } else if (connection_complete) {
+        out->connection = ONBOARDING_STAGE_COMPLETE;
+    } else {
+        out->connection = ONBOARDING_STAGE_IN_PROGRESS;
+    }
+}

--- a/apps/linux/src/readiness.h
+++ b/apps/linux/src/readiness.h
@@ -22,7 +22,25 @@ typedef struct {
     const char *next_action;     /* next recommended action, or NULL */
 } ReadinessInfo;
 
+typedef enum {
+    ONBOARDING_STAGE_PENDING = 0,
+    ONBOARDING_STAGE_IN_PROGRESS,
+    ONBOARDING_STAGE_COMPLETE,
+} OnboardingStageState;
+
+typedef struct {
+    OnboardingStageState configuration;
+    OnboardingStageState service_gateway;
+    OnboardingStageState connection;
+    gboolean operational_ready;
+} OnboardingStageProgress;
+
 void readiness_evaluate(AppState state, const HealthState *health,
                         const SystemdState *sys, ReadinessInfo *out);
+
+void readiness_build_onboarding_progress(AppState state,
+                                         const HealthState *health,
+                                         const SystemdState *sys,
+                                         OnboardingStageProgress *out);
 
 #endif /* OPENCLAW_LINUX_READINESS_H */

--- a/apps/linux/src/section_channels.c
+++ b/apps/linux/src/section_channels.c
@@ -51,17 +51,19 @@ static void on_mutation_done(const GatewayRpcResponse *response, gpointer user_d
 
 /* ── Action handlers ─────────────────────────────────────────────── */
 
-static void on_probe(GtkButton *btn, gpointer user_data) {
+static void on_refresh_all_channels(GtkButton *btn, gpointer user_data) {
     (void)user_data;
+
     gtk_widget_set_sensitive(GTK_WIDGET(btn), FALSE);
-    if (channels_status_label)
-        gtk_label_set_text(GTK_LABEL(channels_status_label), "Probing\u2026");
+    if (channels_status_label) {
+        gtk_label_set_text(GTK_LABEL(channels_status_label), "Refreshing all channels…");
+    }
 
     g_autofree gchar *req = mutation_channels_status(TRUE, on_mutation_done, NULL);
     if (!req) {
         gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
         if (channels_status_label)
-            gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to send request");
+            gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to send refresh request");
     }
 }
 
@@ -559,6 +561,7 @@ static void on_logout(GtkButton *btn, gpointer user_data) {
     (void)user_data;
     const gchar *channel_id = (const gchar *)g_object_get_data(G_OBJECT(btn), "channel-id");
     const gchar *label = (const gchar *)g_object_get_data(G_OBJECT(btn), "channel-label");
+    const gchar *account_id = (const gchar *)g_object_get_data(G_OBJECT(btn), "account-id");
     if (!channel_id) return;
 
     g_autofree gchar *body = g_strdup_printf(
@@ -573,6 +576,9 @@ static void on_logout(GtkButton *btn, gpointer user_data) {
     adw_alert_dialog_set_close_response(dialog, "cancel");
 
     g_object_set_data_full(G_OBJECT(dialog), "channel-id", g_strdup(channel_id), g_free);
+    if (account_id && account_id[0] != '\0') {
+        g_object_set_data_full(G_OBJECT(dialog), "account-id", g_strdup(account_id), g_free);
+    }
 
     GtkWidget *toplevel = GTK_WIDGET(gtk_widget_get_root(GTK_WIDGET(btn)));
     adw_alert_dialog_choose(dialog, toplevel, NULL, on_logout_dialog_response, NULL);
@@ -618,6 +624,11 @@ static void build_channel_card(GatewayChannel *ch) {
         gtk_widget_add_css_class(acct, "dim-label");
         gtk_box_append(GTK_BOX(hdr), acct);
     }
+
+    GtkWidget *status_chip = gtk_label_new(ch->connected ? "connected" : "disconnected");
+    gtk_widget_add_css_class(status_chip, "status-chip");
+    gtk_widget_add_css_class(status_chip, ch->connected ? "chip-ok" : "chip-error");
+    gtk_box_append(GTK_BOX(hdr), status_chip);
 
     gtk_box_append(GTK_BOX(card), hdr);
 
@@ -681,6 +692,13 @@ static void build_channel_card(GatewayChannel *ch) {
     g_signal_connect(btn_config, "clicked", G_CALLBACK(on_edit_config), NULL);
     gtk_box_append(GTK_BOX(actions), btn_config);
 
+    /* Refresh All (row-level affordance that maps to a global probe/refresh) */
+    GtkWidget *btn_probe = gtk_button_new_with_label("Refresh All");
+    gtk_widget_add_css_class(btn_probe, "flat");
+    gtk_widget_set_tooltip_text(btn_probe, "Refreshes connection status for all channels");
+    g_signal_connect(btn_probe, "clicked", G_CALLBACK(on_refresh_all_channels), NULL);
+    gtk_box_append(GTK_BOX(actions), btn_probe);
+
     /* Web Login (WhatsApp QR) */
     if (g_strcmp0(ch->channel_id, "whatsapp") == 0 && !ch->connected) {
         GtkWidget *btn_link = gtk_button_new_with_label("Link Device");
@@ -699,6 +717,10 @@ static void build_channel_card(GatewayChannel *ch) {
             g_strdup(ch->channel_id), g_free);
         g_object_set_data_full(G_OBJECT(btn_logout), "channel-label",
             g_strdup(ch_label), g_free);
+        if (ch->default_account_id) {
+            g_object_set_data_full(G_OBJECT(btn_logout), "account-id",
+                g_strdup(ch->default_account_id), g_free);
+        }
         g_signal_connect(btn_logout, "clicked", G_CALLBACK(on_logout), NULL);
         gtk_box_append(GTK_BOX(actions), btn_logout);
     }
@@ -837,7 +859,7 @@ static GtkWidget* channels_build(void) {
     GtkWidget *btn_probe = gtk_button_new_with_label("Probe All Channels");
     gtk_widget_add_css_class(btn_probe, "flat");
     gtk_widget_set_halign(btn_probe, GTK_ALIGN_START);
-    g_signal_connect(btn_probe, "clicked", G_CALLBACK(on_probe), NULL);
+    g_signal_connect(btn_probe, "clicked", G_CALLBACK(on_refresh_all_channels), NULL);
     gtk_box_append(GTK_BOX(page), btn_probe);
 
     GtkWidget *sep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);

--- a/apps/linux/src/section_control_room.c
+++ b/apps/linux/src/section_control_room.c
@@ -8,6 +8,7 @@
 
 #include <adwaita.h>
 
+#include "app_window.h"
 #include "gateway_mutations.h"
 #include "gateway_rpc.h"
 #include "json_access.h"
@@ -18,11 +19,26 @@ static GtkWidget *control_status_label = NULL;
 static GtkWidget *control_summary_label = NULL;
 static GtkWidget *control_nodes_box = NULL;
 static GtkWidget *control_details_label = NULL;
+static GtkWidget *control_gateway_health_label = NULL;
+static GtkWidget *control_service_label = NULL;
+static GtkWidget *control_version_label = NULL;
+static GtkWidget *control_agents_count_label = NULL;
+static GtkWidget *control_sessions_count_label = NULL;
 static GtkWidget *control_cron_job_entry = NULL;
 static GtkWidget *control_abort_session_entry = NULL;
 
-static gboolean control_fetch_in_flight = FALSE;
+static gboolean control_nodes_fetch_in_flight = FALSE;
+static gboolean control_agents_fetch_in_flight = FALSE;
+static gboolean control_sessions_fetch_in_flight = FALSE;
 static gint64 control_last_fetch_us = 0;
+
+static void control_request_snapshot(void);
+
+static void control_set_count_label(GtkWidget *label, const gchar *prefix, gint count) {
+    if (!label) return;
+    g_autofree gchar *text = g_strdup_printf("%s%d", prefix, count);
+    gtk_label_set_text(GTK_LABEL(label), text);
+}
 
 static void control_set_summary_from_state(void) {
     if (!control_summary_label) return;
@@ -43,6 +59,28 @@ static void control_set_summary_from_state(void) {
                                                 mode_presentation.label ? mode_presentation.label : "Runtime unknown",
                                                 ws ? "connected" : "disconnected");
     gtk_label_set_text(GTK_LABEL(control_summary_label), summary);
+
+    if (control_gateway_health_label) {
+        const gchar *gateway_health = "Gateway: Connecting";
+        if (sys && !sys->active) {
+            gateway_health = "Gateway: Service inactive";
+        } else if (health && health->http_ok && health->ws_connected && health->rpc_ok && health->auth_ok) {
+            gateway_health = "Gateway: Connected";
+        } else if (health && health->http_ok) {
+            gateway_health = "Gateway: Degraded";
+        }
+        gtk_label_set_text(GTK_LABEL(control_gateway_health_label), gateway_health);
+    }
+
+    if (control_service_label) {
+        gtk_label_set_text(GTK_LABEL(control_service_label),
+                           (sys && sys->active) ? "Service: Active" : "Service: Inactive");
+    }
+
+    if (control_version_label) {
+        gtk_label_set_text(GTK_LABEL(control_version_label),
+                           (health && health->gateway_version) ? health->gateway_version : "—");
+    }
 
     if (control_details_label) {
         g_autofree gchar *details = g_strdup_printf("State: %s | Setup: %s | Model config: %s",
@@ -65,22 +103,68 @@ static void on_control_mutation_done(const GatewayRpcResponse *response, gpointe
     section_mark_stale(&control_last_fetch_us);
 }
 
-static void on_probe_channels_clicked(GtkButton *button, gpointer user_data) {
-    (void)button;
-    (void)user_data;
-    g_autofree gchar *rid = mutation_channels_status(TRUE, on_control_mutation_done, NULL);
-    if (!rid && control_status_label) {
-        gtk_label_set_text(GTK_LABEL(control_status_label), "Probe request failed");
+static void control_maybe_finish_refresh(void) {
+    if (control_nodes_fetch_in_flight || control_agents_fetch_in_flight || control_sessions_fetch_in_flight) {
+        return;
+    }
+    section_mark_fresh(&control_last_fetch_us);
+    if (control_status_label) {
+        gtk_label_set_text(GTK_LABEL(control_status_label), "Snapshot refreshed");
     }
 }
 
-static void on_refresh_config_clicked(GtkButton *button, gpointer user_data) {
+static void on_refresh_snapshot_clicked(GtkButton *button, gpointer user_data) {
     (void)button;
     (void)user_data;
-    g_autofree gchar *rid = mutation_config_get(NULL, on_control_mutation_done, NULL);
-    if (!rid && control_status_label) {
-        gtk_label_set_text(GTK_LABEL(control_status_label), "Config refresh request failed");
+
+    app_window_refresh_snapshot();
+    section_mark_stale(&control_last_fetch_us);
+    if (control_status_label) {
+        gtk_label_set_text(GTK_LABEL(control_status_label), "Refreshing snapshot…");
     }
+    control_request_snapshot();
+}
+
+static void on_control_agents_response(const GatewayRpcResponse *response, gpointer user_data) {
+    (void)user_data;
+    control_agents_fetch_in_flight = FALSE;
+
+    gint count = 0;
+    if (response && response->ok && response->payload && JSON_NODE_HOLDS_OBJECT(response->payload)) {
+        JsonObject *obj = json_node_get_object(response->payload);
+        JsonNode *agents_node = json_object_get_member(obj, "agents");
+        if (agents_node && JSON_NODE_HOLDS_ARRAY(agents_node)) {
+            count = (gint)json_array_get_length(json_node_get_array(agents_node));
+        }
+    }
+
+    control_set_count_label(control_agents_count_label, "", count);
+    control_maybe_finish_refresh();
+}
+
+static void on_control_sessions_response(const GatewayRpcResponse *response, gpointer user_data) {
+    (void)user_data;
+    control_sessions_fetch_in_flight = FALSE;
+
+    gint count = 0;
+    if (response && response->ok && response->payload && JSON_NODE_HOLDS_OBJECT(response->payload)) {
+        JsonObject *obj = json_node_get_object(response->payload);
+        JsonNode *count_node = json_object_get_member(obj, "count");
+        if (count_node && JSON_NODE_HOLDS_VALUE(count_node)) {
+            if (json_node_get_value_type(count_node) == G_TYPE_INT64 ||
+                json_node_get_value_type(count_node) == G_TYPE_INT) {
+                count = (gint)json_node_get_int(count_node);
+            }
+        } else {
+            JsonNode *sessions_node = json_object_get_member(obj, "sessions");
+            if (sessions_node && JSON_NODE_HOLDS_ARRAY(sessions_node)) {
+                count = (gint)json_array_get_length(json_node_get_array(sessions_node));
+            }
+        }
+    }
+
+    control_set_count_label(control_sessions_count_label, "", count);
+    control_maybe_finish_refresh();
 }
 
 static void on_run_cron_clicked(GtkButton *button, gpointer user_data) {
@@ -136,7 +220,7 @@ static void on_abort_session_clicked(GtkButton *button, gpointer user_data) {
 
 static void on_control_nodes_response(const GatewayRpcResponse *response, gpointer user_data) {
     (void)user_data;
-    control_fetch_in_flight = FALSE;
+    control_nodes_fetch_in_flight = FALSE;
 
     if (!control_status_label) return;
 
@@ -144,7 +228,8 @@ static void on_control_nodes_response(const GatewayRpcResponse *response, gpoint
     control_set_summary_from_state();
 
     if (!response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
-        gtk_label_set_text(GTK_LABEL(control_status_label), "Failed to load nodes");
+        gtk_label_set_text(GTK_LABEL(control_status_label), "Failed to load node snapshot");
+        control_maybe_finish_refresh();
         return;
     }
 
@@ -189,8 +274,43 @@ static void on_control_nodes_response(const GatewayRpcResponse *response, gpoint
         }
     }
 
-    section_mark_fresh(&control_last_fetch_us);
-    gtk_label_set_text(GTK_LABEL(control_status_label), "Control room updated");
+    control_maybe_finish_refresh();
+}
+
+static void control_request_snapshot(void) {
+    if (!gateway_rpc_is_ready()) {
+        if (control_status_label) {
+            gtk_label_set_text(GTK_LABEL(control_status_label), "Gateway not connected");
+        }
+        return;
+    }
+
+    if (!control_nodes_fetch_in_flight) {
+        control_nodes_fetch_in_flight = TRUE;
+        g_autofree gchar *rid_nodes = gateway_rpc_request("node.list", NULL, 0,
+                                                          on_control_nodes_response, NULL);
+        if (!rid_nodes) {
+            control_nodes_fetch_in_flight = FALSE;
+        }
+    }
+
+    if (!control_agents_fetch_in_flight) {
+        control_agents_fetch_in_flight = TRUE;
+        g_autofree gchar *rid_agents = gateway_rpc_request("agents.list", NULL, 0,
+                                                           on_control_agents_response, NULL);
+        if (!rid_agents) {
+            control_agents_fetch_in_flight = FALSE;
+        }
+    }
+
+    if (!control_sessions_fetch_in_flight) {
+        control_sessions_fetch_in_flight = TRUE;
+        g_autofree gchar *rid_sessions = gateway_rpc_request("sessions.list", NULL, 0,
+                                                             on_control_sessions_response, NULL);
+        if (!rid_sessions) {
+            control_sessions_fetch_in_flight = FALSE;
+        }
+    }
 }
 
 static GtkWidget* control_build(void) {
@@ -223,28 +343,41 @@ static GtkWidget* control_build(void) {
     gtk_label_set_xalign(GTK_LABEL(control_details_label), 0.0);
     gtk_box_append(GTK_BOX(page), control_details_label);
 
-    GtkWidget *actions = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
-    GtkWidget *probe_btn = gtk_button_new_with_label("Probe Channels");
-    GtkWidget *cfg_btn = gtk_button_new_with_label("Refresh Config Snapshot");
+    GtkWidget *runtime_group = gtk_box_new(GTK_ORIENTATION_VERTICAL, 4);
+    gtk_widget_set_margin_top(runtime_group, 8);
+    gtk_box_append(GTK_BOX(runtime_group), section_info_row("Gateway", 120, &control_gateway_health_label));
+    gtk_box_append(GTK_BOX(runtime_group), section_info_row("Service", 120, &control_service_label));
+    gtk_box_append(GTK_BOX(runtime_group), section_info_row("Server Version", 120, &control_version_label));
+    gtk_box_append(GTK_BOX(runtime_group), section_info_row("Agents", 120, &control_agents_count_label));
+    gtk_box_append(GTK_BOX(runtime_group), section_info_row("Sessions", 120, &control_sessions_count_label));
+    gtk_box_append(GTK_BOX(page), runtime_group);
+
+    GtkWidget *refresh_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    GtkWidget *refresh_btn = gtk_button_new_with_label("Refresh Snapshot");
+    gtk_widget_add_css_class(refresh_btn, "suggested-action");
+    g_signal_connect(refresh_btn, "clicked", G_CALLBACK(on_refresh_snapshot_clicked), NULL);
+    gtk_box_append(GTK_BOX(refresh_row), refresh_btn);
+    gtk_box_append(GTK_BOX(page), refresh_row);
+
+    GtkWidget *cron_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
     GtkWidget *cron_btn = gtk_button_new_with_label("Run Cron Job");
-    GtkWidget *abort_btn = gtk_button_new_with_label("Abort Active Chat Session");
     control_cron_job_entry = gtk_entry_new();
     gtk_entry_set_placeholder_text(GTK_ENTRY(control_cron_job_entry), "cron job id (for cron.run)");
     gtk_widget_set_size_request(control_cron_job_entry, 220, -1);
+    g_signal_connect(cron_btn, "clicked", G_CALLBACK(on_run_cron_clicked), NULL);
+    gtk_box_append(GTK_BOX(cron_row), control_cron_job_entry);
+    gtk_box_append(GTK_BOX(cron_row), cron_btn);
+    gtk_box_append(GTK_BOX(page), cron_row);
+
+    GtkWidget *abort_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    GtkWidget *abort_btn = gtk_button_new_with_label("Abort Active Chat Session");
     control_abort_session_entry = gtk_entry_new();
     gtk_entry_set_placeholder_text(GTK_ENTRY(control_abort_session_entry), "session key (for chat.abort)");
     gtk_widget_set_hexpand(control_abort_session_entry, TRUE);
-    g_signal_connect(probe_btn, "clicked", G_CALLBACK(on_probe_channels_clicked), NULL);
-    g_signal_connect(cfg_btn, "clicked", G_CALLBACK(on_refresh_config_clicked), NULL);
-    g_signal_connect(cron_btn, "clicked", G_CALLBACK(on_run_cron_clicked), NULL);
     g_signal_connect(abort_btn, "clicked", G_CALLBACK(on_abort_session_clicked), NULL);
-    gtk_box_append(GTK_BOX(actions), probe_btn);
-    gtk_box_append(GTK_BOX(actions), cfg_btn);
-    gtk_box_append(GTK_BOX(actions), control_cron_job_entry);
-    gtk_box_append(GTK_BOX(actions), cron_btn);
-    gtk_box_append(GTK_BOX(actions), control_abort_session_entry);
-    gtk_box_append(GTK_BOX(actions), abort_btn);
-    gtk_box_append(GTK_BOX(page), actions);
+    gtk_box_append(GTK_BOX(abort_row), control_abort_session_entry);
+    gtk_box_append(GTK_BOX(abort_row), abort_btn);
+    gtk_box_append(GTK_BOX(page), abort_row);
 
     GtkWidget *nodes_title = gtk_label_new("Remote Instances");
     gtk_widget_add_css_class(nodes_title, "heading");
@@ -260,7 +393,7 @@ static GtkWidget* control_build(void) {
 }
 
 static void control_refresh(void) {
-    if (!control_status_label || control_fetch_in_flight) return;
+    if (!control_status_label) return;
     control_set_summary_from_state();
     if (!gateway_rpc_is_ready()) {
         gtk_label_set_text(GTK_LABEL(control_status_label), "Gateway not connected");
@@ -268,23 +401,25 @@ static void control_refresh(void) {
     }
     if (!section_is_stale(&control_last_fetch_us)) return;
 
-    control_fetch_in_flight = TRUE;
-    g_autofree gchar *rid = gateway_rpc_request("node.list", NULL, 0,
-                                                on_control_nodes_response, NULL);
-    if (!rid) {
-        control_fetch_in_flight = FALSE;
-        gtk_label_set_text(GTK_LABEL(control_status_label), "Failed to request node.list");
-    }
+    gtk_label_set_text(GTK_LABEL(control_status_label), "Refreshing snapshot…");
+    control_request_snapshot();
 }
 
 static void control_destroy(void) {
     control_status_label = NULL;
     control_summary_label = NULL;
     control_details_label = NULL;
+    control_gateway_health_label = NULL;
+    control_service_label = NULL;
+    control_version_label = NULL;
+    control_agents_count_label = NULL;
+    control_sessions_count_label = NULL;
     control_cron_job_entry = NULL;
     control_abort_session_entry = NULL;
     control_nodes_box = NULL;
-    control_fetch_in_flight = FALSE;
+    control_nodes_fetch_in_flight = FALSE;
+    control_agents_fetch_in_flight = FALSE;
+    control_sessions_fetch_in_flight = FALSE;
     control_last_fetch_us = 0;
 }
 

--- a/apps/linux/src/section_instances.c
+++ b/apps/linux/src/section_instances.c
@@ -36,6 +36,7 @@ static GtkWidget *inst_state_label = NULL;
 /* Remote nodes */
 static GtkWidget *inst_remote_box = NULL;
 static GtkWidget *inst_remote_status_label = NULL;
+static GtkWidget *inst_copy_debug_btn = NULL;
 static GatewayNodesData *inst_nodes_cache = NULL;
 static gboolean inst_nodes_fetch_in_flight = FALSE;
 static gint64 inst_last_fetch_us = 0;
@@ -145,20 +146,57 @@ static void on_refresh_nodes(GtkButton *btn, gpointer user_data) {
     inst_force_refresh();
 }
 
+static gchar* inst_build_debug_summary(void) {
+    GString *s = g_string_new("OpenClaw Linux Instances Debug\n");
+
+    gint pending_count = 0;
+    gint paired_count = 0;
+    if (inst_pairing_cache) {
+        pending_count = inst_pairing_cache->n_pending;
+        paired_count = inst_pairing_cache->n_paired;
+    }
+    g_string_append_printf(s, "Pending pair requests: %d\n", pending_count);
+    g_string_append_printf(s, "Paired nodes: %d\n", paired_count);
+
+    gint total_nodes = inst_nodes_cache ? inst_nodes_cache->n_nodes : 0;
+    g_string_append_printf(s, "Nodes: %d\n", total_nodes);
+
+    if (inst_nodes_cache) {
+        for (gint i = 0; i < inst_nodes_cache->n_nodes; i++) {
+            GatewayNode *nd = &inst_nodes_cache->nodes[i];
+            g_string_append_printf(
+                s,
+                "- %s (%s) status=%s paired=%s platform=%s version=%s\n",
+                nd->display_name ? nd->display_name : "unknown",
+                nd->node_id ? nd->node_id : "unknown",
+                nd->connected ? "connected" : "disconnected",
+                nd->paired ? "true" : "false",
+                nd->platform ? nd->platform : "unknown",
+                nd->version ? nd->version : "unknown");
+        }
+    }
+
+    return g_string_free(s, FALSE);
+}
+
+static gboolean on_copy_debug_label_reset(gpointer data) {
+    GtkWidget *btn = GTK_WIDGET(data);
+    if (btn) {
+        gtk_button_set_label(GTK_BUTTON(btn), "Copy Debug Info");
+    }
+    return G_SOURCE_REMOVE;
+}
+
 static void on_copy_debug(GtkButton *btn, gpointer user_data) {
     (void)user_data;
-    const gchar *summary = (const gchar *)g_object_get_data(G_OBJECT(btn), "debug-summary");
+    g_autofree gchar *summary = inst_build_debug_summary();
     if (!summary) return;
 
     GdkClipboard *cb = gdk_display_get_clipboard(gdk_display_get_default());
     gdk_clipboard_set_text(cb, summary);
 
-    GtkWidget *toplevel = GTK_WIDGET(gtk_widget_get_root(GTK_WIDGET(btn)));
-    AdwToastOverlay *overlay = g_object_get_data(G_OBJECT(toplevel), "toast-overlay");
-    if (overlay) {
-        AdwToast *toast = adw_toast_new("Debug summary copied to clipboard");
-        adw_toast_overlay_add_toast(overlay, toast);
-    }
+    gtk_button_set_label(GTK_BUTTON(btn), "Copied!");
+    g_timeout_add_seconds(2, on_copy_debug_label_reset, btn);
 }
 
 /* ── Remote node card builder ────────────────────────────────────── */
@@ -220,42 +258,6 @@ static void build_node_card(GatewayNode *nd) {
         g_autofree gchar *at_text = g_strdup_printf("Approved %s", at);
         add_detail_row(card, "Approved", at_text);
     }
-
-    /* Action buttons */
-    GtkWidget *actions = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
-    gtk_widget_set_margin_top(actions, 6);
-
-    GtkWidget *btn_copy = gtk_button_new_with_label("Copy Debug Info");
-    gtk_widget_add_css_class(btn_copy, "flat");
-
-    /* Build a debug summary string for the clipboard */
-    g_autofree gchar *debug_text = g_strdup_printf(
-        "Node: %s\n"
-        "ID: %s\n"
-        "Platform: %s\n"
-        "Core: %s\n"
-        "UI: %s\n"
-        "Device: %s\n"
-        "Model: %s\n"
-        "IP: %s\n"
-        "Paired: %s\n"
-        "Connected: %s",
-        nd->display_name ? nd->display_name : "unknown",
-        nd->node_id ? nd->node_id : "unknown",
-        nd->platform ? nd->platform : "unknown",
-        nd->core_version ? nd->core_version : "unknown",
-        nd->ui_version ? nd->ui_version : "unknown",
-        nd->device_family ? nd->device_family : "unknown",
-        nd->model_identifier ? nd->model_identifier : "unknown",
-        nd->remote_ip ? nd->remote_ip : "unknown",
-        nd->paired ? "true" : "false",
-        nd->connected ? "true" : "false");
-
-    g_object_set_data_full(G_OBJECT(btn_copy), "debug-summary", g_strdup(debug_text), g_free);
-    g_signal_connect(btn_copy, "clicked", G_CALLBACK(on_copy_debug), NULL);
-    gtk_box_append(GTK_BOX(actions), btn_copy);
-
-    gtk_box_append(GTK_BOX(card), actions);
 
     gtk_frame_set_child(GTK_FRAME(frame), card);
     gtk_box_append(GTK_BOX(inst_remote_box), frame);
@@ -626,6 +628,11 @@ static GtkWidget* instances_build(void) {
     g_signal_connect(btn_refresh, "clicked", G_CALLBACK(on_refresh_nodes), NULL);
     gtk_box_append(GTK_BOX(remote_hdr), btn_refresh);
 
+    inst_copy_debug_btn = gtk_button_new_with_label("Copy Debug Info");
+    gtk_widget_add_css_class(inst_copy_debug_btn, "flat");
+    g_signal_connect(inst_copy_debug_btn, "clicked", G_CALLBACK(on_copy_debug), NULL);
+    gtk_box_append(GTK_BOX(remote_hdr), inst_copy_debug_btn);
+
     gtk_box_append(GTK_BOX(page), remote_hdr);
 
     inst_remote_status_label = gtk_label_new("Loading\u2026");
@@ -694,6 +701,7 @@ static void instances_destroy(void) {
     inst_state_label = NULL;
     inst_remote_box = NULL;
     inst_remote_status_label = NULL;
+    inst_copy_debug_btn = NULL;
     inst_pairing_box = NULL;
     inst_pairing_status_label = NULL;
     inst_nodes_fetch_in_flight = FALSE;

--- a/apps/linux/src/section_sessions.c
+++ b/apps/linux/src/section_sessions.c
@@ -16,6 +16,7 @@
 #include "gateway_mutations.h"
 #include "gateway_config.h"
 #include "gateway_client.h"
+#include "json_access.h"
 #include <adwaita.h>
 
 /* ── State ───────────────────────────────────────────────────────── */
@@ -26,9 +27,25 @@ static GatewaySessionsData *sessions_data_cache = NULL;
 static gboolean sessions_fetch_in_flight = FALSE;
 static gint64 sessions_last_fetch_us = 0;
 
+typedef struct {
+    gchar *id;
+    gchar *label;
+} SessionModelChoice;
+
+static GPtrArray *session_model_choices = NULL;
+
+static void session_model_choice_free(SessionModelChoice *choice) {
+    if (!choice) return;
+    g_free(choice->id);
+    g_free(choice->label);
+    g_free(choice);
+}
+
 /* Forward declarations */
 static void sessions_rebuild_list(void);
 static void sessions_force_refresh(void);
+static void on_sessions_models_response(const GatewayRpcResponse *response, gpointer user_data);
+static void on_session_reset_response(GObject *source, GAsyncResult *result, gpointer user_data);
 
 /* ── Dashboard handoff ───────────────────────────────────────────── */
 
@@ -40,6 +57,13 @@ static void on_open_dashboard(GtkButton *b, gpointer d) {
     if (!cfg) return;
     g_autofree gchar *url = gateway_config_dashboard_url(cfg);
     if (url) g_app_info_launch_default_for_uri(url, NULL, NULL);
+}
+
+static gchar* sessions_default_model_label(void) {
+    if (sessions_data_cache && sessions_data_cache->defaults.model) {
+        return g_strdup_printf("Session default (%s)", sessions_data_cache->defaults.model);
+    }
+    return g_strdup("Session default");
 }
 
 /* ── Mutation callbacks ──────────────────────────────────────────── */
@@ -62,17 +86,40 @@ static void on_mutation_done(const GatewayRpcResponse *response, gpointer user_d
 static void on_session_reset(GtkButton *btn, gpointer user_data) {
     (void)user_data;
     const gchar *key = (const gchar *)g_object_get_data(G_OBJECT(btn), "session-key");
+    const gchar *name = (const gchar *)g_object_get_data(G_OBJECT(btn), "session-name");
     if (!key) return;
 
-    gtk_widget_set_sensitive(GTK_WIDGET(btn), FALSE);
+    g_autofree gchar *body = g_strdup_printf(
+        "Reset session \"%s\"? This clears its runtime context.", name ? name : key);
+
+    AdwAlertDialog *dialog = ADW_ALERT_DIALOG(
+        adw_alert_dialog_new("Reset Session", body));
+    adw_alert_dialog_add_responses(dialog, "cancel", "Cancel", "reset", "Reset", NULL);
+    adw_alert_dialog_set_response_appearance(dialog, "reset", ADW_RESPONSE_DESTRUCTIVE);
+    adw_alert_dialog_set_default_response(dialog, "cancel");
+    adw_alert_dialog_set_close_response(dialog, "cancel");
+    g_object_set_data_full(G_OBJECT(dialog), "session-key", g_strdup(key), g_free);
+
+    GtkWidget *toplevel = GTK_WIDGET(gtk_widget_get_root(GTK_WIDGET(btn)));
+    adw_alert_dialog_choose(dialog, toplevel, NULL, on_session_reset_response, NULL);
+}
+
+static void on_session_reset_response(GObject *source, GAsyncResult *result, gpointer user_data) {
+    AdwAlertDialog *dialog = ADW_ALERT_DIALOG(source);
+    (void)user_data;
+
+    const gchar *response_id = adw_alert_dialog_choose_finish(dialog, result);
+    if (g_strcmp0(response_id, "reset") != 0) return;
+
+    const gchar *key = g_object_get_data(G_OBJECT(dialog), "session-key");
+    if (!key) return;
+
     if (sessions_status_label)
-        gtk_label_set_text(GTK_LABEL(sessions_status_label), "Resetting\u2026");
+        gtk_label_set_text(GTK_LABEL(sessions_status_label), "Resetting…");
 
     g_autofree gchar *req = mutation_sessions_reset(key, on_mutation_done, NULL);
-    if (!req) {
-        gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
-        if (sessions_status_label)
-            gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
+    if (!req && sessions_status_label) {
+        gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
 }
 
@@ -106,7 +153,7 @@ static void on_thinking_changed(GObject *gobject, GParamSpec *pspec, gpointer us
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Updating\u2026");
 
-    g_autofree gchar *req = mutation_sessions_patch(key, level, NULL, on_mutation_done, NULL);
+    g_autofree gchar *req = mutation_sessions_patch(key, level, NULL, NULL, on_mutation_done, NULL);
     if (!req && sessions_status_label) {
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
@@ -125,7 +172,28 @@ static void on_verbose_changed(GObject *gobject, GParamSpec *pspec, gpointer use
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Updating\u2026");
 
-    g_autofree gchar *req = mutation_sessions_patch(key, NULL, level, on_mutation_done, NULL);
+    g_autofree gchar *req = mutation_sessions_patch(key, NULL, level, NULL, on_mutation_done, NULL);
+    if (!req && sessions_status_label) {
+        gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
+    }
+}
+
+static void on_model_changed(GObject *gobject, GParamSpec *pspec, gpointer user_data) {
+    (void)pspec;
+    (void)user_data;
+    const gchar *key = (const gchar *)g_object_get_data(gobject, "session-key");
+    gchar **model_ids = (gchar **)g_object_get_data(gobject, "session-model-ids");
+    if (!key || !model_ids) return;
+
+    gint idx = adw_combo_row_get_selected(ADW_COMBO_ROW(gobject));
+    if (idx < 0) return;
+    const gchar *model = model_ids[idx];
+    if (!model && idx > 0) return;
+
+    if (sessions_status_label)
+        gtk_label_set_text(GTK_LABEL(sessions_status_label), "Updating…");
+
+    g_autofree gchar *req = mutation_sessions_patch(key, NULL, NULL, model, on_mutation_done, NULL);
     if (!req && sessions_status_label) {
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
@@ -333,6 +401,57 @@ static void build_session_card(GatewaySession *s) {
     GtkWidget *actions = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
     gtk_widget_set_margin_top(actions, 6);
 
+    GtkStringList *model_dropdown = gtk_string_list_new(NULL);
+    g_autofree gchar *default_model_label = sessions_default_model_label();
+    gtk_string_list_append(model_dropdown, default_model_label);
+
+    guint selected_model_idx = 0;
+    gboolean has_model_match = FALSE;
+    guint model_count = 1;
+    if (session_model_choices) {
+        model_count += session_model_choices->len;
+    }
+
+    gchar **model_ids = g_new0(gchar *, model_count + 2);
+    model_ids[0] = NULL;
+
+    guint write_idx = 1;
+    if (session_model_choices) {
+        for (guint i = 0; i < session_model_choices->len; i++) {
+            SessionModelChoice *choice = g_ptr_array_index(session_model_choices, i);
+            if (!choice || !choice->id) continue;
+            gtk_string_list_append(model_dropdown, choice->label ? choice->label : choice->id);
+            model_ids[write_idx] = g_strdup(choice->id);
+            if (s->model && g_strcmp0(s->model, choice->id) == 0) {
+                selected_model_idx = write_idx;
+                has_model_match = TRUE;
+            }
+            write_idx++;
+        }
+    }
+
+    if (s->model && !has_model_match) {
+        g_autofree gchar *current_label = g_strdup_printf("Current (%s)", s->model);
+        gtk_string_list_append(model_dropdown, current_label);
+        model_ids[write_idx] = g_strdup(s->model);
+        selected_model_idx = write_idx;
+    }
+
+    if (s->model && sessions_data_cache && sessions_data_cache->defaults.model &&
+        g_strcmp0(s->model, sessions_data_cache->defaults.model) == 0) {
+        selected_model_idx = 0;
+    }
+
+    GtkWidget *model_combo = adw_combo_row_new();
+    adw_combo_row_set_model(ADW_COMBO_ROW(model_combo), G_LIST_MODEL(model_dropdown));
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(model_combo), "Model");
+    gtk_widget_add_css_class(model_combo, "flat");
+    adw_combo_row_set_selected(ADW_COMBO_ROW(model_combo), selected_model_idx);
+    g_object_set_data_full(G_OBJECT(model_combo), "session-key", g_strdup(s->key), g_free);
+    g_object_set_data_full(G_OBJECT(model_combo), "session-model-ids", model_ids, (GDestroyNotify)g_strfreev);
+    g_signal_connect(model_combo, "notify::selected", G_CALLBACK(on_model_changed), NULL);
+    gtk_box_append(GTK_BOX(actions), model_combo);
+
     /* Thinking level dropdown */
     GtkStringList *think_model = gtk_string_list_new((const char * const[]){
         "low", "medium", "high", NULL
@@ -375,6 +494,7 @@ static void build_session_card(GatewaySession *s) {
     GtkWidget *btn_reset = gtk_button_new_with_label("Reset");
     gtk_widget_add_css_class(btn_reset, "flat");
     g_object_set_data_full(G_OBJECT(btn_reset), "session-key", g_strdup(s->key), g_free);
+    g_object_set_data_full(G_OBJECT(btn_reset), "session-name", g_strdup(name_str), g_free);
     g_signal_connect(btn_reset, "clicked", G_CALLBACK(on_session_reset), NULL);
     gtk_box_append(GTK_BOX(actions), btn_reset);
 
@@ -425,6 +545,52 @@ static void sessions_rebuild_list(void) {
     }
 }
 
+static void on_sessions_models_response(const GatewayRpcResponse *response, gpointer user_data) {
+    (void)user_data;
+
+    if (session_model_choices) g_ptr_array_unref(session_model_choices);
+    session_model_choices = g_ptr_array_new_with_free_func((GDestroyNotify)session_model_choice_free);
+
+    if (!response || !response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
+        sessions_rebuild_list();
+        return;
+    }
+
+    JsonObject *obj = json_node_get_object(response->payload);
+    JsonNode *models_node = json_object_get_member(obj, "models");
+    if (!models_node || !JSON_NODE_HOLDS_ARRAY(models_node)) {
+        sessions_rebuild_list();
+        return;
+    }
+
+    JsonArray *arr = json_node_get_array(models_node);
+    for (guint i = 0; i < json_array_get_length(arr); i++) {
+        JsonNode *node = json_array_get_element(arr, i);
+        if (!node || !JSON_NODE_HOLDS_OBJECT(node)) continue;
+
+        JsonObject *model_obj = json_node_get_object(node);
+        const gchar *id = oc_json_string_member(model_obj, "id");
+        if (!id || id[0] == '\0') continue;
+
+        SessionModelChoice *choice = g_new0(SessionModelChoice, 1);
+        choice->id = g_strdup(id);
+
+        const gchar *name = oc_json_string_member(model_obj, "name");
+        const gchar *provider = oc_json_string_member(model_obj, "provider");
+        if (name && provider) {
+            choice->label = g_strdup_printf("%s (%s)", name, provider);
+        } else if (name) {
+            choice->label = g_strdup(name);
+        } else {
+            choice->label = g_strdup(id);
+        }
+
+        g_ptr_array_add(session_model_choices, choice);
+    }
+
+    sessions_rebuild_list();
+}
+
 /* ── RPC callback ────────────────────────────────────────────────── */
 
 static void on_sessions_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
@@ -472,9 +638,12 @@ static void sessions_force_refresh(void) {
     sessions_fetch_in_flight = TRUE;
     g_autofree gchar *req_id = gateway_rpc_request(
         "sessions.list", NULL, 0, on_sessions_rpc_response, NULL);
+    g_autofree gchar *models_req_id = gateway_rpc_request(
+        "models.list", NULL, 0, on_sessions_models_response, NULL);
     if (!req_id) {
         sessions_fetch_in_flight = FALSE;
     }
+    (void)models_req_id;
 }
 
 /* ── SectionController callbacks ─────────────────────────────────── */
@@ -532,11 +701,14 @@ static void sessions_refresh(void) {
     sessions_fetch_in_flight = TRUE;
     g_autofree gchar *req_id = gateway_rpc_request(
         "sessions.list", NULL, 0, on_sessions_rpc_response, NULL);
+    g_autofree gchar *models_req_id = gateway_rpc_request(
+        "models.list", NULL, 0, on_sessions_models_response, NULL);
     if (!req_id) {
         sessions_fetch_in_flight = FALSE;
         if (sessions_status_label)
             gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
+    (void)models_req_id;
 }
 
 static void sessions_destroy(void) {
@@ -545,6 +717,8 @@ static void sessions_destroy(void) {
     sessions_fetch_in_flight = FALSE;
     gateway_sessions_data_free(sessions_data_cache);
     sessions_data_cache = NULL;
+    if (session_model_choices) g_ptr_array_unref(session_model_choices);
+    session_model_choices = NULL;
     sessions_last_fetch_us = 0;
 }
 

--- a/apps/linux/src/state.c
+++ b/apps/linux/src/state.c
@@ -30,6 +30,7 @@ static HealthState current_health_state = {0};
 static guint64 current_health_generation = 0;
 static gboolean initial_hydration_done = FALSE;
 static gboolean initial_refresh_fired = FALSE;
+static GatewayConnectionTransitionTracker connection_transition_tracker = {0};
 
 /* Defined in runtime_mode.c — internal to the state module */
 extern RuntimeMode runtime_mode_compute(const SystemdState *sys, const HealthState *health);
@@ -45,6 +46,25 @@ static gboolean config_requires_onboarding(const HealthState *health) {
         return FALSE;
     }
     return !health->has_wizard_onboard_marker;
+}
+
+gboolean state_connection_transition_step(GatewayConnectionTransitionTracker *tracker,
+                                          gboolean connected_now,
+                                          gboolean *out_connected_now) {
+    if (!tracker) return FALSE;
+    if (!tracker->initialized) {
+        tracker->initialized = TRUE;
+        tracker->connected = connected_now;
+        return FALSE;
+    }
+    if (tracker->connected == connected_now) {
+        return FALSE;
+    }
+    tracker->connected = connected_now;
+    if (out_connected_now) {
+        *out_connected_now = connected_now;
+    }
+    return TRUE;
 }
 
 static AppState compute_state(void) {
@@ -151,6 +171,8 @@ void state_init(void) {
     current_runtime_mode = RUNTIME_NONE;
     initial_hydration_done = FALSE;
     initial_refresh_fired = FALSE;
+    connection_transition_tracker.initialized = FALSE;
+    connection_transition_tracker.connected = FALSE;
 
     g_free(current_sys_state.active_state);
     g_free(current_sys_state.sub_state);
@@ -195,6 +217,17 @@ static void trigger_updates(AppState new_state) {
             OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "trigger_updates post-notify");
         }
     }
+
+    if (initial_hydration_done) {
+        gboolean connected_now = (current_health_state.http_ok && current_health_state.ws_connected);
+        gboolean edge_connected = FALSE;
+        if (state_connection_transition_step(&connection_transition_tracker,
+                                             connected_now,
+                                             &edge_connected)) {
+            notify_on_gateway_connection_transition(edge_connected);
+        }
+    }
+
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "trigger_updates pre-tray state=%s",
               state_enum_to_string(current_state));
     tray_update_from_state(current_state);

--- a/apps/linux/src/state.h
+++ b/apps/linux/src/state.h
@@ -116,6 +116,11 @@ typedef struct {
     const char *explanation; /* human-readable detail for diagnostics */
 } RuntimeModePresentation;
 
+typedef struct {
+    gboolean initialized;
+    gboolean connected;
+} GatewayConnectionTransitionTracker;
+
 void state_init(void);
 void health_state_clear(HealthState *hs);
 void state_update_systemd(const SystemdState *sys_state);
@@ -128,6 +133,9 @@ guint64 state_get_health_generation(void);
 RuntimeMode state_get_runtime_mode(void);
 gboolean health_state_listener_proven(const HealthState *hs);
 void runtime_mode_describe(RuntimeMode mode, RuntimeModePresentation *out);
+gboolean state_connection_transition_step(GatewayConnectionTransitionTracker *tracker,
+                                          gboolean connected_now,
+                                          gboolean *out_connected_now);
 
 SystemdState* state_get_systemd(void);
 HealthState* state_get_health(void);
@@ -137,5 +145,6 @@ void systemd_get_runtime_context(gchar **out_profile, gchar **out_state_dir, gch
 
 /* Callbacks (implemented elsewhere) */
 void notify_on_transition(AppState old_state, AppState new_state);
+void notify_on_gateway_connection_transition(gboolean connected);
 void tray_update_from_state(AppState state);
 void state_on_gateway_refresh_requested(void);

--- a/apps/linux/tests/test_gateway.c
+++ b/apps/linux/tests/test_gateway.c
@@ -21,6 +21,10 @@ void notify_on_transition(AppState old_state, AppState new_state) {
     (void)new_state;
 }
 
+void notify_on_gateway_connection_transition(gboolean connected) {
+    (void)connected;
+}
+
 void tray_update_from_state(AppState state) {
     (void)state;
 }

--- a/apps/linux/tests/test_readiness.c
+++ b/apps/linux/tests/test_readiness.c
@@ -331,6 +331,72 @@ static void test_presenter_null_output(void) {
     readiness_evaluate(STATE_RUNNING, NULL, NULL, NULL);
 }
 
+static void test_onboarding_progress_service_inactive(void) {
+    HealthState hs = {0};
+    SystemdState sys = {0};
+    OnboardingStageProgress progress = {0};
+
+    hs.config_valid = TRUE;
+    hs.http_ok = FALSE;
+    hs.ws_connected = FALSE;
+    hs.rpc_ok = FALSE;
+    hs.auth_ok = FALSE;
+
+    sys.installed = TRUE;
+    sys.active = FALSE;
+
+    readiness_build_onboarding_progress(STATE_STOPPED, &hs, &sys, &progress);
+
+    g_assert_cmpint(progress.configuration, ==, ONBOARDING_STAGE_COMPLETE);
+    g_assert_cmpint(progress.service_gateway, ==, ONBOARDING_STAGE_IN_PROGRESS);
+    g_assert_cmpint(progress.connection, ==, ONBOARDING_STAGE_PENDING);
+    g_assert_false(progress.operational_ready);
+}
+
+static void test_onboarding_progress_connecting_service_active(void) {
+    HealthState hs = {0};
+    SystemdState sys = {0};
+    OnboardingStageProgress progress = {0};
+
+    hs.config_valid = TRUE;
+    hs.http_ok = TRUE;
+    hs.ws_connected = FALSE;
+    hs.rpc_ok = FALSE;
+    hs.auth_ok = FALSE;
+
+    sys.installed = TRUE;
+    sys.active = TRUE;
+
+    readiness_build_onboarding_progress(STATE_DEGRADED, &hs, &sys, &progress);
+
+    g_assert_cmpint(progress.configuration, ==, ONBOARDING_STAGE_COMPLETE);
+    g_assert_cmpint(progress.service_gateway, ==, ONBOARDING_STAGE_COMPLETE);
+    g_assert_cmpint(progress.connection, ==, ONBOARDING_STAGE_IN_PROGRESS);
+    g_assert_false(progress.operational_ready);
+}
+
+static void test_onboarding_progress_operational_ready_only_when_running(void) {
+    HealthState hs = {0};
+    SystemdState sys = {0};
+    OnboardingStageProgress progress = {0};
+
+    hs.config_valid = TRUE;
+    hs.http_ok = TRUE;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+
+    sys.installed = TRUE;
+    sys.active = TRUE;
+
+    readiness_build_onboarding_progress(STATE_RUNNING, &hs, &sys, &progress);
+
+    g_assert_cmpint(progress.configuration, ==, ONBOARDING_STAGE_COMPLETE);
+    g_assert_cmpint(progress.service_gateway, ==, ONBOARDING_STAGE_COMPLETE);
+    g_assert_cmpint(progress.connection, ==, ONBOARDING_STAGE_COMPLETE);
+    g_assert_true(progress.operational_ready);
+}
+
 /* ── Registration ── */
 
 int main(int argc, char **argv) {
@@ -363,6 +429,11 @@ int main(int argc, char **argv) {
 
     /* Guard */
     g_test_add_func("/readiness/null_output", test_presenter_null_output);
+
+    /* Onboarding stage mapping */
+    g_test_add_func("/readiness/onboarding_progress/service_inactive", test_onboarding_progress_service_inactive);
+    g_test_add_func("/readiness/onboarding_progress/connecting_service_active", test_onboarding_progress_connecting_service_active);
+    g_test_add_func("/readiness/onboarding_progress/operational_ready_running", test_onboarding_progress_operational_ready_only_when_running);
 
     return g_test_run();
 }

--- a/apps/linux/tests/test_rpc_mutations.c
+++ b/apps/linux/tests/test_rpc_mutations.c
@@ -190,7 +190,7 @@ static void test_skills_update_api_key(void) {
 
 static void test_sessions_patch(void) {
     stub_reset();
-    gchar *rid = mutation_sessions_patch("main", "high", "low", noop_cb, NULL);
+    gchar *rid = mutation_sessions_patch("main", "high", "low", NULL, noop_cb, NULL);
     ASSERT(rid != NULL, "sess_patch: rid");
     ASSERT(g_strcmp0(stub_last_method, "sessions.patch") == 0, "sess_patch: method");
     JsonObject *p = get_stub_params_obj();
@@ -202,11 +202,23 @@ static void test_sessions_patch(void) {
 
 static void test_sessions_patch_partial(void) {
     stub_reset();
-    gchar *rid = mutation_sessions_patch("main", "medium", NULL, noop_cb, NULL);
+    gchar *rid = mutation_sessions_patch("main", "medium", NULL, NULL, noop_cb, NULL);
     ASSERT(rid != NULL, "sess_patch_partial: rid");
     JsonObject *p = get_stub_params_obj();
     ASSERT(g_strcmp0(obj_get_string(p, "thinkingLevel"), "medium") == 0, "sess_patch_partial: thinking");
     ASSERT(!json_object_has_member(p, "verboseLevel"), "sess_patch_partial: no verbose");
+    ASSERT(!json_object_has_member(p, "model"), "sess_patch_partial: no model");
+    g_free(rid);
+}
+
+static void test_sessions_patch_model_only(void) {
+    stub_reset();
+    gchar *rid = mutation_sessions_patch("main", NULL, NULL, "anthropic/claude-sonnet-4", noop_cb, NULL);
+    ASSERT(rid != NULL, "sess_patch_model: rid");
+    JsonObject *p = get_stub_params_obj();
+    ASSERT(g_strcmp0(obj_get_string(p, "model"), "anthropic/claude-sonnet-4") == 0, "sess_patch_model: model");
+    ASSERT(!json_object_has_member(p, "thinkingLevel"), "sess_patch_model: no thinking");
+    ASSERT(!json_object_has_member(p, "verboseLevel"), "sess_patch_model: no verbose");
     g_free(rid);
 }
 
@@ -1278,6 +1290,7 @@ int main(void) {
     /* Sessions */
     test_sessions_patch();
     test_sessions_patch_partial();
+    test_sessions_patch_model_only();
     test_sessions_reset();
     test_sessions_delete();
     test_sessions_compact();

--- a/apps/linux/tests/test_runtime_mode.c
+++ b/apps/linux/tests/test_runtime_mode.c
@@ -21,6 +21,9 @@ void notify_on_transition(AppState old_state, AppState new_state) {
     (void)old_state;
     (void)new_state;
 }
+void notify_on_gateway_connection_transition(gboolean connected) {
+    (void)connected;
+}
 void tray_update_from_state(AppState state) {
     (void)state;
 }

--- a/apps/linux/tests/test_state.c
+++ b/apps/linux/tests/test_state.c
@@ -6,6 +6,9 @@ void notify_on_transition(AppState old_state, AppState new_state) {
     (void)old_state;
     (void)new_state;
 }
+void notify_on_gateway_connection_transition(gboolean connected) {
+    (void)connected;
+}
 void tray_update_from_state(AppState state) {
     (void)state;
 }
@@ -299,6 +302,37 @@ static void test_repeated_running_stopped_transitions(void) {
     sys.active = FALSE;
     state_update_systemd(&sys);
     g_assert_cmpint(state_get_current(), ==, STATE_STOPPED);
+}
+
+static void test_connection_transition_guard_first_observation_no_emit(void) {
+    GatewayConnectionTransitionTracker tracker = {0};
+    gboolean out_connected = FALSE;
+
+    gboolean emit = state_connection_transition_step(&tracker, FALSE, &out_connected);
+    g_assert_false(emit);
+    g_assert_true(tracker.initialized);
+    g_assert_false(tracker.connected);
+}
+
+static void test_connection_transition_guard_emits_only_on_edges(void) {
+    GatewayConnectionTransitionTracker tracker = {0};
+    gboolean out_connected = FALSE;
+
+    g_assert_false(state_connection_transition_step(&tracker, FALSE, &out_connected));
+    g_assert_false(state_connection_transition_step(&tracker, FALSE, &out_connected));
+
+    g_assert_true(state_connection_transition_step(&tracker, TRUE, &out_connected));
+    g_assert_true(out_connected);
+
+    g_assert_false(state_connection_transition_step(&tracker, TRUE, &out_connected));
+
+    g_assert_true(state_connection_transition_step(&tracker, FALSE, &out_connected));
+    g_assert_false(out_connected);
+}
+
+static void test_connection_transition_guard_null_tracker_safe(void) {
+    gboolean out_connected = FALSE;
+    g_assert_false(state_connection_transition_step(NULL, TRUE, &out_connected));
 }
 
 static void test_transition_into_systemd_unavailable(void) {
@@ -689,6 +723,11 @@ int main(int argc, char **argv) {
     g_test_add_func("/state/health_zero_timestamp_preserves_systemd_running", test_health_zero_timestamp_preserves_systemd_running);
     g_test_add_func("/state/activation_boundary_health_persists_through_stop", test_activation_boundary_health_persists_through_stop);
     g_test_add_func("/state/systemd_stop_does_not_regress_native_connected", test_systemd_stop_does_not_regress_native_connected);
+
+    /* Connection transition guard tests */
+    g_test_add_func("/state/connection_transition/first_observation_no_emit", test_connection_transition_guard_first_observation_no_emit);
+    g_test_add_func("/state/connection_transition/edge_only", test_connection_transition_guard_emits_only_on_edges);
+    g_test_add_func("/state/connection_transition/null_tracker_safe", test_connection_transition_guard_null_tracker_safe);
 
     /* Readiness decision table tests */
     g_test_add_func("/state/readiness/needs_setup", test_readiness_needs_setup);


### PR DESCRIPTION
Add persistent shell footer status for gateway and service state with minimal CSS-backed status dots and connecting pulse behavior. Introduce an app-wide snapshot refresh helper so shell content and RPC-backed sections can be invalidated and refreshed coherently.

Convert the config surface into an editable in-app JSON workflow with reload, live validation, dirty tracking, baseline hash tracking, guarded save through config.set, and copy-from-editor behavior. Prevent periodic refresh from overwriting local edits in progress.

Extend sessions.patch to support an optional model field, load model choices from models.list, render session model selectors, and add reset confirmation without changing existing thinking and verbose controls.

Add onboarding stage progress derivation and rendering for Configuration, Service / Gateway, and Connection, and auto-complete onboarding only when operational readiness is reached.

Add gateway connection edge tracking in state handling and emit explicit connect/disconnect notifications only on real transitions. Update channels to expose honest global refresh semantics and status chips, enrich control room snapshot refresh and runtime summary fields, and move instances debug export to a section-level aggregated action.

Extend Linux tests to cover onboarding progress mapping, optional model payload composition, and gateway connection transition guards.