### PR TITLE
fix(linux): derive gateway host from bind semantics safely (#70)

### DIFF
--- a/apps/linux/src/gateway_config.c
+++ b/apps/linux/src/gateway_config.c
@@ -35,6 +35,159 @@ static void secure_clear_free(gchar *s) {
     g_free(s);
 }
 
+static gboolean is_bind_mode_token(const gchar *bind) {
+    return g_strcmp0(bind, "auto") == 0 ||
+           g_strcmp0(bind, "lan") == 0 ||
+           g_strcmp0(bind, "loopback") == 0 ||
+           g_strcmp0(bind, "custom") == 0 ||
+           g_strcmp0(bind, "tailnet") == 0;
+}
+
+static gboolean is_wildcard_bind_literal(const gchar *bind) {
+    return g_strcmp0(bind, "0.0.0.0") == 0 ||
+           g_strcmp0(bind, "::") == 0 ||
+           g_strcmp0(bind, "::0") == 0;
+}
+
+static gboolean is_valid_hostname_label(const gchar *label, gsize len) {
+    if (!label || len == 0 || len > 63) {
+        return FALSE;
+    }
+    if (!g_ascii_isalnum(label[0]) || !g_ascii_isalnum(label[len - 1])) {
+        return FALSE;
+    }
+    for (gsize i = 0; i < len; i++) {
+        gchar ch = label[i];
+        if (!(g_ascii_isalnum(ch) || ch == '-')) {
+            return FALSE;
+        }
+    }
+    return TRUE;
+}
+
+static gboolean is_valid_hostname_literal(const gchar *host) {
+    if (!host || host[0] == '\0') {
+        return FALSE;
+    }
+    gsize host_len = strlen(host);
+    if (host_len > 253) {
+        return FALSE;
+    }
+
+    const gchar *label_start = host;
+    const gchar *p = host;
+    while (TRUE) {
+        if (*p == '.' || *p == '\0') {
+            gsize label_len = (gsize)(p - label_start);
+            if (!is_valid_hostname_label(label_start, label_len)) {
+                return FALSE;
+            }
+            if (*p == '\0') {
+                break;
+            }
+            label_start = p + 1;
+        }
+        p++;
+    }
+    return TRUE;
+}
+
+static gboolean is_valid_bind_host_literal(const gchar *value) {
+    if (!value || value[0] == '\0') {
+        return FALSE;
+    }
+    if (g_hostname_is_ip_address(value)) {
+        return TRUE;
+    }
+    return is_valid_hostname_literal(value);
+}
+
+static gboolean resolve_effective_gateway_host(JsonObject *gateway_obj, GatewayConfig *config) {
+    if (gateway_obj && json_object_has_member(gateway_obj, "host")) {
+        JsonNode *host_node = json_object_get_member(gateway_obj, "host");
+        if (JSON_NODE_HOLDS_VALUE(host_node) && json_node_get_value_type(host_node) == G_TYPE_STRING) {
+            const gchar *host_str = json_node_get_string(host_node);
+            if (host_str && host_str[0] != '\0') {
+                config->host = g_strdup(host_str);
+                return TRUE;
+            }
+        }
+    }
+
+    if (!(gateway_obj && json_object_has_member(gateway_obj, "bind"))) {
+        return TRUE;
+    }
+
+    JsonNode *bind_node = json_object_get_member(gateway_obj, "bind");
+    if (!JSON_NODE_HOLDS_VALUE(bind_node) || json_node_get_value_type(bind_node) != G_TYPE_STRING) {
+        config->valid = FALSE;
+        config->error_code = GW_CFG_ERR_BIND_INVALID;
+        config->error = g_strdup("gateway.bind exists but is not a string");
+        return FALSE;
+    }
+
+    const gchar *bind_str = json_node_get_string(bind_node);
+    if (!bind_str || bind_str[0] == '\0') {
+        return TRUE;
+    }
+
+    if (is_bind_mode_token(bind_str)) {
+        if (g_strcmp0(bind_str, "custom") == 0) {
+            if (!(json_object_has_member(gateway_obj, "customBindHost"))) {
+                config->valid = FALSE;
+                config->error_code = GW_CFG_ERR_BIND_INVALID;
+                config->error = g_strdup("gateway.bind=custom requires gateway.customBindHost");
+                return FALSE;
+            }
+
+            JsonNode *custom_node = json_object_get_member(gateway_obj, "customBindHost");
+            if (!JSON_NODE_HOLDS_VALUE(custom_node) || json_node_get_value_type(custom_node) != G_TYPE_STRING) {
+                config->valid = FALSE;
+                config->error_code = GW_CFG_ERR_BIND_INVALID;
+                config->error = g_strdup("gateway.customBindHost exists but is not a string");
+                return FALSE;
+            }
+
+            const gchar *custom_host = json_node_get_string(custom_node);
+            if (!custom_host || custom_host[0] == '\0') {
+                config->valid = FALSE;
+                config->error_code = GW_CFG_ERR_BIND_INVALID;
+                config->error = g_strdup("gateway.bind=custom requires non-empty gateway.customBindHost");
+                return FALSE;
+            }
+            if (is_bind_mode_token(custom_host) ||
+                is_wildcard_bind_literal(custom_host) ||
+                !is_valid_bind_host_literal(custom_host)) {
+                config->valid = FALSE;
+                config->error_code = GW_CFG_ERR_BIND_INVALID;
+                config->error = g_strdup_printf("gateway.customBindHost is not a valid host literal: '%s'", custom_host);
+                return FALSE;
+            }
+
+            config->host = g_strdup(custom_host);
+            return TRUE;
+        }
+
+        config->host = g_strdup(GATEWAY_DEFAULT_HOST);
+        return TRUE;
+    }
+
+    if (is_wildcard_bind_literal(bind_str)) {
+        config->host = g_strdup(GATEWAY_DEFAULT_HOST);
+        return TRUE;
+    }
+
+    if (!is_valid_bind_host_literal(bind_str)) {
+        config->valid = FALSE;
+        config->error_code = GW_CFG_ERR_BIND_INVALID;
+        config->error = g_strdup_printf("gateway.bind is neither a recognized mode token nor a valid host literal: '%s'", bind_str);
+        return FALSE;
+    }
+
+    config->host = g_strdup(bind_str);
+    return TRUE;
+}
+
 static gchar* resolve_config_path(const GatewayConfigContext *ctx) {
     const gchar *override = g_getenv("OPENCLAW_CONFIG_PATH");
     if (override && override[0] != '\0') {
@@ -459,35 +612,11 @@ GatewayConfig* gateway_config_load(const GatewayConfigContext *ctx) {
         }
     }
 
-    /* L6: Resolve host from config, not always loopback */
+    /* L6: Resolve host from config and bind semantics */
     g_free(config->host);
     config->host = NULL;
-    if (gateway_obj && json_object_has_member(gateway_obj, "host")) {
-        JsonNode *host_node = json_object_get_member(gateway_obj, "host");
-        if (JSON_NODE_HOLDS_VALUE(host_node) && json_node_get_value_type(host_node) == G_TYPE_STRING) {
-            const gchar *host_str = json_node_get_string(host_node);
-            if (host_str && host_str[0] != '\0') {
-                config->host = g_strdup(host_str);
-            }
-        }
-    }
-    /* Fallback: check gateway.bind as alternative host source */
-    if (!config->host && gateway_obj && json_object_has_member(gateway_obj, "bind")) {
-        JsonNode *bind_node = json_object_get_member(gateway_obj, "bind");
-        if (JSON_NODE_HOLDS_VALUE(bind_node) && json_node_get_value_type(bind_node) == G_TYPE_STRING) {
-            const gchar *bind_str = json_node_get_string(bind_node);
-            /* Reject wildcards and unspecified addresses - they are not valid client endpoints */
-            gboolean is_wildcard = (g_strcmp0(bind_str, "0.0.0.0") == 0 ||
-                                    g_strcmp0(bind_str, "::") == 0 ||
-                                    g_strcmp0(bind_str, "::0") == 0);
-            if (bind_str && bind_str[0] != '\0' && !is_wildcard) {
-                if (g_strcmp0(bind_str, "loopback") == 0) {
-                    config->host = g_strdup("127.0.0.1");
-                } else {
-                    config->host = g_strdup(bind_str);
-                }
-            }
-        }
+    if (!resolve_effective_gateway_host(gateway_obj, config)) {
+        return config;
     }
     /* Final fallback to default loopback */
     if (!config->host) {

--- a/apps/linux/src/gateway_config.h
+++ b/apps/linux/src/gateway_config.h
@@ -38,6 +38,7 @@ typedef enum {
     GW_CFG_ERR_AUTH_MODE_UNSUPPORTED,
     GW_CFG_ERR_TOKEN_MISSING,
     GW_CFG_ERR_PASSWORD_MISSING,
+    GW_CFG_ERR_BIND_INVALID,
     GW_CFG_ERR_READ_FAILED,
     GW_CFG_ERR_SECRET_REF_UNSUPPORTED,
 } GatewayConfigError;
@@ -50,7 +51,7 @@ typedef struct {
 
 typedef struct {
     gchar *mode;           /* gateway.mode: "local" or other (NULL treated as local) */
-    gchar *host;           /* effective bind host (default 127.0.0.1) */
+    gchar *host;           /* effective client endpoint host (default 127.0.0.1) */
     gint port;             /* effective port (default 18789) */
     gboolean tls_enabled;  /* L6: TLS enablement from gateway.tls or gateway.security.tls */
     gchar *auth_mode;      /* gateway.auth.mode: "token", "password", "none" */

--- a/apps/linux/tests/test_gateway.c
+++ b/apps/linux/tests/test_gateway.c
@@ -59,6 +59,19 @@ static void clear_env(void) {
     g_unsetenv("OPENCLAW_HOME");
 }
 
+static gboolean is_bind_mode_token_for_test(const gchar *value) {
+    return g_strcmp0(value, "auto") == 0 ||
+           g_strcmp0(value, "lan") == 0 ||
+           g_strcmp0(value, "loopback") == 0 ||
+           g_strcmp0(value, "tailnet") == 0 ||
+           g_strcmp0(value, "custom") == 0;
+}
+
+static void assert_host_not_bind_mode_token(const gchar *host) {
+    g_assert_nonnull(host);
+    g_assert_false(is_bind_mode_token_for_test(host));
+}
+
 static void test_config_defaults_no_token_is_invalid(void) {
     /*
      * With no config file and no env overrides, auth_mode defaults to "token"
@@ -79,6 +92,27 @@ static void test_config_defaults_no_token_is_invalid(void) {
     g_assert_null(config->token);
     gateway_config_free(config);
 
+    clear_env();
+}
+
+static void test_config_host_from_config_wins_over_bind_mode(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"host\":\"192.168.1.100\",\"bind\":\"lan\"}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    g_assert_cmpstr(config->host, ==, "192.168.1.100");
+
+    gateway_config_free(config);
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
     clear_env();
 }
 
@@ -1076,6 +1110,7 @@ static void test_config_bind_fallback_ignores_0_0_0_0(void) {
     g_assert_true(config->valid);
     /* 0.0.0.0 should fall back to default loopback */
     g_assert_cmpstr(config->host, ==, "127.0.0.1");
+    assert_host_not_bind_mode_token(config->host);
     
     gateway_config_free(config);
 
@@ -1099,9 +1134,140 @@ static void test_config_bind_normalizes_loopback(void) {
     g_assert_nonnull(config);
     g_assert_true(config->valid);
     g_assert_cmpstr(config->host, ==, "127.0.0.1");
+    assert_host_not_bind_mode_token(config->host);
     
     gateway_config_free(config);
 
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_bind_mode_auto_maps_to_loopback_host(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"bind\":\"auto\"}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    g_assert_cmpstr(config->host, ==, "127.0.0.1");
+    assert_host_not_bind_mode_token(config->host);
+
+    gateway_config_free(config);
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_bind_mode_lan_maps_to_loopback_host(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"bind\":\"lan\"}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    g_assert_cmpstr(config->host, ==, "127.0.0.1");
+    assert_host_not_bind_mode_token(config->host);
+
+    gateway_config_free(config);
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_bind_mode_tailnet_maps_to_loopback_host(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"bind\":\"tailnet\"}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    g_assert_cmpstr(config->host, ==, "127.0.0.1");
+    assert_host_not_bind_mode_token(config->host);
+
+    gateway_config_free(config);
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_bind_mode_custom_uses_custom_bind_host(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"bind\":\"custom\",\"customBindHost\":\"100.64.0.10\"}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    g_assert_cmpstr(config->host, ==, "100.64.0.10");
+    assert_host_not_bind_mode_token(config->host);
+
+    gateway_config_free(config);
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_bind_mode_custom_without_custom_bind_host_is_invalid(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"bind\":\"custom\"}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_false(config->valid);
+    g_assert_cmpint(config->error_code, ==, GW_CFG_ERR_BIND_INVALID);
+
+    gateway_config_free(config);
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_bind_invalid_literal_is_rejected(void) {
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"bind\":\"not a host value\"}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_false(config->valid);
+    g_assert_cmpint(config->error_code, ==, GW_CFG_ERR_BIND_INVALID);
+
+    gateway_config_free(config);
     g_unlink(config_path);
     g_rmdir(tmpdir);
     clear_env();
@@ -1727,7 +1893,75 @@ static void test_config_bind_ipv4_literal_used(void) {
     g_assert_true(config->valid);
     /* bind = specific IPv4 should be used as host */
     g_assert_cmpstr(config->host, ==, "192.168.1.50");
+    assert_host_not_bind_mode_token(config->host);
     
+    gateway_config_free(config);
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_bind_hostname_literal_used(void) {
+    /* A valid hostname literal bind should be usable as host fallback */
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"bind\":\"gateway.internal\"}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_true(config->valid);
+    g_assert_cmpstr(config->host, ==, "gateway.internal");
+    assert_host_not_bind_mode_token(config->host);
+
+    gateway_config_free(config);
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_bind_mode_custom_with_mode_token_custom_bind_host_is_invalid(void) {
+    /* bind=custom with customBindHost as a bind mode token must be rejected */
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"bind\":\"custom\",\"customBindHost\":\"lan\"}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_false(config->valid);
+    g_assert_cmpint(config->error_code, ==, GW_CFG_ERR_BIND_INVALID);
+
+    gateway_config_free(config);
+    g_unlink(config_path);
+    g_rmdir(tmpdir);
+    clear_env();
+}
+
+static void test_config_bind_invalid_hostname_literal_is_rejected(void) {
+    /* Invalid hostname label (leading '-') must be rejected */
+    g_autofree gchar *tmpdir = g_dir_make_tmp("openclaw-test-XXXXXX", NULL);
+    g_assert_nonnull(tmpdir);
+    g_autofree gchar *config_path = g_build_filename(tmpdir, "openclaw.json", NULL);
+    g_file_set_contents(config_path,
+        "{\"gateway\":{\"auth\":{\"token\":\"tok\"},\"bind\":\"-bad.host\"}}", -1, NULL);
+
+    clear_env();
+    g_setenv("OPENCLAW_CONFIG_PATH", config_path, TRUE);
+
+    GatewayConfig *config = gateway_config_load(NULL);
+    g_assert_nonnull(config);
+    g_assert_false(config->valid);
+    g_assert_cmpint(config->error_code, ==, GW_CFG_ERR_BIND_INVALID);
+
     gateway_config_free(config);
     g_unlink(config_path);
     g_rmdir(tmpdir);
@@ -1750,6 +1984,7 @@ static void test_config_bind_ipv6_unspecified_rejected(void) {
     g_assert_true(config->valid);
     /* :: should fall back to default loopback */
     g_assert_cmpstr(config->host, ==, "127.0.0.1");
+    assert_host_not_bind_mode_token(config->host);
     
     gateway_config_free(config);
     g_unlink(config_path);
@@ -2171,8 +2406,15 @@ int main(int argc, char **argv) {
     g_test_add_func("/gateway/config/tls_disabled_uses_http_ws", test_config_tls_disabled_uses_http_ws);
     g_test_add_func("/gateway/config/tls_enabled_uses_https_wss", test_config_tls_enabled_uses_https_wss);
     g_test_add_func("/gateway/config/host_from_config", test_config_host_from_config);
+    g_test_add_func("/gateway/config/host_from_config_wins_over_bind_mode", test_config_host_from_config_wins_over_bind_mode);
     g_test_add_func("/gateway/config/bind_fallback_ignores_0_0_0_0", test_config_bind_fallback_ignores_0_0_0_0);
     g_test_add_func("/gateway/config/bind_normalizes_loopback", test_config_bind_normalizes_loopback);
+    g_test_add_func("/gateway/config/bind_mode_auto_maps_to_loopback_host", test_config_bind_mode_auto_maps_to_loopback_host);
+    g_test_add_func("/gateway/config/bind_mode_lan_maps_to_loopback_host", test_config_bind_mode_lan_maps_to_loopback_host);
+    g_test_add_func("/gateway/config/bind_mode_tailnet_maps_to_loopback_host", test_config_bind_mode_tailnet_maps_to_loopback_host);
+    g_test_add_func("/gateway/config/bind_mode_custom_uses_custom_bind_host", test_config_bind_mode_custom_uses_custom_bind_host);
+    g_test_add_func("/gateway/config/bind_mode_custom_without_custom_bind_host_is_invalid", test_config_bind_mode_custom_without_custom_bind_host_is_invalid);
+    g_test_add_func("/gateway/config/bind_invalid_literal_is_rejected", test_config_bind_invalid_literal_is_rejected);
     g_test_add_func("/gateway/config/tls_object_form", test_config_tls_object_form);
     g_test_add_func("/gateway/config/tls_from_security_block", test_config_tls_from_security_block);
 
@@ -2186,6 +2428,9 @@ int main(int argc, char **argv) {
 
     /* gateway.bind safety tests */
     g_test_add_func("/gateway/config/bind_ipv4_literal_used", test_config_bind_ipv4_literal_used);
+    g_test_add_func("/gateway/config/bind_hostname_literal_used", test_config_bind_hostname_literal_used);
+    g_test_add_func("/gateway/config/bind_mode_custom_with_mode_token_custom_bind_host_is_invalid", test_config_bind_mode_custom_with_mode_token_custom_bind_host_is_invalid);
+    g_test_add_func("/gateway/config/bind_invalid_hostname_literal_is_rejected", test_config_bind_invalid_hostname_literal_is_rejected);
     g_test_add_func("/gateway/config/bind_ipv6_unspecified_rejected", test_config_bind_ipv6_unspecified_rejected);
 
     /* Feature A: Config path resolution tests */


### PR DESCRIPTION
Resolve the Linux companion's effective gateway endpoint host through explicit host/bind semantics instead of copying raw bind values into client URLs.

Add bind-mode classification and hostname validation helpers to the gateway config loader. Preserve explicit gateway.host precedence, map auto/lan/loopback/tailnet and wildcard bind literals to the default loopback client host, and require a valid customBindHost for bind=custom. Reject malformed bind-derived host inputs with the new GW_CFG_ERR_BIND_INVALID error.

Extend gateway config tests to cover explicit host precedence, bind-mode mapping, custom bind validation, wildcard fallback, hostname literal acceptance, invalid literal rejection, and regression guards ensuring resolved hosts never equal bind-mode tokens.