### PR TITLE
test(linux): lock mutation method contracts and update skills docs (#72)

### DIFF
--- a/apps/linux/src/section_skills.c
+++ b/apps/linux/src/section_skills.c
@@ -5,8 +5,8 @@
  *
  * Complete native skill management: list, enable/disable, install,
  * update, set environment variables, and display requirements/config
- * checks. RPC fetch via skills.status, mutations via skills.enable,
- * skills.install, skills.update, skills.setEnv.
+ * checks. RPC fetch via skills.status, mutations via skills.update
+ * and skills.install.
  *
  * Author: Thiago Camargo <thiagocmc@proton.me>
  */

--- a/apps/linux/tests/test_rpc_mutations.c
+++ b/apps/linux/tests/test_rpc_mutations.c
@@ -125,6 +125,7 @@ static void test_skills_disable(void) {
     stub_reset();
     gchar *rid = mutation_skills_enable("code-runner", FALSE, noop_cb, NULL);
     ASSERT(rid != NULL, "skills_disable: rid");
+    ASSERT(g_strcmp0(stub_last_method, "skills.update") == 0, "skills_disable: method");
     JsonObject *p = get_stub_params_obj();
     ASSERT(obj_get_bool(p, "enabled") == FALSE, "skills_disable: enabled false");
     g_free(rid);
@@ -347,8 +348,13 @@ static void test_channels_status_no_probe(void) {
     stub_reset();
     gchar *rid = mutation_channels_status(FALSE, noop_cb, NULL);
     ASSERT(rid != NULL, "ch_no_probe: rid");
+    ASSERT(g_strcmp0(stub_last_method, "channels.status") == 0, "ch_no_probe: method");
     JsonObject *p = get_stub_params_obj();
+    ASSERT(p != NULL, "ch_no_probe: params obj");
+    ASSERT(json_object_get_size(p) == 0, "ch_no_probe: params empty object");
     ASSERT(!json_object_has_member(p, "probe"), "ch_no_probe: no probe field");
+    ASSERT(!json_object_has_member(p, "channelId"), "ch_no_probe: no channelId");
+    ASSERT(!json_object_has_member(p, "channel"), "ch_no_probe: no channel");
     g_free(rid);
 }
 


### PR DESCRIPTION
Align the Linux skills section comment with the current mutation surface and strengthen mutation regression coverage for canonical RPC behavior.

Update section_skills.c documentation to reference skills.status, skills.update, and skills.install only.

Add explicit assertions in test_rpc_mutations.c to verify:
- mutation_skills_enable() emits skills.update
- mutation_channels_status(FALSE, ...) emits channels.status
- the non-probe channels status path produces an empty params object
- the non-probe channels status path does not include probe, channelId, or channel fields

This keeps the Linux mutation layer contract-accurate and prevents future drift toward stale method names or unsupported payload shapes.