### PR TITLE
linux: stabilize companion readiness flow (#74)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -50,6 +50,8 @@ sources = [
   'src/markdown_render.c',
   'src/chat_blocks.c',
   'src/format_utils.c',
+  'src/ui_model_utils.c',
+  'src/config_setup_transform.c',
   'src/app_window.c',
   'src/section_chat.c',
   'src/section_agents.c',
@@ -114,7 +116,7 @@ test_runtime_mode_pres_exe = executable('test_runtime_mode_presentation',
 test('runtime_mode_presentation', test_runtime_mode_pres_exe)
 
 test_config_exe = executable('test_config',
-  ['tests/test_config.c', 'src/gateway_config.c', 'src/log.c'],
+  ['tests/test_config.c', 'src/gateway_config.c', 'src/config_setup_transform.c', 'src/log.c'],
   dependencies : [glib_dep, gio_dep, json_glib_dep])
 test('config', test_config_exe)
 

--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -27,6 +27,8 @@
 #include "gateway_rpc.h"
 #include "gateway_data.h"
 #include "gateway_mutations.h"
+#include "json_access.h"
+#include "config_setup_transform.h"
 #include "section_channels.h"
 #include "section_skills.h"
 #include "section_sessions.h"
@@ -38,6 +40,7 @@
 #include "section_logs.h"
 #include "section_control_room.h"
 #include "section_workflows.h"
+#include "ui_model_utils.h"
 #include "log.h"
 
 /* ── Section metadata ── */
@@ -84,6 +87,7 @@ static gboolean last_rpc_ready = FALSE;
 static AppState last_app_state = STATE_NEEDS_SETUP;
 static gboolean shell_seen_gateway_connected = FALSE;
 static gboolean app_css_installed = FALSE;
+static gboolean window_shutting_down = FALSE;
 
 /* Section content widgets that need updating */
 static GtkWidget *section_pages[SECTION_COUNT] = {0};
@@ -111,6 +115,12 @@ static void refresh_shell_status_footer(void);
 static void ensure_app_css_loaded(void);
 static void on_sidebar_row_activated(GtkListBox *box, GtkListBoxRow *row, gpointer user_data);
 static void on_window_destroy(GtkWindow *window, gpointer user_data);
+
+/* Integrated (non-controller) surfaces are lifecycle-sensitive: refresh helpers
+ * must treat widget pointers as ephemeral and no-op during shutdown/teardown. */
+static inline gboolean app_window_can_refresh_integrated(void) {
+    return !window_shutting_down && main_window != NULL;
+}
 
 /* ── Sidebar construction ── */
 
@@ -336,6 +346,34 @@ static void refresh_active_rpc_section(AppSection section) {
     }
 }
 
+static void refresh_active_integrated_section(AppSection section) {
+    switch (section) {
+    case SECTION_DASHBOARD:
+        refresh_dashboard_content();
+        break;
+    case SECTION_GENERAL:
+        refresh_general_content();
+        break;
+    case SECTION_CONFIG:
+        refresh_config_content();
+        break;
+    case SECTION_DIAGNOSTICS:
+        refresh_diagnostics_content();
+        break;
+    case SECTION_ENVIRONMENT:
+        refresh_environment_content();
+        break;
+    case SECTION_INSTANCES:
+        section_instances_refresh_local();
+        break;
+    case SECTION_DEBUG:
+        refresh_debug_content();
+        break;
+    default:
+        break;
+    }
+}
+
 static void invalidate_all_rpc_sections(void) {
     for (int i = 0; i < SECTION_COUNT; i++) {
         if (section_controllers[i] && section_controllers[i]->invalidate) {
@@ -352,6 +390,7 @@ static void on_sidebar_row_activated(GtkListBox *box, GtkListBoxRow *row, gpoint
     if (idx >= 0 && idx < SECTION_COUNT) {
         active_section = (AppSection)idx;
         gtk_stack_set_visible_child_name(GTK_STACK(content_stack), section_meta[idx].id);
+        refresh_active_integrated_section(active_section);
         refresh_active_rpc_section(active_section);
     }
 }
@@ -617,7 +656,7 @@ static GtkWidget* build_dashboard_section(void) {
 /* ── Dashboard refresh ── */
 
 static void refresh_dashboard_content(void) {
-    if (!main_window) return;
+    if (!app_window_can_refresh_integrated()) return;
 
     AppState current = state_get_current();
     RuntimeMode rm = state_get_runtime_mode();
@@ -938,6 +977,7 @@ static GtkWidget* build_general_section(void) {
 }
 
 static void refresh_general_content(void) {
+    if (!app_window_can_refresh_integrated()) return;
     if (!gen_status_label) return;
 
     AppState current = state_get_current();
@@ -991,12 +1031,28 @@ static void refresh_general_content(void) {
     g_autofree gchar *config_path = NULL;
     systemd_get_runtime_context(&profile, &state_dir, &config_path);
 
+    RuntimePathStatus general_paths = {0};
+    runtime_path_status_build(config_path, state_dir, NULL, &general_paths);
+
+    g_autofree gchar *profile_display = NULL;
+    if (profile && profile[0] != '\0') {
+        if (g_utf8_validate(profile, -1, NULL)) {
+            profile_display = g_strdup(profile);
+        } else {
+            profile_display = g_utf8_make_valid(profile, -1);
+        }
+    } else {
+        profile_display = g_strdup("default");
+    }
+
     gtk_label_set_text(GTK_LABEL(gen_config_path_label),
-        config_path ? config_path : "—");
+        general_paths.config_path_resolved ? general_paths.config_path : "—");
     gtk_label_set_text(GTK_LABEL(gen_state_dir_label),
-        state_dir ? state_dir : "—");
+        general_paths.state_dir_resolved ? general_paths.state_dir : "—");
     gtk_label_set_text(GTK_LABEL(gen_profile_label),
-        profile ? profile : "default");
+        profile_display);
+
+    runtime_path_status_clear(&general_paths);
 
     /* Button sensitivity */
     gtk_widget_set_sensitive(gen_btn_start, dm.can_start);
@@ -1028,6 +1084,15 @@ static GtkWidget *cfg_validation_label = NULL;
 static GtkWidget *cfg_copy_btn = NULL;
 static GtkWidget *cfg_reload_btn = NULL;
 static GtkWidget *cfg_save_btn = NULL;
+static GtkWidget *cfg_setup_summary_label = NULL;
+static GtkWidget *cfg_setup_status_label = NULL;
+static GtkWidget *cfg_provider_id_entry = NULL;
+static GtkWidget *cfg_provider_base_url_entry = NULL;
+static GtkWidget *cfg_reload_models_btn = NULL;
+static GtkWidget *cfg_model_dropdown = NULL;
+static GtkStringList *cfg_model_dropdown_model = NULL;
+static GtkWidget *cfg_apply_provider_btn = NULL;
+static GtkWidget *cfg_apply_model_btn = NULL;
 static guint cfg_copy_reset_id = 0;
 static gboolean cfg_programmatic_change = FALSE;
 static gboolean cfg_editor_dirty = FALSE;
@@ -1036,9 +1101,107 @@ static gboolean cfg_request_in_flight = FALSE;
 static gboolean cfg_initial_load_requested = FALSE;
 static gchar *cfg_baseline_text = NULL;
 static gchar *cfg_baseline_hash = NULL;
+static guint cfg_generation = 1;
+static gboolean cfg_models_request_in_flight = FALSE;
+static GPtrArray *cfg_models_cache = NULL;
+
+typedef struct {
+    gchar *id;
+    gchar *label;
+} ConfigModelChoice;
+
+typedef struct {
+    guint generation;
+} ConfigRequestContext;
 
 static gchar* cfg_editor_get_text(void);
 static void cfg_request_reload(void);
+static void cfg_refresh_setup_surface(void);
+static void on_cfg_save_done(const GatewayRpcResponse *response, gpointer user_data);
+
+static ConfigRequestContext* cfg_request_context_new(void) {
+    ConfigRequestContext *ctx = g_new0(ConfigRequestContext, 1);
+    ctx->generation = cfg_generation;
+    return ctx;
+}
+
+static gboolean cfg_request_context_is_stale(const ConfigRequestContext *ctx) {
+    return !ctx || ctx->generation != cfg_generation;
+}
+
+static void cfg_request_context_free(gpointer data) {
+    g_free(data);
+}
+
+static void cfg_model_choice_free(ConfigModelChoice *choice) {
+    if (!choice) return;
+    g_free(choice->id);
+    g_free(choice->label);
+    g_free(choice);
+}
+
+static void cfg_attach_model_dropdown_model(GtkStringList *new_model,
+                                            guint selected,
+                                            gboolean enabled) {
+    if (!new_model) return;
+    ui_dropdown_replace_model(cfg_model_dropdown,
+                              (gpointer *)&cfg_model_dropdown_model,
+                              G_LIST_MODEL(new_model),
+                              selected,
+                              enabled);
+}
+
+static void cfg_set_model_dropdown_placeholder(const gchar *label,
+                                               gboolean enabled) {
+    GtkStringList *new_model = gtk_string_list_new(NULL);
+    gtk_string_list_append(new_model, label && label[0] != '\0' ? label : "No models loaded");
+    cfg_attach_model_dropdown_model(new_model, 0, enabled);
+}
+
+static gchar* cfg_extract_default_model_id(JsonObject *root_obj) {
+    if (!root_obj || !json_object_has_member(root_obj, "agents")) return NULL;
+    JsonNode *agents_node = json_object_get_member(root_obj, "agents");
+    if (!agents_node || !JSON_NODE_HOLDS_OBJECT(agents_node)) return NULL;
+    JsonObject *agents_obj = json_node_get_object(agents_node);
+
+    JsonObject *defaults_obj = NULL;
+    if (json_object_has_member(agents_obj, "defaults")) {
+        JsonNode *defaults_node = json_object_get_member(agents_obj, "defaults");
+        if (defaults_node && JSON_NODE_HOLDS_OBJECT(defaults_node)) {
+            defaults_obj = json_node_get_object(defaults_node);
+        }
+    }
+    if (!defaults_obj && json_object_has_member(agents_obj, "default")) {
+        JsonNode *defaults_node = json_object_get_member(agents_obj, "default");
+        if (defaults_node && JSON_NODE_HOLDS_OBJECT(defaults_node)) {
+            defaults_obj = json_node_get_object(defaults_node);
+        }
+    }
+    if (!defaults_obj || !json_object_has_member(defaults_obj, "model")) return NULL;
+
+    JsonNode *model_node = json_object_get_member(defaults_obj, "model");
+    if (model_node && JSON_NODE_HOLDS_VALUE(model_node) &&
+        json_node_get_value_type(model_node) == G_TYPE_STRING) {
+        const gchar *model = json_node_get_string(model_node);
+        return (model && model[0] != '\0') ? g_strdup(model) : NULL;
+    }
+    if (model_node && JSON_NODE_HOLDS_OBJECT(model_node)) {
+        JsonObject *model_obj = json_node_get_object(model_node);
+        const gchar *primary = oc_json_string_member(model_obj, "primary");
+        return (primary && primary[0] != '\0') ? g_strdup(primary) : NULL;
+    }
+
+    return NULL;
+}
+
+static gboolean cfg_set_editor_text_programmatically(const gchar *text) {
+    if (!cfg_json_view) return FALSE;
+    GtkTextBuffer *buf = gtk_text_view_get_buffer(GTK_TEXT_VIEW(cfg_json_view));
+    cfg_programmatic_change = TRUE;
+    gtk_text_buffer_set_text(buf, text ? text : "{}", -1);
+    cfg_programmatic_change = FALSE;
+    return TRUE;
+}
 
 static void on_cfg_open_file(GtkButton *b, gpointer d) {
     (void)b; (void)d;
@@ -1112,6 +1275,19 @@ static void cfg_refresh_buttons(void) {
         gtk_widget_set_sensitive(cfg_save_btn,
             !cfg_request_in_flight && cfg_editor_dirty && cfg_editor_valid);
     }
+    if (cfg_reload_models_btn) {
+        gtk_widget_set_sensitive(cfg_reload_models_btn,
+                                 !cfg_request_in_flight && !cfg_models_request_in_flight);
+    }
+    if (cfg_apply_provider_btn) {
+        gtk_widget_set_sensitive(cfg_apply_provider_btn,
+                                 !cfg_request_in_flight && cfg_editor_valid);
+    }
+    if (cfg_apply_model_btn) {
+        gboolean has_models = cfg_models_cache && cfg_models_cache->len > 0;
+        gtk_widget_set_sensitive(cfg_apply_model_btn,
+                                 !cfg_request_in_flight && has_models && cfg_editor_valid);
+    }
 }
 
 static gboolean cfg_validate_and_track(const gchar *text) {
@@ -1141,16 +1317,309 @@ static gboolean cfg_validate_and_track(const gchar *text) {
     return valid;
 }
 
+static void cfg_request_save_text(const gchar *text) {
+    if (cfg_request_in_flight) return;
+    if (!cfg_validate_and_track(text)) return;
+    if (!cfg_editor_dirty) {
+        if (cfg_setup_status_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "No config changes to save.");
+        }
+        return;
+    }
+
+    cfg_request_in_flight = TRUE;
+    cfg_refresh_buttons();
+    ConfigRequestContext *ctx = cfg_request_context_new();
+    g_autofree gchar *rid = mutation_config_set(text, cfg_baseline_hash, on_cfg_save_done, ctx);
+    if (!rid) {
+        cfg_request_context_free(ctx);
+        cfg_request_in_flight = FALSE;
+        if (cfg_validation_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Failed to request config.set");
+        }
+        if (cfg_setup_status_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Provider/model save request failed.");
+        }
+        cfg_refresh_buttons();
+    }
+}
+
+static void cfg_rebuild_models_dropdown(const gchar *default_model_id) {
+    GtkStringList *new_model = gtk_string_list_new(NULL);
+    guint selected = 0;
+    for (guint i = 0; cfg_models_cache && i < cfg_models_cache->len; i++) {
+        ConfigModelChoice *choice = g_ptr_array_index(cfg_models_cache, i);
+        gtk_string_list_append(new_model, choice->label ? choice->label : choice->id);
+        if (default_model_id && choice->id && g_strcmp0(choice->id, default_model_id) == 0) {
+            selected = i;
+        }
+    }
+    if (cfg_models_cache && cfg_models_cache->len > 0) {
+        cfg_attach_model_dropdown_model(new_model, selected, TRUE);
+    } else {
+        cfg_attach_model_dropdown_model(new_model, 0, FALSE);
+    }
+}
+
+static void cfg_refresh_setup_surface(void) {
+    g_autofree gchar *text = cfg_editor_get_text();
+    g_autoptr(JsonParser) parser = json_parser_new();
+    g_autoptr(GError) err = NULL;
+
+    const gchar *provider_id = NULL;
+    const gchar *provider_base_url = NULL;
+    g_autofree gchar *default_model_id = NULL;
+
+    if (json_parser_load_from_data(parser, text ? text : "", -1, &err)) {
+        JsonNode *root = json_parser_get_root(parser);
+        if (root && JSON_NODE_HOLDS_OBJECT(root)) {
+            JsonObject *root_obj = json_node_get_object(root);
+            default_model_id = cfg_extract_default_model_id(root_obj);
+
+            if (json_object_has_member(root_obj, "models")) {
+                JsonNode *models_node = json_object_get_member(root_obj, "models");
+                if (models_node && JSON_NODE_HOLDS_OBJECT(models_node)) {
+                    JsonObject *models_obj = json_node_get_object(models_node);
+                    if (json_object_has_member(models_obj, "providers")) {
+                        JsonNode *providers_node = json_object_get_member(models_obj, "providers");
+                        if (providers_node && JSON_NODE_HOLDS_OBJECT(providers_node)) {
+                            JsonObject *providers_obj = json_node_get_object(providers_node);
+                            GList *members = json_object_get_members(providers_obj);
+                            if (members) {
+                                provider_id = members->data;
+                                JsonNode *provider_node = json_object_get_member(providers_obj, provider_id);
+                                if (provider_node && JSON_NODE_HOLDS_OBJECT(provider_node)) {
+                                    JsonObject *provider_obj = json_node_get_object(provider_node);
+                                    provider_base_url = oc_json_string_member(provider_obj, "baseUrl");
+                                }
+                            }
+                            g_list_free(members);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (cfg_provider_id_entry) {
+        gtk_editable_set_text(GTK_EDITABLE(cfg_provider_id_entry), provider_id ? provider_id : "");
+    }
+    if (cfg_provider_base_url_entry) {
+        gtk_editable_set_text(GTK_EDITABLE(cfg_provider_base_url_entry), provider_base_url ? provider_base_url : "");
+    }
+    const DesktopReadinessSnapshot *snap = state_get_readiness_snapshot();
+    ChatGateInfo gate = {0};
+    readiness_describe_chat_gate(snap, &gate);
+    if (cfg_setup_summary_label) {
+        g_autofree gchar *summary = g_strdup_printf(
+            "Provider: %s | Default model: %s | Catalog: %s | Selected: %s | Agents: %s | Chat: %s (%s)",
+            provider_id && provider_id[0] != '\0' ? provider_id : "missing",
+            default_model_id ? default_model_id : "missing",
+            snap && snap->model_catalog_available ? "ready" : "missing",
+            snap && snap->selected_model_resolved ? "resolved" : "unresolved",
+            snap && snap->agents_available ? "ready" : "missing",
+            gate.ready ? "ready" : "blocked",
+            readiness_chat_block_reason_to_string(gate.reason));
+        gtk_label_set_text(GTK_LABEL(cfg_setup_summary_label), summary);
+    }
+
+    if (cfg_setup_status_label) {
+        if (gate.ready) {
+            gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Chat is ready.");
+        } else {
+            g_autofree gchar *status = g_strdup_printf("Blocked (%s). %s",
+                                                       readiness_chat_block_reason_to_string(gate.reason),
+                                                       gate.next_action ? gate.next_action : "Resolve provider/model readiness.");
+            gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), status);
+        }
+    }
+
+    if (cfg_models_cache && cfg_models_cache->len > 0) {
+        cfg_rebuild_models_dropdown(default_model_id);
+    } else {
+        cfg_set_model_dropdown_placeholder("Load models to pick default", FALSE);
+    }
+    cfg_refresh_buttons();
+}
+
+static void on_cfg_models_list_done(const GatewayRpcResponse *response, gpointer user_data) {
+    ConfigRequestContext *ctx = (ConfigRequestContext *)user_data;
+    if (cfg_request_context_is_stale(ctx)) {
+        cfg_request_context_free(ctx);
+        return;
+    }
+    cfg_request_context_free(ctx);
+
+    cfg_models_request_in_flight = FALSE;
+    if (cfg_models_cache) g_ptr_array_unref(cfg_models_cache);
+    cfg_models_cache = g_ptr_array_new_with_free_func((GDestroyNotify)cfg_model_choice_free);
+
+    if (!response || !response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
+        if (cfg_setup_status_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Failed to reload models from gateway.");
+        }
+        cfg_set_model_dropdown_placeholder("Model list unavailable", FALSE);
+        cfg_refresh_buttons();
+        return;
+    }
+
+    JsonObject *obj = json_node_get_object(response->payload);
+    JsonNode *models_node = json_object_get_member(obj, "models");
+    if (models_node && JSON_NODE_HOLDS_ARRAY(models_node)) {
+        JsonArray *arr = json_node_get_array(models_node);
+        for (guint i = 0; i < json_array_get_length(arr); i++) {
+            JsonNode *n = json_array_get_element(arr, i);
+            if (!n || !JSON_NODE_HOLDS_OBJECT(n)) continue;
+            JsonObject *mo = json_node_get_object(n);
+            const gchar *id = oc_json_string_member(mo, "id");
+            if (!id || id[0] == '\0') continue;
+            const gchar *name = oc_json_string_member(mo, "name");
+            const gchar *provider = oc_json_string_member(mo, "provider");
+            ConfigModelChoice *choice = g_new0(ConfigModelChoice, 1);
+            choice->id = g_strdup(id);
+            choice->label = g_strdup_printf("%s (%s)", name ? name : id, provider ? provider : "provider");
+            g_ptr_array_add(cfg_models_cache, choice);
+        }
+    }
+
+    if (active_section == SECTION_CONFIG) {
+        cfg_refresh_setup_surface();
+    }
+    if (cfg_setup_status_label) {
+        g_autofree gchar *msg = g_strdup_printf("Loaded %u model(s) from gateway.", cfg_models_cache->len);
+        gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), msg);
+    }
+}
+
+static void on_cfg_reload_models(GtkButton *button, gpointer user_data) {
+    (void)button;
+    (void)user_data;
+    if (cfg_models_request_in_flight) return;
+
+    cfg_models_request_in_flight = TRUE;
+    cfg_refresh_buttons();
+    ConfigRequestContext *ctx = cfg_request_context_new();
+    g_autofree gchar *rid = gateway_rpc_request("models.list", NULL, 0, on_cfg_models_list_done, ctx);
+    if (!rid) {
+        cfg_request_context_free(ctx);
+        cfg_models_request_in_flight = FALSE;
+        if (cfg_setup_status_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Failed to request models.list.");
+        }
+        cfg_refresh_buttons();
+        gateway_client_request_dependency_refresh();
+        return;
+    }
+
+    gateway_client_invalidate_dependencies(TRUE, FALSE);
+    gateway_client_request_dependency_refresh();
+}
+
+static void on_cfg_apply_provider(GtkButton *button, gpointer user_data) {
+    (void)button;
+    (void)user_data;
+    g_autofree gchar *provider_id = g_strdup(
+        gtk_editable_get_text(GTK_EDITABLE(cfg_provider_id_entry)));
+    g_autofree gchar *base_url = g_strdup(
+        gtk_editable_get_text(GTK_EDITABLE(cfg_provider_base_url_entry)));
+
+    if (!provider_id || provider_id[0] == '\0') {
+        if (cfg_setup_status_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Provider id is required.");
+        }
+        return;
+    }
+
+    if (!cfg_editor_valid) {
+        if (cfg_setup_status_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Fix config JSON before applying provider.");
+        }
+        return;
+    }
+
+    g_autofree gchar *text = cfg_editor_get_text();
+    g_autoptr(GError) err = NULL;
+    g_autofree gchar *updated = config_setup_apply_provider(text, provider_id, base_url, &err);
+    if (!updated) {
+        if (cfg_setup_status_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_setup_status_label),
+                               err && err->message ? err->message : "Failed to apply provider config shape.");
+        }
+        return;
+    }
+
+    cfg_set_editor_text_programmatically(updated);
+    cfg_validate_and_track(updated);
+    if (cfg_setup_status_label) {
+        gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Provider block updated. Saving…");
+    }
+    cfg_request_save_text(updated);
+}
+
+static void on_cfg_apply_default_model(GtkButton *button, gpointer user_data) {
+    (void)button;
+    (void)user_data;
+    guint idx = cfg_model_dropdown ? gtk_drop_down_get_selected(GTK_DROP_DOWN(cfg_model_dropdown)) : GTK_INVALID_LIST_POSITION;
+    if (!cfg_models_cache || idx == GTK_INVALID_LIST_POSITION || idx >= cfg_models_cache->len) {
+        if (cfg_setup_status_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Select a model from the loaded catalog.");
+        }
+        return;
+    }
+
+    ConfigModelChoice *choice = g_ptr_array_index(cfg_models_cache, idx);
+    if (!choice || !choice->id) return;
+
+    if (!cfg_editor_valid) {
+        if (cfg_setup_status_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Fix config JSON before applying default model.");
+        }
+        return;
+    }
+
+    g_autofree gchar *provider_id = g_strdup(
+        gtk_editable_get_text(GTK_EDITABLE(cfg_provider_id_entry)));
+    g_autofree gchar *text = cfg_editor_get_text();
+    g_autoptr(GError) err = NULL;
+    g_autofree gchar *updated = config_setup_apply_default_model(text,
+                                                                 provider_id,
+                                                                 choice->id,
+                                                                 &err);
+    if (!updated) {
+        if (cfg_setup_status_label) {
+            gtk_label_set_text(GTK_LABEL(cfg_setup_status_label),
+                               err && err->message ? err->message : "Failed to apply default model config shape.");
+        }
+        return;
+    }
+
+    cfg_set_editor_text_programmatically(updated);
+    cfg_validate_and_track(updated);
+    if (cfg_setup_status_label) {
+        gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Default model updated. Saving…");
+    }
+    cfg_request_save_text(updated);
+}
+
 static void on_cfg_buffer_changed(GtkTextBuffer *buffer, gpointer user_data) {
     (void)buffer;
     (void)user_data;
     if (cfg_programmatic_change) return;
     g_autofree gchar *text = cfg_editor_get_text();
     cfg_validate_and_track(text);
+    if (active_section == SECTION_CONFIG) {
+        cfg_refresh_setup_surface();
+    }
 }
 
 static void on_cfg_get_done(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    ConfigRequestContext *ctx = (ConfigRequestContext *)user_data;
+    if (cfg_request_context_is_stale(ctx)) {
+        cfg_request_context_free(ctx);
+        return;
+    }
+    cfg_request_context_free(ctx);
+
     cfg_request_in_flight = FALSE;
 
     if (!response || !response->ok) {
@@ -1192,6 +1661,9 @@ static void on_cfg_get_done(const GatewayRpcResponse *response, gpointer user_da
 
     cfg_editor_dirty = FALSE;
     cfg_validate_and_track(cfg_baseline_text);
+    if (active_section == SECTION_CONFIG) {
+        cfg_refresh_setup_surface();
+    }
     cfg_refresh_buttons();
     gateway_config_snapshot_free(snapshot);
 }
@@ -1200,8 +1672,10 @@ static void cfg_request_reload(void) {
     if (cfg_request_in_flight) return;
     cfg_request_in_flight = TRUE;
     cfg_refresh_buttons();
-    g_autofree gchar *rid = mutation_config_get(NULL, on_cfg_get_done, NULL);
+    ConfigRequestContext *ctx = cfg_request_context_new();
+    g_autofree gchar *rid = mutation_config_get(NULL, on_cfg_get_done, ctx);
     if (!rid) {
+        cfg_request_context_free(ctx);
         cfg_request_in_flight = FALSE;
         if (cfg_validation_label) {
             gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Failed to request config.get");
@@ -1217,7 +1691,13 @@ static void on_cfg_reload(GtkButton *b, gpointer d) {
 }
 
 static void on_cfg_save_done(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    ConfigRequestContext *ctx = (ConfigRequestContext *)user_data;
+    if (cfg_request_context_is_stale(ctx)) {
+        cfg_request_context_free(ctx);
+        return;
+    }
+    cfg_request_context_free(ctx);
+
     cfg_request_in_flight = FALSE;
     if (!response || !response->ok) {
         if (cfg_validation_label) {
@@ -1232,6 +1712,12 @@ static void on_cfg_save_done(const GatewayRpcResponse *response, gpointer user_d
     if (cfg_validation_label) {
         gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Save successful. Reloading baseline…");
     }
+    if (cfg_setup_status_label) {
+        gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Saved provider/model config. Reloading baseline…");
+    }
+    gateway_client_invalidate_dependencies(TRUE, TRUE);
+    gateway_client_refresh();
+    gateway_client_request_dependency_refresh();
     cfg_request_reload();
 }
 
@@ -1241,19 +1727,7 @@ static void on_cfg_save(GtkButton *b, gpointer d) {
     if (cfg_request_in_flight) return;
 
     g_autofree gchar *text = cfg_editor_get_text();
-    if (!cfg_validate_and_track(text)) return;
-    if (!cfg_editor_dirty) return;
-
-    cfg_request_in_flight = TRUE;
-    cfg_refresh_buttons();
-    g_autofree gchar *rid = mutation_config_set(text, cfg_baseline_hash, on_cfg_save_done, NULL);
-    if (!rid) {
-        cfg_request_in_flight = FALSE;
-        if (cfg_validation_label) {
-            gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Failed to request config.set");
-        }
-        cfg_refresh_buttons();
-    }
+    cfg_request_save_text(text);
 }
 
 static GtkWidget* build_config_section(void) {
@@ -1326,6 +1800,61 @@ static GtkWidget* build_config_section(void) {
 
     gtk_box_append(GTK_BOX(page), file_row);
 
+    GtkWidget *setup_sep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_top(setup_sep, 8);
+    gtk_box_append(GTK_BOX(page), setup_sep);
+
+    GtkWidget *setup_heading = gtk_label_new("Provider & Model Setup");
+    gtk_widget_add_css_class(setup_heading, "heading");
+    gtk_label_set_xalign(GTK_LABEL(setup_heading), 0.0);
+    gtk_widget_set_margin_top(setup_heading, 8);
+    gtk_box_append(GTK_BOX(page), setup_heading);
+
+    cfg_setup_summary_label = gtk_label_new("Provider: missing | Default model: missing");
+    gtk_widget_add_css_class(cfg_setup_summary_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(cfg_setup_summary_label), 0.0);
+    gtk_box_append(GTK_BOX(page), cfg_setup_summary_label);
+
+    cfg_setup_status_label = gtk_label_new("Use this section to complete provider/model setup for chat readiness.");
+    gtk_widget_add_css_class(cfg_setup_status_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(cfg_setup_status_label), 0.0);
+    gtk_label_set_wrap(GTK_LABEL(cfg_setup_status_label), TRUE);
+    gtk_box_append(GTK_BOX(page), cfg_setup_status_label);
+
+    GtkWidget *provider_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    cfg_provider_id_entry = gtk_entry_new();
+    gtk_entry_set_placeholder_text(GTK_ENTRY(cfg_provider_id_entry), "Provider id (e.g. openai, ollama)");
+    gtk_widget_set_size_request(cfg_provider_id_entry, 220, -1);
+    gtk_box_append(GTK_BOX(provider_row), cfg_provider_id_entry);
+
+    cfg_provider_base_url_entry = gtk_entry_new();
+    gtk_entry_set_placeholder_text(GTK_ENTRY(cfg_provider_base_url_entry), "Provider baseUrl (optional)");
+    gtk_widget_set_hexpand(cfg_provider_base_url_entry, TRUE);
+    gtk_box_append(GTK_BOX(provider_row), cfg_provider_base_url_entry);
+
+    cfg_apply_provider_btn = gtk_button_new_with_label("Configure Provider");
+    g_signal_connect(cfg_apply_provider_btn, "clicked", G_CALLBACK(on_cfg_apply_provider), NULL);
+    gtk_box_append(GTK_BOX(provider_row), cfg_apply_provider_btn);
+    gtk_box_append(GTK_BOX(page), provider_row);
+
+    GtkWidget *model_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    cfg_reload_models_btn = gtk_button_new_with_label("Reload Models");
+    g_signal_connect(cfg_reload_models_btn, "clicked", G_CALLBACK(on_cfg_reload_models), NULL);
+    gtk_box_append(GTK_BOX(model_row), cfg_reload_models_btn);
+
+    cfg_model_dropdown_model = NULL;
+    cfg_model_dropdown = gtk_drop_down_new(NULL, NULL);
+    gtk_widget_set_hexpand(cfg_model_dropdown, TRUE);
+    gtk_box_append(GTK_BOX(model_row), cfg_model_dropdown);
+
+    cfg_apply_model_btn = gtk_button_new_with_label("Set Default Model");
+    gtk_widget_add_css_class(cfg_apply_model_btn, "suggested-action");
+    g_signal_connect(cfg_apply_model_btn, "clicked", G_CALLBACK(on_cfg_apply_default_model), NULL);
+    gtk_box_append(GTK_BOX(model_row), cfg_apply_model_btn);
+    gtk_box_append(GTK_BOX(page), model_row);
+
+    cfg_set_model_dropdown_placeholder("Load models to pick default", FALSE);
+
     /* 5. Raw JSON read-only view */
     GtkWidget *json_heading = gtk_label_new("Raw Config");
     gtk_widget_add_css_class(json_heading, "heading");
@@ -1379,6 +1908,7 @@ static GtkWidget* build_config_section(void) {
 }
 
 static void refresh_config_content(void) {
+    if (!app_window_can_refresh_integrated()) return;
     if (!cfg_status_label) return;
 
     HealthState *health = state_get_health();
@@ -1410,7 +1940,15 @@ static void refresh_config_content(void) {
     }
 
     /* 4. Path + last modified */
-    gtk_label_set_text(GTK_LABEL(cfg_path_label), cm.config_path ? cm.config_path : "—");
+    g_autofree gchar *cfg_path_display = NULL;
+    if (cm.config_path && cm.config_path[0] != '\0') {
+        if (g_utf8_validate(cm.config_path, -1, NULL)) {
+            cfg_path_display = g_strdup(cm.config_path);
+        } else {
+            cfg_path_display = g_filename_display_name(cm.config_path);
+        }
+    }
+    gtk_label_set_text(GTK_LABEL(cfg_path_label), cfg_path_display ? cfg_path_display : "—");
     g_autofree gchar *mod_text = cfg_get_modified_text(path);
     g_autofree gchar *mod_label = g_strdup_printf("Last modified: %s", mod_text);
     gtk_label_set_text(GTK_LABEL(cfg_modified_label), mod_label);
@@ -1418,6 +1956,10 @@ static void refresh_config_content(void) {
     if (!cfg_initial_load_requested && gateway_rpc_is_ready()) {
         cfg_initial_load_requested = TRUE;
         cfg_request_reload();
+    }
+
+    if (active_section == SECTION_CONFIG) {
+        cfg_refresh_setup_surface();
     }
 
     cfg_refresh_buttons();
@@ -1500,6 +2042,7 @@ static GtkWidget* build_diagnostics_section(void) {
 }
 
 static void refresh_diagnostics_content(void) {
+    if (!app_window_can_refresh_integrated()) return;
     if (!diag_text_view) return;
     g_autofree gchar *text = build_diagnostics_text();
     GtkTextBuffer *buf = gtk_text_view_get_buffer(GTK_TEXT_VIEW(diag_text_view));
@@ -1547,19 +2090,11 @@ static void populate_env_checks(GtkWidget *container) {
         effective_config_path = config_path;
     }
 
-    g_autofree gchar *derived_state_dir = NULL;
-    const gchar *effective_state_dir = NULL;
-    if (state_dir && state_dir[0] != '\0') {
-        effective_state_dir = state_dir;
-    } else if (effective_config_path && effective_config_path[0] != '\0') {
-        derived_state_dir = g_path_get_dirname(effective_config_path);
-        if (derived_state_dir && derived_state_dir[0] != '\0') {
-            effective_state_dir = derived_state_dir;
-        }
-    }
-
     EnvironmentCheckResult ecr;
-    environment_check_build(sys, effective_config_path, effective_state_dir, &ecr);
+    environment_check_build(sys,
+                            effective_config_path,
+                            state_dir,
+                            &ecr);
 
     for (int i = 0; i < ecr.count; i++) {
         GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
@@ -1580,6 +2115,8 @@ static void populate_env_checks(GtkWidget *container) {
 
         gtk_box_append(GTK_BOX(container), row);
     }
+
+    environment_check_result_clear(&ecr);
 }
 
 static GtkWidget* build_environment_section(void) {
@@ -1618,6 +2155,7 @@ static GtkWidget* build_environment_section(void) {
 }
 
 static void refresh_environment_content(void) {
+    if (!app_window_can_refresh_integrated()) return;
     if (!env_checks_box) return;
     populate_env_checks(env_checks_box);
 }
@@ -1820,6 +2358,7 @@ static GtkWidget* build_debug_section(void) {
 }
 
 static void refresh_debug_content(void) {
+    if (!app_window_can_refresh_integrated()) return;
     if (!dbg_state_label) return;
 
     SystemdState *sys = state_get_systemd();
@@ -1839,11 +2378,17 @@ static void refresh_debug_content(void) {
         unit ? unit : "openclaw-gateway.service");
     gtk_label_set_text(GTK_LABEL(dbg_journal_label), cmd);
 }
-
 /* ── Auto-refresh timer ── */
 
 static gboolean on_refresh_tick(gpointer user_data) {
     (void)user_data;
+
+    /* During shutdown, integrated refresh must stop before any widget teardown. */
+    if (window_shutting_down) {
+        refresh_timer_id = 0;
+        return G_SOURCE_REMOVE;
+    }
+
     if (main_window) {
         gboolean rpc_ready = gateway_rpc_is_ready();
         AppState app_state = state_get_current();
@@ -1853,13 +2398,7 @@ static gboolean on_refresh_tick(gpointer user_data) {
             last_app_state = app_state;
         }
 
-        refresh_dashboard_content();
-        refresh_general_content();
-        refresh_config_content();
-        refresh_diagnostics_content();
-        refresh_environment_content();
-        section_instances_refresh_local();
-        refresh_debug_content();
+        refresh_active_integrated_section(active_section);
         refresh_shell_status_footer();
         /* RPC-backed sections refresh on activation + TTL, not every tick */
         refresh_active_rpc_section(active_section);
@@ -1876,9 +2415,18 @@ static void on_window_destroy(GtkWindow *window, gpointer user_data) {
     (void)window;
     (void)user_data;
 
+    window_shutting_down = TRUE;
+
     if (refresh_timer_id > 0) {
         g_source_remove(refresh_timer_id);
         refresh_timer_id = 0;
+    }
+
+    /* Destroy section-owned async/list resources before clearing global widgets. */
+    for (int i = 0; i < SECTION_COUNT; i++) {
+        if (section_controllers[i]) {
+            section_controllers[i]->destroy();
+        }
     }
 
     main_window = NULL;
@@ -1936,6 +2484,15 @@ static void on_window_destroy(GtkWindow *window, gpointer user_data) {
     cfg_issues_label = NULL;
     cfg_json_view = NULL;
     cfg_validation_label = NULL;
+    cfg_setup_summary_label = NULL;
+    cfg_setup_status_label = NULL;
+    cfg_provider_id_entry = NULL;
+    cfg_provider_base_url_entry = NULL;
+    cfg_reload_models_btn = NULL;
+    ui_dropdown_detach_model(cfg_model_dropdown, (gpointer *)&cfg_model_dropdown_model);
+    cfg_model_dropdown = NULL;
+    cfg_apply_provider_btn = NULL;
+    cfg_apply_model_btn = NULL;
     if (cfg_copy_reset_id > 0) {
         g_source_remove(cfg_copy_reset_id);
         cfg_copy_reset_id = 0;
@@ -1948,6 +2505,10 @@ static void on_window_destroy(GtkWindow *window, gpointer user_data) {
     cfg_editor_valid = TRUE;
     cfg_request_in_flight = FALSE;
     cfg_initial_load_requested = FALSE;
+    cfg_models_request_in_flight = FALSE;
+    cfg_generation++;
+    if (cfg_models_cache) g_ptr_array_unref(cfg_models_cache);
+    cfg_models_cache = NULL;
     g_clear_pointer(&cfg_baseline_text, g_free);
     g_clear_pointer(&cfg_baseline_hash, g_free);
 
@@ -1964,13 +2525,6 @@ static void on_window_destroy(GtkWindow *window, gpointer user_data) {
     dbg_unit_label = NULL;
     dbg_journal_label = NULL;
 
-    /* Destroy all section controllers */
-    for (int i = 0; i < SECTION_COUNT; i++) {
-        if (section_controllers[i]) {
-            section_controllers[i]->destroy();
-        }
-    }
-
     active_section = SECTION_DASHBOARD;
     last_rpc_ready = FALSE;
     last_app_state = STATE_NEEDS_SETUP;
@@ -1984,6 +2538,8 @@ void app_window_show(void) {
         gtk_window_present(GTK_WINDOW(main_window));
         return;
     }
+
+    window_shutting_down = FALSE;
 
     GApplication *app = g_application_get_default();
     if (!app) return;
@@ -2028,13 +2584,7 @@ void app_window_show(void) {
     g_signal_connect(main_window, "destroy", G_CALLBACK(on_window_destroy), NULL);
 
     /* Initial content fill for local/cheap sections + start auto-refresh */
-    refresh_dashboard_content();
-    refresh_general_content();
-    refresh_config_content();
-    refresh_diagnostics_content();
-    refresh_environment_content();
-    section_instances_refresh_local();
-    refresh_debug_content();
+    refresh_active_integrated_section(active_section);
     refresh_shell_status_footer();
     last_rpc_ready = gateway_rpc_is_ready();
     last_app_state = state_get_current();
@@ -2059,19 +2609,17 @@ void app_window_navigate_to(AppSection section) {
             gtk_list_box_select_row(GTK_LIST_BOX(sidebar_list), row);
         }
     }
+    refresh_active_integrated_section(active_section);
     refresh_active_rpc_section(active_section);
 }
 
 void app_window_refresh_snapshot(void) {
+    /* Explicit lifecycle invariant: snapshot refresh is invalid once shutdown begins. */
+    if (window_shutting_down || !main_window) return;
+
     invalidate_all_rpc_sections();
 
-    refresh_dashboard_content();
-    refresh_general_content();
-    refresh_config_content();
-    refresh_diagnostics_content();
-    refresh_environment_content();
-    section_instances_refresh_local();
-    refresh_debug_content();
+    refresh_active_integrated_section(active_section);
     refresh_shell_status_footer();
 
     refresh_active_rpc_section(active_section);

--- a/apps/linux/src/config_setup_transform.c
+++ b/apps/linux/src/config_setup_transform.c
@@ -1,0 +1,197 @@
+#include "config_setup_transform.h"
+
+#include <json-glib/json-glib.h>
+#include <string.h>
+
+static JsonObject* ensure_object_member(JsonObject *parent, const gchar *member) {
+    JsonNode *node = json_object_get_member(parent, member);
+    if (node && JSON_NODE_HOLDS_OBJECT(node)) {
+        return json_node_get_object(node);
+    }
+
+    JsonObject *child = json_object_new();
+    JsonNode *child_node = json_node_new(JSON_NODE_OBJECT);
+    json_node_take_object(child_node, child);
+    json_object_set_member(parent, member, child_node);
+    return child;
+}
+
+static gchar* transform_to_pretty_json(JsonObject *root_obj) {
+    JsonNode *node = json_node_new(JSON_NODE_OBJECT);
+    json_node_set_object(node, root_obj);
+    gchar *updated = json_to_string(node, TRUE);
+    json_node_unref(node);
+    return updated;
+}
+
+static JsonObject* parse_root_object(const gchar *raw_json,
+                                     GError **error,
+                                     JsonParser **out_parser) {
+    JsonParser *parser = json_parser_new();
+    if (!json_parser_load_from_data(parser, raw_json ? raw_json : "{}", -1, error)) {
+        g_object_unref(parser);
+        return NULL;
+    }
+
+    JsonNode *root = json_parser_get_root(parser);
+    if (!root || !JSON_NODE_HOLDS_OBJECT(root)) {
+        g_set_error_literal(error,
+                            g_quark_from_static_string("openclaw-config-setup"),
+                            1,
+                            "Config root must be a JSON object");
+        g_object_unref(parser);
+        return NULL;
+    }
+
+    if (out_parser) *out_parser = parser;
+    return json_node_get_object(root);
+}
+
+static gboolean provider_id_is(const gchar *provider_id,
+                               const gchar *expected) {
+    if (!provider_id || !expected) {
+        return FALSE;
+    }
+    return g_ascii_strcasecmp(provider_id, expected) == 0;
+}
+
+static const gchar* provider_default_base_url(const gchar *provider_id) {
+    if (provider_id_is(provider_id, "ollama")) {
+        return "http://127.0.0.1:11434";
+    }
+    if (provider_id_is(provider_id, "openai")) {
+        return "https://api.openai.com/v1";
+    }
+    return NULL;
+}
+
+static const gchar* provider_default_api(const gchar *provider_id) {
+    if (provider_id_is(provider_id, "ollama")) {
+        return "ollama";
+    }
+    if (provider_id_is(provider_id, "openai")) {
+        return "openai-responses";
+    }
+    return provider_id;
+}
+
+static const gchar* provider_profile_mode(const gchar *provider_id) {
+    if (provider_id_is(provider_id, "ollama")) {
+        return "api_key";
+    }
+    return "api_key";
+}
+
+static void auth_order_ensure_profile(JsonObject *order_obj,
+                                      const gchar *provider_id,
+                                      const gchar *profile_id) {
+    JsonNode *existing = json_object_get_member(order_obj, provider_id);
+    if (!existing || !JSON_NODE_HOLDS_ARRAY(existing)) {
+        JsonArray *order = json_array_new();
+        json_array_add_string_element(order, profile_id);
+        JsonNode *order_node = json_node_new(JSON_NODE_ARRAY);
+        json_node_take_array(order_node, order);
+        json_object_set_member(order_obj, provider_id, order_node);
+        return;
+    }
+
+    JsonArray *arr = json_node_get_array(existing);
+    guint len = json_array_get_length(arr);
+    for (guint i = 0; i < len; i++) {
+        const gchar *candidate = json_array_get_string_element(arr, i);
+        if (candidate && g_strcmp0(candidate, profile_id) == 0) {
+            return;
+        }
+    }
+    json_array_add_string_element(arr, profile_id);
+}
+
+gchar* config_setup_apply_provider(const gchar *raw_json,
+                                   const gchar *provider_id,
+                                   const gchar *base_url,
+                                   GError **error) {
+    if (!provider_id || provider_id[0] == '\0') {
+        g_set_error_literal(error,
+                            g_quark_from_static_string("openclaw-config-setup"),
+                            2,
+                            "Provider id is required");
+        return NULL;
+    }
+
+    JsonParser *parser = NULL;
+    JsonObject *root_obj = parse_root_object(raw_json, error, &parser);
+    if (!root_obj) return NULL;
+
+    JsonObject *models_obj = ensure_object_member(root_obj, "models");
+    JsonObject *providers_obj = ensure_object_member(models_obj, "providers");
+    JsonObject *provider_obj = ensure_object_member(providers_obj, provider_id);
+    const gchar *effective_base_url = (base_url && base_url[0] != '\0')
+        ? base_url
+        : provider_default_base_url(provider_id);
+    if (effective_base_url && effective_base_url[0] != '\0') {
+        json_object_set_string_member(provider_obj, "baseUrl", effective_base_url);
+    }
+
+    const gchar *effective_api = provider_default_api(provider_id);
+    if (!json_object_has_member(provider_obj, "api") &&
+        effective_api && effective_api[0] != '\0') {
+        json_object_set_string_member(provider_obj, "api", effective_api);
+    }
+
+    if (provider_id_is(provider_id, "ollama") &&
+        !json_object_has_member(provider_obj, "apiKey")) {
+        json_object_set_string_member(provider_obj, "apiKey", "ollama-local");
+    }
+
+    JsonObject *plugins_obj = ensure_object_member(root_obj, "plugins");
+    JsonObject *entries_obj = ensure_object_member(plugins_obj, "entries");
+    JsonObject *provider_entry = ensure_object_member(entries_obj, provider_id);
+    json_object_set_boolean_member(provider_entry, "enabled", TRUE);
+
+    JsonObject *auth_obj = ensure_object_member(root_obj, "auth");
+    JsonObject *profiles_obj = ensure_object_member(auth_obj, "profiles");
+    g_autofree gchar *profile_id = g_strdup_printf("%s:default", provider_id);
+    JsonObject *profile_obj = ensure_object_member(profiles_obj, profile_id);
+    json_object_set_string_member(profile_obj, "provider", provider_id);
+    json_object_set_string_member(profile_obj, "mode", provider_profile_mode(provider_id));
+
+    JsonObject *order_obj = ensure_object_member(auth_obj, "order");
+    auth_order_ensure_profile(order_obj, provider_id, profile_id);
+
+    gchar *updated = transform_to_pretty_json(root_obj);
+    g_object_unref(parser);
+    return updated;
+}
+
+gchar* config_setup_apply_default_model(const gchar *raw_json,
+                                        const gchar *provider_id,
+                                        const gchar *model_id,
+                                        GError **error) {
+    if (!model_id || model_id[0] == '\0') {
+        g_set_error_literal(error,
+                            g_quark_from_static_string("openclaw-config-setup"),
+                            3,
+                            "Model id is required");
+        return NULL;
+    }
+
+    JsonParser *parser = NULL;
+    JsonObject *root_obj = parse_root_object(raw_json, error, &parser);
+    if (!root_obj) return NULL;
+
+    JsonObject *agents_obj = ensure_object_member(root_obj, "agents");
+    JsonObject *defaults_obj = ensure_object_member(agents_obj, "defaults");
+    JsonObject *model_obj = ensure_object_member(defaults_obj, "model");
+    json_object_set_string_member(model_obj, "primary", model_id);
+
+    JsonObject *models_map_obj = ensure_object_member(defaults_obj, "models");
+    (void)ensure_object_member(models_map_obj, model_id);
+
+    if (provider_id && provider_id[0] != '\0') {
+        json_object_set_string_member(defaults_obj, "modelProvider", provider_id);
+    }
+
+    gchar *updated = transform_to_pretty_json(root_obj);
+    g_object_unref(parser);
+    return updated;
+}

--- a/apps/linux/src/config_setup_transform.h
+++ b/apps/linux/src/config_setup_transform.h
@@ -1,0 +1,16 @@
+#ifndef OPENCLAW_LINUX_CONFIG_SETUP_TRANSFORM_H
+#define OPENCLAW_LINUX_CONFIG_SETUP_TRANSFORM_H
+
+#include <glib.h>
+
+gchar* config_setup_apply_provider(const gchar *raw_json,
+                                   const gchar *provider_id,
+                                   const gchar *base_url,
+                                   GError **error);
+
+gchar* config_setup_apply_default_model(const gchar *raw_json,
+                                        const gchar *provider_id,
+                                        const gchar *model_id,
+                                        GError **error);
+
+#endif

--- a/apps/linux/src/diagnostics.c
+++ b/apps/linux/src/diagnostics.c
@@ -1,29 +1,20 @@
 /*
  * diagnostics.c
  *
- * Diagnostics window and debug payload generation.
+ * Diagnostics text payload generation.
  *
- * Provides a plain-text Adwaita window detailing the gateway client
- * connectivity state: systemd service context and native HTTP/WebSocket
- * health. Exposes a canonical formatter to ensure the displayed text
- * and the copied clipboard payload are always identical.
+ * Provides a canonical formatter detailing gateway client readiness,
+ * runtime mode, connectivity, and path/environment truth.
  *
  * Author: Thiago Camargo <thiagocmc@proton.me>
  */
 
-#include <gtk/gtk.h>
-#include <adwaita.h>
 #include "gateway_client.h"
 #include "gateway_config.h"
 #include "diagnostics.h"
 #include "state.h"
 #include "readiness.h"
-
-static GtkWidget *diag_window = NULL;
-static GtkWidget *copy_btn = NULL;
-static guint copy_timeout_id = 0;
-static guint auto_refresh_timeout_id = 0;
-static GtkWidget *text_view = NULL;
+#include "display_model.h"
 
 static gchar* format_age(gint64 timestamp_us) {
     if (timestamp_us == 0) {
@@ -42,6 +33,7 @@ gchar* build_diagnostics_text(void) {
     AppState current = state_get_current();
     SystemdState *sys = state_get_systemd();
     HealthState *health = state_get_health();
+    const DesktopReadinessSnapshot *snapshot = state_get_readiness_snapshot();
 
     ReadinessInfo ri;
     readiness_evaluate(current, health, sys, &ri);
@@ -59,6 +51,19 @@ gchar* build_diagnostics_text(void) {
     if (ri.next_action) {
         g_string_append_printf(out, "Next:   %s\n", ri.next_action);
     }
+    g_string_append_printf(out, "Chat Ready: %s\n", snapshot && snapshot->desktop_chat_ready ? "Yes" : "No");
+    g_string_append_printf(out, "Chat Block Reason: %s\n",
+                           snapshot ? readiness_chat_block_reason_to_string(snapshot->chat_block_reason) : "Unknown");
+    g_string_append_printf(out, "Provider Configured: %s\n",
+                           snapshot && snapshot->provider_configured ? "Yes" : "No");
+    g_string_append_printf(out, "Default Model Configured: %s\n",
+                           snapshot && snapshot->default_model_configured ? "Yes" : "No");
+    g_string_append_printf(out, "Model Catalog Available: %s\n",
+                           snapshot && snapshot->model_catalog_available ? "Yes" : "No");
+    g_string_append_printf(out, "Selected Model Resolved: %s\n",
+                           snapshot && snapshot->selected_model_resolved ? "Yes" : "No");
+    g_string_append_printf(out, "Agents Available: %s\n",
+                           snapshot && snapshot->agents_available ? "Yes" : "No");
 
     /* Runtime mode */
     RuntimeMode rm = state_get_runtime_mode();
@@ -102,14 +107,38 @@ gchar* build_diagnostics_text(void) {
     /* Configuration */
     g_string_append_printf(out, "\n=== Configuration ===\n");
     const GatewayConfig *cfg = gateway_client_get_config();
-    g_string_append_printf(out, "Config Path: %s\n", 
-        cfg && cfg->config_path ? cfg->config_path : "N/A");
-    
-    gboolean config_file_exists = FALSE;
-    if (cfg && cfg->config_path) {
-        config_file_exists = g_file_test(cfg->config_path, G_FILE_TEST_EXISTS);
+
+    g_autofree gchar *profile = NULL;
+    g_autofree gchar *state_dir = NULL;
+    g_autofree gchar *config_path = NULL;
+    extern void systemd_get_runtime_context(gchar **out_profile, gchar **out_state_dir, gchar **out_config_path);
+    systemd_get_runtime_context(&profile, &state_dir, &config_path);
+
+    GatewayConfigContext cfg_ctx = {0};
+    cfg_ctx.explicit_config_path = config_path;
+    cfg_ctx.effective_state_dir = state_dir;
+    cfg_ctx.profile = profile;
+    g_autofree gchar *resolved_config_path = gateway_config_resolve_path(&cfg_ctx);
+
+    const gchar *effective_config_path = NULL;
+    if (cfg && cfg->config_path && cfg->config_path[0] != '\0') {
+        effective_config_path = cfg->config_path;
+    } else if (resolved_config_path && resolved_config_path[0] != '\0') {
+        effective_config_path = resolved_config_path;
+    } else if (config_path && config_path[0] != '\0') {
+        effective_config_path = config_path;
     }
-    g_string_append_printf(out, "Config Exists: %s\n", config_file_exists ? "Yes" : "No");
+
+    RuntimePathStatus paths = {0};
+    runtime_path_status_build(effective_config_path, state_dir, NULL, &paths);
+
+    g_string_append_printf(out, "Config Path: %s\n",
+                           paths.config_path_resolved ? paths.config_path : "N/A");
+    g_string_append_printf(out, "Config Exists: %s\n", paths.config_file_exists ? "Yes" : "No");
+    g_string_append_printf(out, "Config Dir Exists: %s\n", paths.config_dir_exists ? "Yes" : "No");
+    g_string_append_printf(out, "State Dir: %s\n",
+                           paths.state_dir_resolved ? paths.state_dir : "N/A");
+    g_string_append_printf(out, "State Dir Exists: %s\n", paths.state_dir_exists ? "Yes" : "No");
     g_string_append_printf(out, "Setup Detected: %s\n", health->setup_detected ? "Yes" : "No");
     g_string_append_printf(out, "Config Valid: %s\n", health->config_valid ? "Yes" : "No");
     
@@ -127,136 +156,7 @@ gchar* build_diagnostics_text(void) {
     g_string_append_printf(out, "Config Issues: %d\n", health->config_issues_count);
     g_string_append_printf(out, "Last Error: %s\n", health->last_error ? health->last_error : "None");
 
+    runtime_path_status_clear(&paths);
+
     return g_string_free(out, FALSE);
-}
-
-static gboolean refresh_diagnostics_view(gpointer user_data) {
-    (void)user_data;
-    if (diag_window && text_view) {
-        gchar *info_text = build_diagnostics_text();
-        GtkTextBuffer *buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(text_view));
-        gtk_text_buffer_set_text(buffer, info_text, -1);
-        g_free(info_text);
-        return G_SOURCE_CONTINUE;
-    }
-    return G_SOURCE_REMOVE;
-}
-
-static gboolean reset_copy_button(gpointer user_data) {
-    (void)user_data;
-    if (copy_btn) {
-        gtk_button_set_label(GTK_BUTTON(copy_btn), "Copy Diagnostics");
-    }
-    copy_timeout_id = 0;
-    return G_SOURCE_REMOVE;
-}
-
-static void on_copy_clicked(GtkButton *btn, gpointer user_data) {
-    (void)btn;
-    (void)user_data;
-    
-    gchar *payload = build_diagnostics_text();
-    GdkClipboard *clipboard = gdk_display_get_clipboard(gdk_display_get_default());
-    gdk_clipboard_set_text(clipboard, payload);
-    g_free(payload);
-
-    if (copy_btn) {
-        gtk_button_set_label(GTK_BUTTON(copy_btn), "Copied!");
-        
-        if (copy_timeout_id > 0) {
-            g_source_remove(copy_timeout_id);
-        }
-        copy_timeout_id = g_timeout_add(2000, reset_copy_button, NULL);
-    }
-}
-
-static void on_diag_window_close(GtkWindow *window, gpointer user_data) {
-    (void)window;
-    (void)user_data;
-    if (copy_timeout_id > 0) {
-        g_source_remove(copy_timeout_id);
-        copy_timeout_id = 0;
-    }
-    if (auto_refresh_timeout_id > 0) {
-        g_source_remove(auto_refresh_timeout_id);
-        auto_refresh_timeout_id = 0;
-    }
-    copy_btn = NULL;
-    text_view = NULL;
-    diag_window = NULL;
-}
-
-void diagnostics_show_window(void) {
-    if (diag_window) {
-        gtk_window_present(GTK_WINDOW(diag_window));
-        return;
-    }
-
-    GApplication *app = g_application_get_default();
-    
-    diag_window = adw_window_new();
-    gtk_window_set_application(GTK_WINDOW(diag_window), GTK_APPLICATION(app));
-    gtk_window_set_title(GTK_WINDOW(diag_window), "OpenClaw Diagnostics");
-    gtk_window_set_default_size(GTK_WINDOW(diag_window), 550, 550);
-
-    GtkWidget *content_vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-    
-    GtkWidget *header_bar = adw_header_bar_new();
-    GtkWidget *close_header_btn = gtk_button_new_from_icon_name("window-close-symbolic");
-    gtk_widget_set_valign(close_header_btn, GTK_ALIGN_CENTER);
-    g_signal_connect_swapped(close_header_btn, "clicked", G_CALLBACK(gtk_window_destroy), diag_window);
-    adw_header_bar_pack_end(ADW_HEADER_BAR(header_bar), close_header_btn);
-    gtk_box_append(GTK_BOX(content_vbox), header_bar);
-
-    GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 10);
-    gtk_widget_set_margin_start(vbox, 20);
-    gtk_widget_set_margin_end(vbox, 20);
-    gtk_widget_set_margin_top(vbox, 20);
-    gtk_widget_set_margin_bottom(vbox, 20);
-    gtk_widget_set_vexpand(vbox, TRUE);
-    gtk_box_append(GTK_BOX(content_vbox), vbox);
-
-    adw_window_set_content(ADW_WINDOW(diag_window), content_vbox);
-
-    gchar *info_text = build_diagnostics_text();
-    
-    GtkTextBuffer *buffer = gtk_text_buffer_new(NULL);
-    gtk_text_buffer_set_text(buffer, info_text, -1);
-    g_free(info_text);
-
-    text_view = gtk_text_view_new_with_buffer(buffer);
-    gtk_text_view_set_editable(GTK_TEXT_VIEW(text_view), FALSE);
-    gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(text_view), FALSE);
-    gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(text_view), GTK_WRAP_WORD_CHAR);
-    gtk_text_view_set_monospace(GTK_TEXT_VIEW(text_view), TRUE);
-    gtk_widget_set_vexpand(text_view, TRUE);
-
-    GtkWidget *scrolled_window = gtk_scrolled_window_new();
-    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled_window), text_view);
-    gtk_widget_set_vexpand(scrolled_window, TRUE);
-    gtk_box_append(GTK_BOX(vbox), scrolled_window);
-
-    GtkWidget *action_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
-    gtk_widget_set_halign(action_row, GTK_ALIGN_END);
-    gtk_widget_set_margin_top(action_row, 10);
-
-    copy_btn = gtk_button_new_with_label("Copy Diagnostics");
-    g_signal_connect(copy_btn, "clicked", G_CALLBACK(on_copy_clicked), NULL);
-    
-    GtkWidget *close_btn = gtk_button_new_with_label("Close");
-    g_signal_connect_swapped(close_btn, "clicked", G_CALLBACK(gtk_window_destroy), diag_window);
-
-    gtk_box_append(GTK_BOX(action_row), copy_btn);
-    gtk_box_append(GTK_BOX(action_row), close_btn);
-    gtk_box_append(GTK_BOX(vbox), action_row);
-
-    g_signal_connect(diag_window, "destroy", G_CALLBACK(on_diag_window_close), NULL);
-
-    // Refresh diagnostics text every 1 second while window is open.
-    // Note: This auto-refresh updates ONLY the displayed text from already-held 
-    // in-memory state. It does NOT trigger additional CLI work. Lane timers 
-    // and lane subprocesses remain completely separate.
-    auto_refresh_timeout_id = g_timeout_add_seconds(1, refresh_diagnostics_view, NULL);
-
-    gtk_window_present(GTK_WINDOW(diag_window));
 }

--- a/apps/linux/src/diagnostics.h
+++ b/apps/linux/src/diagnostics.h
@@ -1,7 +1,7 @@
 /*
  * diagnostics.h
  *
- * Diagnostics window and debug payload generation.
+ * Diagnostics text payload generation.
  *
  * Author: Thiago Camargo <thiagocmc@proton.me>
  */
@@ -10,5 +10,4 @@
 
 #include <glib.h>
 
-void diagnostics_show_window(void);
 gchar* build_diagnostics_text(void);

--- a/apps/linux/src/display_model.c
+++ b/apps/linux/src/display_model.c
@@ -18,8 +18,6 @@
 
 #include "display_model.h"
 #include <string.h>
-#include <unistd.h>
-#include <stdio.h>
 
 /* ── HTTP probe labels ── */
 
@@ -238,6 +236,86 @@ void config_display_model_build(
 
 /* ── Environment check ── */
 
+static gchar* display_safe_path(const gchar *path) {
+    if (!path || path[0] == '\0') return NULL;
+    if (g_utf8_validate(path, -1, NULL)) {
+        return g_strdup(path);
+    }
+    return g_filename_display_name(path);
+}
+
+static void environment_check_row_set(EnvironmentCheckResult *out,
+                                      int index,
+                                      const char *label,
+                                      gboolean passed,
+                                      const gchar *detail)
+{
+    out->rows[index].label = label;
+    out->rows[index].passed = passed;
+    out->rows[index].detail = g_strdup(detail ? detail : "");
+}
+
+void runtime_path_status_build(
+    const gchar *runtime_config_path,
+    const gchar *runtime_state_dir,
+    const gchar *loaded_config_path,
+    RuntimePathStatus *out)
+{
+    if (!out) return;
+    memset(out, 0, sizeof(*out));
+
+    const gchar *effective_config_path = NULL;
+    gchar *config_dir_raw = NULL;
+    const gchar *state_dir_raw = NULL;
+
+    /* Precedence contract: loaded config path (gateway client) wins over
+     * runtime context path, which wins over unresolved state. */
+    if (loaded_config_path && loaded_config_path[0] != '\0') {
+        effective_config_path = loaded_config_path;
+    } else if (runtime_config_path && runtime_config_path[0] != '\0') {
+        effective_config_path = runtime_config_path;
+    }
+
+    if (effective_config_path) {
+        out->config_path_resolved = TRUE;
+        out->config_file_exists = g_file_test(effective_config_path, G_FILE_TEST_EXISTS);
+
+        config_dir_raw = g_path_get_dirname(effective_config_path);
+        if (config_dir_raw && config_dir_raw[0] != '\0') {
+            out->config_dir_exists = g_file_test(config_dir_raw, G_FILE_TEST_IS_DIR);
+        }
+
+        out->config_path = display_safe_path(effective_config_path);
+        out->config_dir = display_safe_path(config_dir_raw);
+    }
+
+    if (runtime_state_dir && runtime_state_dir[0] != '\0') {
+        state_dir_raw = runtime_state_dir;
+    } else if (config_dir_raw && config_dir_raw[0] != '\0') {
+        state_dir_raw = config_dir_raw;
+    }
+
+    if (state_dir_raw && state_dir_raw[0] != '\0') {
+        out->state_dir_resolved = TRUE;
+        out->state_dir_exists = g_file_test(state_dir_raw, G_FILE_TEST_IS_DIR);
+        out->state_dir = display_safe_path(state_dir_raw);
+    }
+
+    g_free(config_dir_raw);
+}
+
+void runtime_path_status_clear(RuntimePathStatus *status) {
+    if (!status) return;
+    g_clear_pointer(&status->config_path, g_free);
+    g_clear_pointer(&status->config_dir, g_free);
+    g_clear_pointer(&status->state_dir, g_free);
+    status->config_path_resolved = FALSE;
+    status->config_file_exists = FALSE;
+    status->config_dir_exists = FALSE;
+    status->state_dir_resolved = FALSE;
+    status->state_dir_exists = FALSE;
+}
+
 void environment_check_build(
     const SystemdState *sys,
     const char *config_path,
@@ -248,82 +326,90 @@ void environment_check_build(
     memset(out, 0, sizeof(*out));
     int i = 0;
 
+    RuntimePathStatus paths = {0};
+    runtime_path_status_build(config_path, state_dir, NULL, &paths);
+
     /* 1. User systemd session */
-    out->rows[i].label = "User systemd session";
     if (sys && !sys->systemd_unavailable) {
-        out->rows[i].passed = TRUE;
-        out->rows[i].detail = "Available";
+        environment_check_row_set(out, i, "User systemd session", TRUE, "Available");
     } else {
-        out->rows[i].passed = FALSE;
-        out->rows[i].detail = "Cannot connect to user systemd session bus.";
+        environment_check_row_set(out, i, "User systemd session", FALSE,
+                                  "Cannot connect to user systemd session bus.");
     }
     i++;
 
     /* 2. D-Bus session bus — if systemd works, D-Bus works */
-    out->rows[i].label = "D-Bus session bus";
-    out->rows[i].passed = (sys && !sys->systemd_unavailable);
-    out->rows[i].detail = out->rows[i].passed ? "Reachable" : "Not reachable";
+    gboolean dbus_reachable = (sys && !sys->systemd_unavailable);
+    environment_check_row_set(out, i, "D-Bus session bus", dbus_reachable,
+                              dbus_reachable ? "Reachable" : "Not reachable");
     i++;
 
     /* 3. Config path resolved */
-    out->rows[i].label = "Config file";
-    if (config_path && config_path[0] != '\0') {
-        out->rows[i].passed = TRUE;
-        out->rows[i].detail = config_path;
+    if (paths.config_path_resolved) {
+        environment_check_row_set(out, i, "Config file", TRUE, paths.config_path);
     } else {
-        out->rows[i].passed = FALSE;
-        out->rows[i].detail = "No config path resolved.";
+        environment_check_row_set(out, i, "Config file", FALSE, "No config path resolved.");
     }
     i++;
 
     /* 4. Config file exists */
-    out->rows[i].label = "Config exists";
-    if (config_path && config_path[0] != '\0') {
-        out->rows[i].passed = (access(config_path, F_OK) == 0);
-        out->rows[i].detail = out->rows[i].passed ? "Yes" : "No";
+    if (paths.config_path_resolved) {
+        environment_check_row_set(out, i, "Config exists", paths.config_file_exists,
+                                  paths.config_file_exists ? "Yes" : "No");
     } else {
-        out->rows[i].passed = FALSE;
-        out->rows[i].detail = "No (path unresolved)";
+        environment_check_row_set(out, i, "Config exists", FALSE, "No (path unresolved)");
     }
     i++;
 
-    /* 5. State directory resolved */
-    out->rows[i].label = "State directory";
-    if (state_dir && state_dir[0] != '\0') {
-        out->rows[i].passed = TRUE;
-        out->rows[i].detail = state_dir;
+    /* 5. Config directory exists */
+    if (paths.config_path_resolved && paths.config_dir && paths.config_dir[0] != '\0') {
+        environment_check_row_set(out, i, "Config dir exists", paths.config_dir_exists,
+                                  paths.config_dir_exists ? "Yes" : "No");
     } else {
-        out->rows[i].passed = FALSE;
-        out->rows[i].detail = "No state directory resolved.";
+        environment_check_row_set(out, i, "Config dir exists", FALSE, "No (path unresolved)");
     }
     i++;
 
-    /* 6. State directory exists */
-    out->rows[i].label = "State dir exists";
-    if (state_dir && state_dir[0] != '\0') {
-        out->rows[i].passed = (access(state_dir, F_OK) == 0);
-        out->rows[i].detail = out->rows[i].passed ? "Yes" : "No";
+    /* 6. State directory resolved */
+    if (paths.state_dir_resolved) {
+        environment_check_row_set(out, i, "State directory", TRUE, paths.state_dir);
     } else {
-        out->rows[i].passed = FALSE;
-        out->rows[i].detail = "No (path unresolved)";
+        environment_check_row_set(out, i, "State directory", FALSE, "No state directory resolved.");
     }
     i++;
 
-    /* 7. Expected systemd unit present */
-    out->rows[i].label = "Expected systemd unit";
+    /* 7. State directory exists */
+    if (paths.state_dir_resolved) {
+        environment_check_row_set(out, i, "State dir exists", paths.state_dir_exists,
+                                  paths.state_dir_exists ? "Yes" : "No");
+    } else {
+        environment_check_row_set(out, i, "State dir exists", FALSE, "No (path unresolved)");
+    }
+    i++;
+
+    /* 8. Expected systemd unit present */
     if (sys && sys->installed) {
-        out->rows[i].passed = TRUE;
-        out->rows[i].detail = sys->unit_name ? sys->unit_name : "Installed";
+        environment_check_row_set(out, i, "Expected systemd unit", TRUE,
+                                  sys->unit_name ? sys->unit_name : "Installed");
     } else if (sys && sys->systemd_unavailable) {
-        out->rows[i].passed = FALSE;
-        out->rows[i].detail = "Systemd unavailable";
+        environment_check_row_set(out, i, "Expected systemd unit", FALSE, "Systemd unavailable");
     } else {
-        out->rows[i].passed = FALSE;
-        out->rows[i].detail = "Not installed";
+        environment_check_row_set(out, i, "Expected systemd unit", FALSE, "Not installed");
     }
     i++;
 
     out->count = i;
+    runtime_path_status_clear(&paths);
+}
+
+void environment_check_result_clear(EnvironmentCheckResult *result) {
+    if (!result) return;
+    for (int i = 0; i < ENV_CHECK_MAX_ROWS; i++) {
+        g_clear_pointer(&result->rows[i].detail, g_free);
+        result->rows[i].label = NULL;
+        result->rows[i].passed = FALSE;
+    }
+    result->count = 0;
 }
 
 /* ── Onboarding routing ── */

--- a/apps/linux/src/display_model.h
+++ b/apps/linux/src/display_model.h
@@ -125,7 +125,7 @@ void config_display_model_build(
 typedef struct {
     const char *label;
     gboolean passed;
-    const char *detail;            /* path or explanation */
+    gchar *detail;                 /* owned UTF-8 path or explanation */
 } EnvironmentCheckRow;
 
 #define ENV_CHECK_MAX_ROWS 8
@@ -135,11 +135,33 @@ typedef struct {
     int count;
 } EnvironmentCheckResult;
 
+typedef struct {
+    /* Display-safe UTF-8 values for rendering and diagnostics text. */
+    gchar *config_path;
+    gchar *config_dir;
+    gchar *state_dir;
+    gboolean config_path_resolved;
+    gboolean config_file_exists;
+    gboolean config_dir_exists;
+    gboolean state_dir_resolved;
+    gboolean state_dir_exists;
+} RuntimePathStatus;
+
+void runtime_path_status_build(
+    const gchar *runtime_config_path,
+    const gchar *runtime_state_dir,
+    const gchar *loaded_config_path,
+    RuntimePathStatus *out);
+
+void runtime_path_status_clear(RuntimePathStatus *status);
+
 void environment_check_build(
     const SystemdState *sys,
     const char *config_path,
     const char *state_dir,
     EnvironmentCheckResult *out);
+
+void environment_check_result_clear(EnvironmentCheckResult *result);
 
 /* ── Onboarding routing ── */
 

--- a/apps/linux/src/gateway_client.c
+++ b/apps/linux/src/gateway_client.c
@@ -16,7 +16,9 @@
 #include "gateway_client.h"
 #include "gateway_config.h"
 #include "gateway_http.h"
+#include "gateway_rpc.h"
 #include "gateway_ws.h"
+#include "json_access.h"
 #include "state.h"
 #include "log.h"
 #include "test_seams.h"
@@ -27,6 +29,16 @@ typedef struct {
     guint generation;
     gchar *url;
 } GatewayHealthContext;
+
+typedef enum {
+    DEP_REFRESH_MODELS = 1,
+    DEP_REFRESH_AGENTS = 2,
+} DependencyRefreshKind;
+
+typedef struct {
+    guint generation;
+    DependencyRefreshKind kind;
+} DependencyRefreshContext;
 
 static GatewayConfig *current_config = NULL;
 static gchar *current_http_url = NULL;
@@ -39,6 +51,17 @@ static gboolean current_setup_detected = FALSE;
 static guint health_poll_timer_id = 0;
 #define HEALTH_POLL_INTERVAL_S 10
 
+static guint dependency_generation = 1;
+static gboolean dependency_models_in_flight = FALSE;
+static gboolean dependency_agents_in_flight = FALSE;
+static gint64 dependency_last_refresh_us = 0;
+static gboolean dependency_models_fresh = FALSE;
+static gboolean dependency_agents_fresh = FALSE;
+static gint64 dependency_models_last_success_us = 0;
+static gint64 dependency_agents_last_success_us = 0;
+#define DEPENDENCY_REFRESH_MIN_INTERVAL_US (2 * G_TIME_SPAN_SECOND)
+#define DEPENDENCY_REFRESH_STALE_AFTER_US (30 * G_TIME_SPAN_SECOND)
+
 /* Config monitor state for live config discovery/reload (Feature A) */
 static GFileMonitor *config_dir_monitor = NULL;
 static GFileMonitor *config_file_monitor = NULL;
@@ -50,6 +73,202 @@ static guint config_monitor_refresh_source_id = 0;
 static void do_health_check(void);
 static void config_monitor_clear(void);
 static void config_monitor_rearm(void);
+static void dependency_refresh_start(gboolean force);
+static void dependency_invalidate(gboolean invalidate_models,
+                                  gboolean invalidate_agents,
+                                  gboolean cancel_in_flight,
+                                  const gchar *reason);
+
+static DependencyRefreshContext* dependency_refresh_context_new(DependencyRefreshKind kind) {
+    DependencyRefreshContext *ctx = g_new0(DependencyRefreshContext, 1);
+    ctx->generation = dependency_generation;
+    ctx->kind = kind;
+    return ctx;
+}
+
+static gboolean dependency_refresh_context_is_stale(const DependencyRefreshContext *ctx) {
+    return !ctx || ctx->generation != dependency_generation;
+}
+
+static void dependency_refresh_context_free(gpointer data) {
+    g_free(data);
+}
+
+static gboolean gateway_can_refresh_dependencies(void) {
+    if (!current_config || !current_config->valid) return FALSE;
+    return gateway_rpc_is_ready();
+}
+
+static gboolean dependency_fact_is_stale(gboolean fresh,
+                                         gint64 last_success_us,
+                                         gint64 now_us) {
+    if (!fresh || last_success_us <= 0) {
+        return TRUE;
+    }
+    return (now_us - last_success_us) >= DEPENDENCY_REFRESH_STALE_AFTER_US;
+}
+
+static void dependency_invalidate(gboolean invalidate_models,
+                                  gboolean invalidate_agents,
+                                  gboolean cancel_in_flight,
+                                  const gchar *reason) {
+    if (!invalidate_models && !invalidate_agents) {
+        return;
+    }
+
+    if (cancel_in_flight) {
+        dependency_generation++;
+        dependency_models_in_flight = FALSE;
+        dependency_agents_in_flight = FALSE;
+    }
+
+    if (invalidate_models) {
+        dependency_models_fresh = FALSE;
+        dependency_models_last_success_us = 0;
+        state_set_model_catalog_fact(FALSE, 0, FALSE);
+    }
+    if (invalidate_agents) {
+        dependency_agents_fresh = FALSE;
+        dependency_agents_last_success_us = 0;
+        state_set_agents_fact(FALSE, 0);
+    }
+
+    dependency_last_refresh_us = 0;
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
+                 "dependency refresh invalidated models=%d agents=%d cancel_in_flight=%d reason=%s",
+                 invalidate_models,
+                 invalidate_agents,
+                 cancel_in_flight,
+                 reason ? reason : "(none)");
+}
+
+static void on_dependency_models_response(const GatewayRpcResponse *response, gpointer user_data) {
+    DependencyRefreshContext *ctx = (DependencyRefreshContext *)user_data;
+    if (dependency_refresh_context_is_stale(ctx)) {
+        dependency_refresh_context_free(ctx);
+        return;
+    }
+    dependency_refresh_context_free(ctx);
+    dependency_models_in_flight = FALSE;
+
+    if (!response || !response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
+        dependency_models_fresh = FALSE;
+        dependency_models_last_success_us = 0;
+        state_set_model_catalog_fact(FALSE, 0, FALSE);
+        return;
+    }
+
+    JsonObject *obj = json_node_get_object(response->payload);
+    JsonNode *models_node = json_object_get_member(obj, "models");
+    if (!models_node || !JSON_NODE_HOLDS_ARRAY(models_node)) {
+        dependency_models_fresh = TRUE;
+        dependency_models_last_success_us = g_get_real_time();
+        state_set_model_catalog_fact(TRUE, 0, FALSE);
+        return;
+    }
+
+    JsonArray *arr = json_node_get_array(models_node);
+    guint model_count = json_array_get_length(arr);
+    gboolean selected_resolved = FALSE;
+    const gchar *default_model_id =
+        (current_config && current_config->configured_default_model_id)
+            ? current_config->configured_default_model_id
+            : NULL;
+    if (default_model_id && default_model_id[0] != '\0') {
+        for (guint i = 0; i < model_count; i++) {
+            JsonNode *n = json_array_get_element(arr, i);
+            if (!n || !JSON_NODE_HOLDS_OBJECT(n)) continue;
+            JsonObject *mo = json_node_get_object(n);
+            const gchar *id = oc_json_string_member(mo, "id");
+            if (id && g_strcmp0(id, default_model_id) == 0) {
+                selected_resolved = TRUE;
+                break;
+            }
+        }
+    }
+
+    dependency_models_fresh = TRUE;
+    dependency_models_last_success_us = g_get_real_time();
+    state_set_model_catalog_fact(TRUE, model_count, selected_resolved);
+}
+
+static void on_dependency_agents_response(const GatewayRpcResponse *response, gpointer user_data) {
+    DependencyRefreshContext *ctx = (DependencyRefreshContext *)user_data;
+    if (dependency_refresh_context_is_stale(ctx)) {
+        dependency_refresh_context_free(ctx);
+        return;
+    }
+    dependency_refresh_context_free(ctx);
+    dependency_agents_in_flight = FALSE;
+
+    if (!response || !response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
+        dependency_agents_fresh = FALSE;
+        dependency_agents_last_success_us = 0;
+        state_set_agents_fact(FALSE, 0);
+        return;
+    }
+
+    JsonObject *obj = json_node_get_object(response->payload);
+    JsonNode *agents_node = json_object_get_member(obj, "agents");
+    if (!agents_node || !JSON_NODE_HOLDS_ARRAY(agents_node)) {
+        dependency_agents_fresh = TRUE;
+        dependency_agents_last_success_us = g_get_real_time();
+        state_set_agents_fact(TRUE, 0);
+        return;
+    }
+
+    JsonArray *arr = json_node_get_array(agents_node);
+    dependency_agents_fresh = TRUE;
+    dependency_agents_last_success_us = g_get_real_time();
+    state_set_agents_fact(TRUE, json_array_get_length(arr));
+}
+
+static void dependency_refresh_start(gboolean force) {
+    if (!gateway_can_refresh_dependencies()) return;
+    if (dependency_models_in_flight || dependency_agents_in_flight) return;
+
+    gint64 now_us = g_get_real_time();
+    if (!force) {
+        gboolean models_stale = dependency_fact_is_stale(
+            dependency_models_fresh, dependency_models_last_success_us, now_us);
+        gboolean agents_stale = dependency_fact_is_stale(
+            dependency_agents_fresh, dependency_agents_last_success_us, now_us);
+        gboolean freshness_refresh_needed = models_stale || agents_stale;
+
+        if (!freshness_refresh_needed &&
+            dependency_last_refresh_us > 0 &&
+            (now_us - dependency_last_refresh_us) < DEPENDENCY_REFRESH_MIN_INTERVAL_US) {
+            return;
+        }
+    }
+    dependency_last_refresh_us = now_us;
+
+    dependency_models_in_flight = TRUE;
+    dependency_agents_in_flight = TRUE;
+
+    DependencyRefreshContext *models_ctx = dependency_refresh_context_new(DEP_REFRESH_MODELS);
+    g_autofree gchar *models_rid = gateway_rpc_request("models.list", NULL, 0,
+                                                       on_dependency_models_response, models_ctx);
+    if (!models_rid) {
+        dependency_refresh_context_free(models_ctx);
+        dependency_models_in_flight = FALSE;
+        dependency_models_fresh = FALSE;
+        dependency_models_last_success_us = 0;
+        state_set_model_catalog_fact(FALSE, 0, FALSE);
+    }
+
+    DependencyRefreshContext *agents_ctx = dependency_refresh_context_new(DEP_REFRESH_AGENTS);
+    g_autofree gchar *agents_rid = gateway_rpc_request("agents.list", NULL, 0,
+                                                       on_dependency_agents_response, agents_ctx);
+    if (!agents_rid) {
+        dependency_refresh_context_free(agents_ctx);
+        dependency_agents_in_flight = FALSE;
+        dependency_agents_fresh = FALSE;
+        dependency_agents_last_success_us = 0;
+        state_set_agents_fact(FALSE, 0);
+    }
+}
 
 static GatewayConfig* load_config_with_context(void) {
     GatewayConfigContext ctx = {0};
@@ -94,6 +313,9 @@ static void publish_health_state(gboolean http_ok, HttpProbeResult http_probe_re
     hs.config_valid = current_config ? current_config->valid : FALSE;
     hs.setup_detected = current_setup_detected;
     hs.has_model_config = current_config ? current_config->has_model_config : FALSE;
+    hs.has_provider_config = current_config ? current_config->has_provider_config : FALSE;
+    hs.has_default_model_config = current_config ? current_config->has_default_model_config : FALSE;
+    hs.configured_default_model_id = current_config ? current_config->configured_default_model_id : NULL;
     
     /* Feature B: Wizard onboard marker fields */
     hs.has_wizard_onboard_marker = current_config ? current_config->has_wizard_onboard_marker : FALSE;
@@ -134,7 +356,9 @@ static void publish_invalid_config_state(void) {
     if (current_config) {
         hs.endpoint_host = g_strdup(current_config->host);
         hs.endpoint_port = current_config->port;
+        hs.configured_default_model_id = current_config->configured_default_model_id;
     }
+    state_reset_resolved_facts();
     state_update_health(&hs);
     g_free(hs.endpoint_host);
     g_free(hs.last_error);
@@ -189,6 +413,7 @@ static void on_ws_status(const GatewayWsStatus *status, gpointer user_data) {
      */
     if (ws_connected) {
         do_health_check();
+        dependency_refresh_start(TRUE);
     }
 }
 
@@ -247,6 +472,10 @@ static void on_health_result(const GatewayHealthResult *result, gpointer user_da
         result->version,
         current ? current->auth_source : NULL,
         merged_error);
+
+    if (result->ok && ws_connected && current && current->rpc_ok && current->auth_ok) {
+        dependency_refresh_start(FALSE);
+    }
 }
 
 static void do_health_check(void) {
@@ -266,7 +495,8 @@ static gboolean on_health_poll_timer(gpointer user_data) {
     return G_SOURCE_CONTINUE;
 }
 
-static void teardown_transport(void) {
+static void teardown_transport(gboolean invalidate_models,
+                              gboolean invalidate_agents) {
     if (health_poll_timer_id) {
         g_source_remove(health_poll_timer_id);
         health_poll_timer_id = 0;
@@ -280,6 +510,11 @@ static void teardown_transport(void) {
     /* Reset health gate and increment generation so stale callbacks are ignored */
     health_in_flight = FALSE;
     current_health_generation++;
+    dependency_invalidate(invalidate_models,
+                          invalidate_agents,
+                          TRUE,
+                          "transport teardown");
+    state_reset_resolved_facts();
 }
 
 static void start_transport(void) {
@@ -607,6 +842,7 @@ void gateway_client_refresh(void) {
             /* Unchanged valid config — lightweight health refresh */
             gateway_config_free(new_config);
             do_health_check();
+            dependency_refresh_start(FALSE);
             return;
         }
         /* Unchanged invalid config — republish error state */
@@ -624,7 +860,19 @@ void gateway_client_refresh(void) {
               new_config ? (int)new_config->error_code : -1);
 
     /* Config changed — always replace stored config */
-    teardown_transport();
+    gboolean invalidate_models = TRUE;
+    gboolean invalidate_agents = TRUE;
+    if (current_config && new_config && current_config->valid && new_config->valid) {
+        gboolean model_context_changed =
+            current_config->has_provider_config != new_config->has_provider_config ||
+            current_config->has_default_model_config != new_config->has_default_model_config ||
+            g_strcmp0(current_config->configured_default_model_id,
+                      new_config->configured_default_model_id) != 0;
+        if (!model_context_changed) {
+            invalidate_models = FALSE;
+        }
+    }
+    teardown_transport(invalidate_models, invalidate_agents);
     gateway_config_free(current_config);
     current_config = new_config;
 
@@ -645,7 +893,7 @@ void gateway_client_shutdown(void) {
     /* Stop monitoring config file (Feature A) */
     config_monitor_clear();
 
-    teardown_transport();
+    teardown_transport(TRUE, TRUE);
     gateway_ws_shutdown();
     gateway_http_shutdown();
     gateway_config_free(current_config);
@@ -658,4 +906,16 @@ gboolean gateway_client_is_connected(void) {
 
 GatewayConfig* gateway_client_get_config(void) {
     return current_config;
+}
+
+void gateway_client_request_dependency_refresh(void) {
+    dependency_refresh_start(TRUE);
+}
+
+void gateway_client_invalidate_dependencies(gboolean invalidate_models,
+                                            gboolean invalidate_agents) {
+    dependency_invalidate(invalidate_models,
+                          invalidate_agents,
+                          FALSE,
+                          "explicit request");
 }

--- a/apps/linux/src/gateway_client.h
+++ b/apps/linux/src/gateway_client.h
@@ -21,6 +21,9 @@ void gateway_client_init(void);
 void gateway_client_refresh(void);
 void gateway_client_shutdown(void);
 gboolean gateway_client_is_connected(void);
+void gateway_client_request_dependency_refresh(void);
+void gateway_client_invalidate_dependencies(gboolean invalidate_models,
+                                            gboolean invalidate_agents);
 
 #include "gateway_config.h"
 GatewayConfig* gateway_client_get_config(void);

--- a/apps/linux/src/gateway_config.c
+++ b/apps/linux/src/gateway_config.c
@@ -408,36 +408,149 @@ static gboolean validate_auth(GatewayConfig *config) {
  * Feature B: onboarding detection based on agents.default.model or
  * agents.default.modelProvider presence.
  */
-static gboolean detect_has_model_config(JsonObject *root_obj) {
+static gboolean detect_has_provider_config(JsonObject *root_obj) {
     if (!root_obj) return FALSE;
 
-    /* Check agents.default object for model or modelProvider */
+    if (json_object_has_member(root_obj, "models")) {
+        JsonNode *models_node = json_object_get_member(root_obj, "models");
+        if (JSON_NODE_HOLDS_OBJECT(models_node)) {
+            JsonObject *models_obj = json_node_get_object(models_node);
+            if (json_object_has_member(models_obj, "providers")) {
+                JsonNode *providers_node = json_object_get_member(models_obj, "providers");
+                if (JSON_NODE_HOLDS_OBJECT(providers_node) &&
+                    json_object_get_size(json_node_get_object(providers_node)) > 0) {
+                    return TRUE;
+                }
+            }
+        }
+    }
+
     if (json_object_has_member(root_obj, "agents")) {
         JsonNode *agents_node = json_object_get_member(root_obj, "agents");
         if (JSON_NODE_HOLDS_OBJECT(agents_node)) {
             JsonObject *agents_obj = json_node_get_object(agents_node);
-            if (json_object_has_member(agents_obj, "default")) {
+            JsonObject *defaults_obj = NULL;
+            if (json_object_has_member(agents_obj, "defaults")) {
+                JsonNode *defaults_node = json_object_get_member(agents_obj, "defaults");
+                if (JSON_NODE_HOLDS_OBJECT(defaults_node)) {
+                    defaults_obj = json_node_get_object(defaults_node);
+                }
+            }
+            if (!defaults_obj && json_object_has_member(agents_obj, "default")) {
                 JsonNode *default_node = json_object_get_member(agents_obj, "default");
                 if (JSON_NODE_HOLDS_OBJECT(default_node)) {
-                    JsonObject *default_obj = json_node_get_object(default_node);
-                    /* Presence of model or modelProvider indicates onboarding completed */
-                    if (json_object_has_member(default_obj, "model")) {
-                        JsonNode *model_node = json_object_get_member(default_obj, "model");
-                        if (json_node_get_value_type(model_node) == G_TYPE_STRING) {
-                            const gchar *model = json_node_get_string(model_node);
-                            if (model && model[0] != '\0') {
-                                return TRUE;
+                    defaults_obj = json_node_get_object(default_node);
+                }
+            }
+            if (defaults_obj && json_object_has_member(defaults_obj, "modelProvider")) {
+                JsonNode *provider_node = json_object_get_member(defaults_obj, "modelProvider");
+                if (JSON_NODE_HOLDS_VALUE(provider_node) &&
+                    json_node_get_value_type(provider_node) == G_TYPE_STRING) {
+                    const gchar *provider = json_node_get_string(provider_node);
+                    if (provider && provider[0] != '\0') {
+                        return TRUE;
+                    }
+                }
+            }
+        }
+    }
+
+    return FALSE;
+}
+
+static gchar* extract_configured_default_model_id(JsonObject *root_obj) {
+    if (!root_obj || !json_object_has_member(root_obj, "agents")) return NULL;
+
+    JsonNode *agents_node = json_object_get_member(root_obj, "agents");
+    if (!JSON_NODE_HOLDS_OBJECT(agents_node)) return NULL;
+
+    JsonObject *agents_obj = json_node_get_object(agents_node);
+    JsonObject *defaults_obj = NULL;
+    if (json_object_has_member(agents_obj, "defaults")) {
+        JsonNode *defaults_node = json_object_get_member(agents_obj, "defaults");
+        if (JSON_NODE_HOLDS_OBJECT(defaults_node)) {
+            defaults_obj = json_node_get_object(defaults_node);
+        }
+    }
+    if (!defaults_obj && json_object_has_member(agents_obj, "default")) {
+        JsonNode *default_node = json_object_get_member(agents_obj, "default");
+        if (JSON_NODE_HOLDS_OBJECT(default_node)) {
+            defaults_obj = json_node_get_object(default_node);
+        }
+    }
+    if (!defaults_obj || !json_object_has_member(defaults_obj, "model")) {
+        return NULL;
+    }
+
+    JsonNode *model_node = json_object_get_member(defaults_obj, "model");
+    if (JSON_NODE_HOLDS_VALUE(model_node) && json_node_get_value_type(model_node) == G_TYPE_STRING) {
+        const gchar *model = json_node_get_string(model_node);
+        return (model && model[0] != '\0') ? g_strdup(model) : NULL;
+    }
+    if (JSON_NODE_HOLDS_OBJECT(model_node)) {
+        JsonObject *model_obj = json_node_get_object(model_node);
+        if (model_obj && json_object_has_member(model_obj, "primary")) {
+            JsonNode *primary_node = json_object_get_member(model_obj, "primary");
+            if (JSON_NODE_HOLDS_VALUE(primary_node) &&
+                json_node_get_value_type(primary_node) == G_TYPE_STRING) {
+                const gchar *primary = json_node_get_string(primary_node);
+                return (primary && primary[0] != '\0') ? g_strdup(primary) : NULL;
+            }
+        }
+    }
+
+    return NULL;
+}
+
+static gboolean detect_has_default_model_config(JsonObject *root_obj) {
+    if (!root_obj) return FALSE;
+
+    /* Check agents.defaults/default object for model/provider metadata. */
+    if (json_object_has_member(root_obj, "agents")) {
+        JsonNode *agents_node = json_object_get_member(root_obj, "agents");
+        if (JSON_NODE_HOLDS_OBJECT(agents_node)) {
+            JsonObject *agents_obj = json_node_get_object(agents_node);
+            JsonObject *defaults_obj = NULL;
+            if (json_object_has_member(agents_obj, "defaults")) {
+                JsonNode *defaults_node = json_object_get_member(agents_obj, "defaults");
+                if (JSON_NODE_HOLDS_OBJECT(defaults_node)) {
+                    defaults_obj = json_node_get_object(defaults_node);
+                }
+            }
+            if (!defaults_obj && json_object_has_member(agents_obj, "default")) {
+                JsonNode *default_node = json_object_get_member(agents_obj, "default");
+                if (JSON_NODE_HOLDS_OBJECT(default_node)) {
+                    defaults_obj = json_node_get_object(default_node);
+                }
+            }
+
+            if (defaults_obj) {
+                if (json_object_has_member(defaults_obj, "model")) {
+                    JsonNode *model_node = json_object_get_member(defaults_obj, "model");
+                    if (JSON_NODE_HOLDS_VALUE(model_node) && json_node_get_value_type(model_node) == G_TYPE_STRING) {
+                        const gchar *model = json_node_get_string(model_node);
+                        if (model && model[0] != '\0') {
+                            return TRUE;
+                        }
+                    } else if (JSON_NODE_HOLDS_OBJECT(model_node)) {
+                        JsonObject *model_obj = json_node_get_object(model_node);
+                        if (model_obj && json_object_has_member(model_obj, "primary")) {
+                            JsonNode *primary_node = json_object_get_member(model_obj, "primary");
+                            if (JSON_NODE_HOLDS_VALUE(primary_node) &&
+                                json_node_get_value_type(primary_node) == G_TYPE_STRING) {
+                                const gchar *primary = json_node_get_string(primary_node);
+                                if (primary && primary[0] != '\0') {
+                                    return TRUE;
+                                }
                             }
                         }
                     }
-                    if (json_object_has_member(default_obj, "modelProvider")) {
-                        JsonNode *provider_node = json_object_get_member(default_obj, "modelProvider");
-                        if (json_node_get_value_type(provider_node) == G_TYPE_STRING) {
-                            const gchar *provider = json_node_get_string(provider_node);
-                            if (provider && provider[0] != '\0') {
-                                return TRUE;
-                            }
-                        }
+                }
+                if (json_object_has_member(defaults_obj, "models")) {
+                    JsonNode *models_node = json_object_get_member(defaults_obj, "models");
+                    if (JSON_NODE_HOLDS_OBJECT(models_node) &&
+                        json_object_get_size(json_node_get_object(models_node)) > 0) {
+                        return TRUE;
                     }
                 }
             }
@@ -697,7 +810,10 @@ GatewayConfig* gateway_config_load(const GatewayConfigContext *ctx) {
     config->error_code = GW_CFG_OK;
 
     /* Feature B: Detect if config has model/provider (diagnostic only) */
-    config->has_model_config = detect_has_model_config(root_obj);
+    config->has_provider_config = detect_has_provider_config(root_obj);
+    config->has_default_model_config = detect_has_default_model_config(root_obj);
+    config->has_model_config = (config->has_provider_config || config->has_default_model_config);
+    config->configured_default_model_id = extract_configured_default_model_id(root_obj);
 
     /* Feature B: Detect if wizard onboarding is complete */
     if (json_object_has_member(root_obj, "wizard")) {
@@ -767,6 +883,7 @@ void gateway_config_free(GatewayConfig *config) {
     g_free(config->control_ui_base_path);
     g_free(config->config_path);
     g_free(config->error);
+    g_free(config->configured_default_model_id);
 
     g_free(config->wizard_last_run_command);
     g_free(config->wizard_last_run_at);
@@ -836,6 +953,9 @@ gboolean gateway_config_equivalent(const GatewayConfig *a, const GatewayConfig *
 
     /* Feature B: Wizard fields */
     if (a->has_model_config != b->has_model_config) return FALSE;
+    if (a->has_provider_config != b->has_provider_config) return FALSE;
+    if (a->has_default_model_config != b->has_default_model_config) return FALSE;
+    if (g_strcmp0(a->configured_default_model_id, b->configured_default_model_id) != 0) return FALSE;
     if (a->has_wizard_onboard_marker != b->has_wizard_onboard_marker) return FALSE;
     if (a->wizard_is_local != b->wizard_is_local) return FALSE;
     if (g_strcmp0(a->wizard_last_run_command, b->wizard_last_run_command) != 0) return FALSE;

--- a/apps/linux/src/gateway_config.h
+++ b/apps/linux/src/gateway_config.h
@@ -64,7 +64,10 @@ typedef struct {
     gboolean valid;        /* whether config was loaded successfully */
     GatewayConfigError error_code; /* stable error discriminator */
     gchar *error;          /* human-readable error message */
-    gboolean has_model_config; /* diagnostic only: config has model/provider for runtime */
+    gboolean has_model_config; /* compatibility aggregate: provider/default model present */
+    gboolean has_provider_config; /* config declares at least one provider */
+    gboolean has_default_model_config; /* config declares a default/primary model */
+    gchar *configured_default_model_id; /* parsed default model id when present */
 
     /* Feature B: Wizard onboard marker fields */
     gboolean has_wizard_onboard_marker;

--- a/apps/linux/src/onboarding.c
+++ b/apps/linux/src/onboarding.c
@@ -70,6 +70,20 @@ void onboarding_reset(void) {
 static GtkWidget *onboard_window = NULL;
 static GtkWidget *onboard_carousel = NULL;
 static GtkWidget *onboard_indicator = NULL;
+static OnboardingRoute onboard_current_route = ONBOARDING_SHOW_SHORTENED;
+
+static GtkWidget *onboard_gateway_explanation_label = NULL;
+static GtkWidget *onboard_gateway_stage_config_icon = NULL;
+static GtkWidget *onboard_gateway_stage_config_detail = NULL;
+static GtkWidget *onboard_gateway_stage_service_icon = NULL;
+static GtkWidget *onboard_gateway_stage_service_detail = NULL;
+static GtkWidget *onboard_gateway_stage_connection_icon = NULL;
+static GtkWidget *onboard_gateway_stage_connection_detail = NULL;
+static GtkWidget *onboard_gateway_next_action_box = NULL;
+static GtkWidget *onboard_gateway_next_action_value = NULL;
+
+static GtkWidget *onboard_whats_next_guidance_label = NULL;
+static GtkWidget *onboard_whats_next_dashboard_button = NULL;
 
 typedef struct {
     AppState state;
@@ -90,6 +104,11 @@ typedef struct {
 static gboolean onboard_has_render_snapshot = FALSE;
 static OnboardingRenderSnapshot onboard_last_snapshot = {0};
 
+static void onboarding_refresh_live_content(void);
+static GtkWidget* build_gateway_page(GtkWidget *carousel);
+static GtkWidget* build_environment_page(GtkWidget *carousel);
+static GtkWidget* build_whats_next_page(GtkWidget *carousel);
+
 static void snapshot_free(OnboardingRenderSnapshot *snap) {
     g_free(snap->next_action);
     snap->next_action = NULL;
@@ -101,6 +120,17 @@ static void on_onboard_destroy(GtkWindow *window, gpointer user_data) {
     onboard_window = NULL;
     onboard_carousel = NULL;
     onboard_indicator = NULL;
+    onboard_gateway_explanation_label = NULL;
+    onboard_gateway_stage_config_icon = NULL;
+    onboard_gateway_stage_config_detail = NULL;
+    onboard_gateway_stage_service_icon = NULL;
+    onboard_gateway_stage_service_detail = NULL;
+    onboard_gateway_stage_connection_icon = NULL;
+    onboard_gateway_stage_connection_detail = NULL;
+    onboard_gateway_next_action_box = NULL;
+    onboard_gateway_next_action_value = NULL;
+    onboard_whats_next_guidance_label = NULL;
+    onboard_whats_next_dashboard_button = NULL;
     onboard_has_render_snapshot = FALSE;
     snapshot_free(&onboard_last_snapshot);
 }
@@ -188,11 +218,16 @@ static const char* stage_detail_for_connection(OnboardingStageState state) {
     }
 }
 
-static GtkWidget* build_stage_row(const char *label, OnboardingStageState state, const char *detail) {
+static GtkWidget* build_stage_row(const char *label,
+                                  OnboardingStageState state,
+                                  const char *detail,
+                                  GtkWidget **out_icon,
+                                  GtkWidget **out_detail) {
     GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
     gtk_widget_set_margin_top(row, 2);
 
     GtkWidget *icon = gtk_label_new(stage_icon(state));
+    if (out_icon) *out_icon = icon;
     gtk_box_append(GTK_BOX(row), icon);
 
     GtkWidget *text_col = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
@@ -204,6 +239,7 @@ static GtkWidget* build_stage_row(const char *label, OnboardingStageState state,
     gtk_box_append(GTK_BOX(text_col), title);
 
     GtkWidget *detail_lbl = gtk_label_new(detail);
+    if (out_detail) *out_detail = detail_lbl;
     gtk_widget_add_css_class(detail_lbl, "dim-label");
     gtk_label_set_xalign(GTK_LABEL(detail_lbl), 0.0);
     gtk_label_set_wrap(GTK_LABEL(detail_lbl), TRUE);
@@ -260,6 +296,156 @@ static GtkWidget* build_welcome_page(GtkWidget *carousel) {
     return page;
 }
 
+static void onboarding_update_gateway_content(AppState current,
+                                              const ReadinessInfo *ri,
+                                              const OnboardingStageProgress *progress,
+                                              const ChatGateInfo *gate) {
+    if (onboard_gateway_explanation_label) {
+        if (current == STATE_NEEDS_SETUP) {
+            gtk_label_set_text(GTK_LABEL(onboard_gateway_explanation_label),
+                               "OpenClaw is not bootstrapped yet. The companion app needs a local gateway service to function.");
+        } else if (current == STATE_NEEDS_GATEWAY_INSTALL) {
+            gtk_label_set_text(GTK_LABEL(onboard_gateway_explanation_label),
+                               "A configuration exists, but the gateway service is not installed.");
+        } else if (current == STATE_NEEDS_ONBOARDING) {
+            gtk_label_set_text(GTK_LABEL(onboard_gateway_explanation_label),
+                               "Local bootstrap is incomplete. The onboarding wizard needs to finish configuring the gateway.");
+        } else if (!gate->ready) {
+            gtk_label_set_text(GTK_LABEL(onboard_gateway_explanation_label),
+                               "Gateway bootstrap is complete. Open Config -> Provider & Model Setup, configure a provider, reload models, and set a default model to unlock chat.");
+        } else {
+            gtk_label_set_text(GTK_LABEL(onboard_gateway_explanation_label),
+                               "The gateway service is installed and configured.");
+        }
+    }
+
+    if (onboard_gateway_stage_config_icon) {
+        gtk_label_set_text(GTK_LABEL(onboard_gateway_stage_config_icon),
+                           stage_icon(progress->configuration));
+    }
+    if (onboard_gateway_stage_config_detail) {
+        gtk_label_set_text(GTK_LABEL(onboard_gateway_stage_config_detail),
+                           stage_detail_for_config(progress->configuration));
+    }
+
+    if (onboard_gateway_stage_service_icon) {
+        gtk_label_set_text(GTK_LABEL(onboard_gateway_stage_service_icon),
+                           stage_icon(progress->service_gateway));
+    }
+    if (onboard_gateway_stage_service_detail) {
+        gtk_label_set_text(GTK_LABEL(onboard_gateway_stage_service_detail),
+                           stage_detail_for_service(progress->service_gateway));
+    }
+
+    if (onboard_gateway_stage_connection_icon) {
+        gtk_label_set_text(GTK_LABEL(onboard_gateway_stage_connection_icon),
+                           stage_icon(progress->connection));
+    }
+    if (onboard_gateway_stage_connection_detail) {
+        gtk_label_set_text(GTK_LABEL(onboard_gateway_stage_connection_detail),
+                           stage_detail_for_connection(progress->connection));
+    }
+
+    const gchar *next_action = gate->next_action ? gate->next_action : ri->next_action;
+    if (onboard_gateway_next_action_value) {
+        gtk_label_set_text(GTK_LABEL(onboard_gateway_next_action_value),
+                           next_action ? next_action : "");
+    }
+    if (onboard_gateway_next_action_box) {
+        gtk_widget_set_visible(onboard_gateway_next_action_box,
+                               next_action != NULL && next_action[0] != '\0');
+    }
+}
+
+static void onboarding_update_whats_next_content(const ReadinessInfo *ri,
+                                                 const ChatGateInfo *gate) {
+    if (onboard_whats_next_guidance_label) {
+        if (gate->ready) {
+            gtk_label_set_text(GTK_LABEL(onboard_whats_next_guidance_label),
+                               "Your gateway is running. Open the Dashboard to start interacting with your AI agent, or explore the companion app to monitor and manage your gateway.");
+        } else {
+            const gchar *guidance_text = gate->next_action ? gate->next_action : ri->next_action;
+            g_autofree gchar *guided = g_strdup_printf(
+                "%s Then open Config -> Provider & Model Setup to finish provider/model readiness in-app.",
+                guidance_text ? guidance_text : "");
+            gtk_label_set_text(GTK_LABEL(onboard_whats_next_guidance_label), guided);
+        }
+    }
+    if (onboard_whats_next_dashboard_button) {
+        gtk_widget_set_visible(onboard_whats_next_dashboard_button, gate->ready);
+    }
+}
+
+static void onboarding_refresh_live_content(void) {
+    AppState current = state_get_current();
+    ReadinessInfo ri;
+    readiness_evaluate(current, state_get_health(), state_get_systemd(), &ri);
+    const DesktopReadinessSnapshot *snapshot = state_get_readiness_snapshot();
+    ChatGateInfo gate = {0};
+    readiness_describe_chat_gate(snapshot, &gate);
+    OnboardingStageProgress progress;
+    readiness_build_onboarding_progress(current, state_get_health(), state_get_systemd(), &progress);
+
+    onboarding_update_gateway_content(current, &ri, &progress, &gate);
+    onboarding_update_whats_next_content(&ri, &gate);
+}
+
+static void onboarding_build_pages(OnboardingRoute route) {
+    GtkWidget *welcome = build_welcome_page(onboard_carousel);
+    adw_carousel_append(ADW_CAROUSEL(onboard_carousel), welcome);
+
+    if (route == ONBOARDING_SHOW_FULL) {
+        GtkWidget *gateway = build_gateway_page(onboard_carousel);
+        adw_carousel_append(ADW_CAROUSEL(onboard_carousel), gateway);
+
+        GtkWidget *env = build_environment_page(onboard_carousel);
+        adw_carousel_append(ADW_CAROUSEL(onboard_carousel), env);
+    }
+
+    GtkWidget *whats_next = build_whats_next_page(onboard_carousel);
+    adw_carousel_append(ADW_CAROUSEL(onboard_carousel), whats_next);
+
+    onboard_current_route = route;
+    onboarding_refresh_live_content();
+}
+
+static void onboarding_rebuild_pages(OnboardingRoute route) {
+    if (!onboard_carousel) return;
+
+    guint page_count = (guint)adw_carousel_get_n_pages(ADW_CAROUSEL(onboard_carousel));
+    guint current_pos = (guint)adw_carousel_get_position(ADW_CAROUSEL(onboard_carousel));
+
+    while (page_count > 0) {
+        GtkWidget *child = GTK_WIDGET(adw_carousel_get_nth_page(ADW_CAROUSEL(onboard_carousel), 0));
+        if (!child) break;
+        adw_carousel_remove(ADW_CAROUSEL(onboard_carousel), child);
+        page_count--;
+    }
+
+    onboard_gateway_explanation_label = NULL;
+    onboard_gateway_stage_config_icon = NULL;
+    onboard_gateway_stage_config_detail = NULL;
+    onboard_gateway_stage_service_icon = NULL;
+    onboard_gateway_stage_service_detail = NULL;
+    onboard_gateway_stage_connection_icon = NULL;
+    onboard_gateway_stage_connection_detail = NULL;
+    onboard_gateway_next_action_box = NULL;
+    onboard_gateway_next_action_value = NULL;
+    onboard_whats_next_guidance_label = NULL;
+    onboard_whats_next_dashboard_button = NULL;
+
+    onboarding_build_pages(route);
+
+    guint new_count = (guint)adw_carousel_get_n_pages(ADW_CAROUSEL(onboard_carousel));
+    if (new_count > 0) {
+        guint clamped = current_pos < new_count ? current_pos : (new_count - 1);
+        GtkWidget *target = GTK_WIDGET(adw_carousel_get_nth_page(ADW_CAROUSEL(onboard_carousel), clamped));
+        if (target) {
+            adw_carousel_scroll_to(ADW_CAROUSEL(onboard_carousel), target, FALSE);
+        }
+    }
+}
+
 static GtkWidget* build_gateway_page(GtkWidget *carousel) {
     GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
     gtk_widget_set_margin_start(page, 40);
@@ -276,6 +462,9 @@ static GtkWidget* build_gateway_page(GtkWidget *carousel) {
     AppState current = state_get_current();
     SystemdState *sys = state_get_systemd();
     HealthState *health = state_get_health();
+    const DesktopReadinessSnapshot *snapshot = state_get_readiness_snapshot();
+    ChatGateInfo gate = {0};
+    readiness_describe_chat_gate(snapshot, &gate);
 
     ReadinessInfo ri;
     readiness_evaluate(current, health, sys, &ri);
@@ -294,6 +483,9 @@ static GtkWidget* build_gateway_page(GtkWidget *carousel) {
     } else if (current == STATE_NEEDS_ONBOARDING) {
         gtk_label_set_text(GTK_LABEL(explanation),
             "Local bootstrap is incomplete. The onboarding wizard needs to finish configuring the gateway.");
+    } else if (!gate.ready) {
+        gtk_label_set_text(GTK_LABEL(explanation),
+            "Gateway bootstrap is complete. Open Config -> Provider & Model Setup, configure a provider, reload models, and set a default model to unlock chat.");
     } else {
         gtk_label_set_text(GTK_LABEL(explanation),
             "The gateway service is installed and configured.");
@@ -301,6 +493,7 @@ static GtkWidget* build_gateway_page(GtkWidget *carousel) {
     gtk_label_set_wrap(GTK_LABEL(explanation), TRUE);
     gtk_label_set_xalign(GTK_LABEL(explanation), 0.0);
     gtk_box_append(GTK_BOX(page), explanation);
+    onboard_gateway_explanation_label = explanation;
 
     GtkWidget *stage_heading = gtk_label_new("Setup progress");
     gtk_widget_add_css_class(stage_heading, "heading");
@@ -313,42 +506,48 @@ static GtkWidget* build_gateway_page(GtkWidget *carousel) {
     gtk_box_append(GTK_BOX(stages),
                    build_stage_row("Configuration",
                                    progress.configuration,
-                                   stage_detail_for_config(progress.configuration)));
+                                   stage_detail_for_config(progress.configuration),
+                                   &onboard_gateway_stage_config_icon,
+                                   &onboard_gateway_stage_config_detail));
     gtk_box_append(GTK_BOX(stages),
                    build_stage_row("Service / Gateway",
                                    progress.service_gateway,
-                                   stage_detail_for_service(progress.service_gateway)));
+                                   stage_detail_for_service(progress.service_gateway),
+                                   &onboard_gateway_stage_service_icon,
+                                   &onboard_gateway_stage_service_detail));
     gtk_box_append(GTK_BOX(stages),
                    build_stage_row("Connection",
                                    progress.connection,
-                                   stage_detail_for_connection(progress.connection)));
+                                   stage_detail_for_connection(progress.connection),
+                                   &onboard_gateway_stage_connection_icon,
+                                   &onboard_gateway_stage_connection_detail));
     gtk_box_append(GTK_BOX(page), stages);
 
-    if (ri.next_action) {
-        GtkWidget *action_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
-        gtk_widget_set_margin_top(action_box, 16);
-        gtk_widget_set_margin_bottom(action_box, 16);
-        
-        GtkWidget *action_label = gtk_label_new("Next step:");
-        gtk_widget_add_css_class(action_label, "dim-label");
-        gtk_label_set_xalign(GTK_LABEL(action_label), 0.0);
-        gtk_box_append(GTK_BOX(action_box), action_label);
+    const gchar *next_action = gate.next_action ? gate.next_action : ri.next_action;
+    GtkWidget *action_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
+    gtk_widget_set_margin_top(action_box, 16);
+    gtk_widget_set_margin_bottom(action_box, 16);
 
-        /* Present the exact command as a selectable monospace block */
-        GtkWidget *cmd_label = gtk_label_new(ri.next_action);
-        gtk_widget_add_css_class(cmd_label, "accent");
-        gtk_label_set_wrap(GTK_LABEL(cmd_label), TRUE);
-        gtk_label_set_selectable(GTK_LABEL(cmd_label), TRUE);
-        gtk_label_set_xalign(GTK_LABEL(cmd_label), 0.0);
-        
-        /* Apply a subtle background/border to make it look like a terminal snippet */
-        GtkWidget *frame = gtk_frame_new(NULL);
-        gtk_widget_set_margin_top(frame, 4);
-        gtk_frame_set_child(GTK_FRAME(frame), cmd_label);
-        gtk_box_append(GTK_BOX(action_box), frame);
+    GtkWidget *action_label = gtk_label_new("Next step:");
+    gtk_widget_add_css_class(action_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(action_label), 0.0);
+    gtk_box_append(GTK_BOX(action_box), action_label);
 
-        gtk_box_append(GTK_BOX(page), action_box);
-    }
+    GtkWidget *cmd_label = gtk_label_new(next_action ? next_action : "");
+    gtk_widget_add_css_class(cmd_label, "accent");
+    gtk_label_set_wrap(GTK_LABEL(cmd_label), TRUE);
+    gtk_label_set_selectable(GTK_LABEL(cmd_label), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(cmd_label), 0.0);
+
+    GtkWidget *frame = gtk_frame_new(NULL);
+    gtk_widget_set_margin_top(frame, 4);
+    gtk_frame_set_child(GTK_FRAME(frame), cmd_label);
+    gtk_box_append(GTK_BOX(action_box), frame);
+
+    gtk_widget_set_visible(action_box, next_action != NULL && next_action[0] != '\0');
+    gtk_box_append(GTK_BOX(page), action_box);
+    onboard_gateway_next_action_box = action_box;
+    onboard_gateway_next_action_value = cmd_label;
 
     GtkWidget *btn_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
     gtk_widget_set_halign(btn_row, GTK_ALIGN_CENTER);
@@ -415,6 +614,8 @@ static GtkWidget* build_environment_page(GtkWidget *carousel) {
         gtk_box_append(GTK_BOX(page), row);
     }
 
+    environment_check_result_clear(&ecr);
+
     g_free(config_path);
     g_free(state_dir);
     g_free(profile);
@@ -457,33 +658,33 @@ static GtkWidget* build_whats_next_page(GtkWidget *carousel) {
     AppState current = state_get_current();
     ReadinessInfo ri;
     readiness_evaluate(current, state_get_health(), state_get_systemd(), &ri);
+    const DesktopReadinessSnapshot *snapshot = state_get_readiness_snapshot();
+    ChatGateInfo gate = {0};
+    readiness_describe_chat_gate(snapshot, &gate);
 
-    if (current == STATE_RUNNING || current == STATE_RUNNING_WITH_WARNING) {
-        GtkWidget *msg = gtk_label_new(
-            "Your gateway is running. Open the Dashboard to start interacting "
-            "with your AI agent, or explore the companion app to monitor and "
-            "manage your gateway.");
-        gtk_label_set_wrap(GTK_LABEL(msg), TRUE);
-        gtk_label_set_xalign(GTK_LABEL(msg), 0.0);
-        gtk_box_append(GTK_BOX(page), msg);
+    const gchar *guidance_text = gate.next_action ? gate.next_action : ri.next_action;
+    g_autofree gchar *guided = gate.ready
+        ? g_strdup("Your gateway is running. Open the Dashboard to start interacting with your AI agent, or explore the companion app to monitor and manage your gateway.")
+        : g_strdup_printf("%s Then open Config -> Provider & Model Setup to finish provider/model readiness in-app.",
+                          guidance_text ? guidance_text : "");
+    GtkWidget *guidance = gtk_label_new(guided);
+    gtk_widget_add_css_class(guidance, "accent");
+    gtk_label_set_wrap(GTK_LABEL(guidance), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(guidance), 0.0);
+    gtk_box_append(GTK_BOX(page), guidance);
+    onboard_whats_next_guidance_label = guidance;
 
-        GtkWidget *btn_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
-        gtk_widget_set_halign(btn_row, GTK_ALIGN_CENTER);
-        gtk_widget_set_margin_top(btn_row, 12);
+    GtkWidget *dash_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_halign(dash_row, GTK_ALIGN_CENTER);
+    gtk_widget_set_margin_top(dash_row, 12);
 
-        GtkWidget *dash_btn = gtk_button_new_with_label("Open Dashboard");
-        gtk_widget_add_css_class(dash_btn, "suggested-action");
-        g_signal_connect(dash_btn, "clicked", G_CALLBACK(on_open_dashboard_clicked), NULL);
-        gtk_box_append(GTK_BOX(btn_row), dash_btn);
-
-        gtk_box_append(GTK_BOX(page), btn_row);
-    } else if (ri.next_action) {
-        GtkWidget *guidance = gtk_label_new(ri.next_action);
-        gtk_widget_add_css_class(guidance, "accent");
-        gtk_label_set_wrap(GTK_LABEL(guidance), TRUE);
-        gtk_label_set_xalign(GTK_LABEL(guidance), 0.0);
-        gtk_box_append(GTK_BOX(page), guidance);
-    }
+    GtkWidget *dash_btn = gtk_button_new_with_label("Open Dashboard");
+    gtk_widget_add_css_class(dash_btn, "suggested-action");
+    g_signal_connect(dash_btn, "clicked", G_CALLBACK(on_open_dashboard_clicked), NULL);
+    gtk_box_append(GTK_BOX(dash_row), dash_btn);
+    gtk_widget_set_visible(dash_row, gate.ready);
+    gtk_box_append(GTK_BOX(page), dash_row);
+    onboard_whats_next_dashboard_button = dash_row;
 
     /* Documentation links */
     GtkWidget *links_label = gtk_label_new("Documentation:");
@@ -541,23 +742,7 @@ void onboarding_show(void) {
 
     onboard_carousel = adw_carousel_new();
     adw_carousel_set_allow_long_swipes(ADW_CAROUSEL(onboard_carousel), TRUE);
-
-    /* Page 1: Welcome + Security (always shown) */
-    GtkWidget *welcome = build_welcome_page(onboard_carousel);
-    adw_carousel_append(ADW_CAROUSEL(onboard_carousel), welcome);
-
-    if (route == ONBOARDING_SHOW_FULL) {
-        /* Full flow: Gateway & Service + Environment Check */
-        GtkWidget *gateway = build_gateway_page(onboard_carousel);
-        adw_carousel_append(ADW_CAROUSEL(onboard_carousel), gateway);
-
-        GtkWidget *env = build_environment_page(onboard_carousel);
-        adw_carousel_append(ADW_CAROUSEL(onboard_carousel), env);
-    }
-
-    /* Final page: What's Next (always shown) */
-    GtkWidget *whats_next = build_whats_next_page(onboard_carousel);
-    adw_carousel_append(ADW_CAROUSEL(onboard_carousel), whats_next);
+    onboarding_build_pages(route);
 
     /* Carousel indicator dots */
     onboard_indicator = adw_carousel_indicator_dots_new();
@@ -591,6 +776,10 @@ void onboarding_check_and_show(void) {
     OC_LOG_INFO(OPENCLAW_LOG_CAT_STATE, "onboarding: showing %s flow",
                 route == ONBOARDING_SHOW_FULL ? "full" : "shortened");
     onboarding_show();
+}
+
+gboolean onboarding_is_visible(void) {
+    return onboard_window != NULL;
 }
 
 void onboarding_refresh(void) {
@@ -671,45 +860,14 @@ void onboarding_refresh(void) {
         return; /* No material change, skip rebuild */
     }
 
-    /* We need to rebuild the carousel pages with the current state.
-       We preserve the current page index if possible. */
-    double current_position = adw_carousel_get_position(ADW_CAROUSEL(onboard_carousel));
-
-    /* Remove all existing pages */
-    GtkWidget *child;
-    while ((child = gtk_widget_get_first_child(onboard_carousel)) != NULL) {
-        adw_carousel_remove(ADW_CAROUSEL(onboard_carousel), child);
-    }
-
-    /* Rebuild and append pages */
-    GtkWidget *welcome = build_welcome_page(onboard_carousel);
-    adw_carousel_append(ADW_CAROUSEL(onboard_carousel), welcome);
-
-    if (route == ONBOARDING_SHOW_FULL) {
-        GtkWidget *gateway = build_gateway_page(onboard_carousel);
-        adw_carousel_append(ADW_CAROUSEL(onboard_carousel), gateway);
-
-        GtkWidget *env = build_environment_page(onboard_carousel);
-        adw_carousel_append(ADW_CAROUSEL(onboard_carousel), env);
-    }
-
-    GtkWidget *whats_next = build_whats_next_page(onboard_carousel);
-    adw_carousel_append(ADW_CAROUSEL(onboard_carousel), whats_next);
-
-    /* Restore position if valid */
-    guint n_pages = adw_carousel_get_n_pages(ADW_CAROUSEL(onboard_carousel));
-    if (n_pages > 0) {
-        guint target_idx = (guint)(current_position + 0.5);
-        if (target_idx >= n_pages) {
-            target_idx = n_pages - 1;
-        }
-        GtkWidget *target_page = adw_carousel_get_nth_page(ADW_CAROUSEL(onboard_carousel), target_idx);
-        if (target_page) {
-            adw_carousel_scroll_to(ADW_CAROUSEL(onboard_carousel), target_page, FALSE);
-        }
+    if (new_snap.route != onboard_current_route) {
+        onboarding_rebuild_pages(new_snap.route);
+    } else {
+        onboarding_refresh_live_content();
     }
 
     snapshot_free(&onboard_last_snapshot);
     onboard_last_snapshot = new_snap;
     onboard_has_render_snapshot = TRUE;
+    return;
 }

--- a/apps/linux/src/onboarding.h
+++ b/apps/linux/src/onboarding.h
@@ -31,3 +31,4 @@ void onboarding_show(void);
 void onboarding_refresh(void);
 void onboarding_reset(void);
 int onboarding_get_seen_version(void);
+gboolean onboarding_is_visible(void);

--- a/apps/linux/src/readiness.c
+++ b/apps/linux/src/readiness.c
@@ -13,6 +13,111 @@
 #include "readiness.h"
 #include <stddef.h>
 
+const char* readiness_chat_block_reason_to_string(ChatBlockReason reason) {
+    switch (reason) {
+    case CHAT_BLOCK_NONE:
+        return "Ready";
+    case CHAT_BLOCK_NO_CONFIG:
+        return "No config detected";
+    case CHAT_BLOCK_CONFIG_INVALID:
+        return "Config invalid";
+    case CHAT_BLOCK_BOOTSTRAP_INCOMPLETE:
+        return "Bootstrap incomplete";
+    case CHAT_BLOCK_SERVICE_INACTIVE:
+        return "Service inactive";
+    case CHAT_BLOCK_GATEWAY_UNREACHABLE:
+        return "Gateway unreachable";
+    case CHAT_BLOCK_AUTH_INVALID:
+        return "Auth not usable";
+    case CHAT_BLOCK_PROVIDER_MISSING:
+        return "Provider missing";
+    case CHAT_BLOCK_DEFAULT_MODEL_MISSING:
+        return "Default model missing";
+    case CHAT_BLOCK_MODEL_CATALOG_EMPTY:
+        return "Model catalog unavailable";
+    case CHAT_BLOCK_SELECTED_MODEL_UNRESOLVED:
+        return "Selected model unresolved";
+    case CHAT_BLOCK_AGENTS_UNAVAILABLE:
+        return "Agents unavailable";
+    case CHAT_BLOCK_UNKNOWN:
+    default:
+        return "Unknown";
+    }
+}
+
+void readiness_describe_chat_gate(const DesktopReadinessSnapshot *snapshot,
+                                  ChatGateInfo *out) {
+    if (!out) return;
+
+    out->ready = FALSE;
+    out->reason = CHAT_BLOCK_UNKNOWN;
+    out->status = "Chat readiness unknown.";
+    out->next_action = "Refresh gateway status.";
+
+    if (!snapshot) {
+        return;
+    }
+
+    out->ready = snapshot->desktop_chat_ready;
+    out->reason = snapshot->chat_block_reason;
+
+    switch (snapshot->chat_block_reason) {
+    case CHAT_BLOCK_NONE:
+        out->status = "Chat is ready.";
+        out->next_action = NULL;
+        break;
+    case CHAT_BLOCK_NO_CONFIG:
+        out->status = "No OpenClaw config detected.";
+        out->next_action = "Run 'openclaw onboard --install-daemon' to bootstrap OpenClaw.";
+        break;
+    case CHAT_BLOCK_CONFIG_INVALID:
+        out->status = "Gateway configuration is invalid.";
+        out->next_action = "Open Config and fix validation errors in openclaw.json.";
+        break;
+    case CHAT_BLOCK_BOOTSTRAP_INCOMPLETE:
+        out->status = "Gateway bootstrapped, but onboarding is incomplete.";
+        out->next_action = "Complete onboarding setup, then configure provider/model.";
+        break;
+    case CHAT_BLOCK_SERVICE_INACTIVE:
+        out->status = "Gateway service is not active.";
+        out->next_action = "Start the service from Dashboard or run 'openclaw gateway run'.";
+        break;
+    case CHAT_BLOCK_GATEWAY_UNREACHABLE:
+        out->status = "Gateway connection is not fully established.";
+        out->next_action = "Wait for connection or restart the gateway service.";
+        break;
+    case CHAT_BLOCK_AUTH_INVALID:
+        out->status = "Gateway auth handshake is not complete.";
+        out->next_action = "Check gateway auth config and reconnect.";
+        break;
+    case CHAT_BLOCK_PROVIDER_MISSING:
+        out->status = "No provider configured yet.";
+        out->next_action = "Open Config and add a model provider.";
+        break;
+    case CHAT_BLOCK_DEFAULT_MODEL_MISSING:
+        out->status = "No default model selected yet.";
+        out->next_action = "Open Config and select a default model.";
+        break;
+    case CHAT_BLOCK_MODEL_CATALOG_EMPTY:
+        out->status = "Model catalog is unavailable.";
+        out->next_action = "Reload models after provider configuration.";
+        break;
+    case CHAT_BLOCK_SELECTED_MODEL_UNRESOLVED:
+        out->status = "Configured default model is not available in the current catalog.";
+        out->next_action = "Reload models and choose an available default model.";
+        break;
+    case CHAT_BLOCK_AGENTS_UNAVAILABLE:
+        out->status = "No agents available for chat.";
+        out->next_action = "Create or enable an agent in Agents.";
+        break;
+    case CHAT_BLOCK_UNKNOWN:
+    default:
+        out->status = "Chat prerequisites are not yet satisfied.";
+        out->next_action = "Refresh gateway status and review diagnostics.";
+        break;
+    }
+}
+
 void readiness_evaluate(AppState state, const HealthState *health,
                         const SystemdState *sys, ReadinessInfo *out) {
     if (!out) return;

--- a/apps/linux/src/readiness.h
+++ b/apps/linux/src/readiness.h
@@ -35,6 +35,13 @@ typedef struct {
     gboolean operational_ready;
 } OnboardingStageProgress;
 
+typedef struct {
+    gboolean ready;
+    ChatBlockReason reason;
+    const char *status;
+    const char *next_action;
+} ChatGateInfo;
+
 void readiness_evaluate(AppState state, const HealthState *health,
                         const SystemdState *sys, ReadinessInfo *out);
 
@@ -42,5 +49,9 @@ void readiness_build_onboarding_progress(AppState state,
                                          const HealthState *health,
                                          const SystemdState *sys,
                                          OnboardingStageProgress *out);
+
+const char* readiness_chat_block_reason_to_string(ChatBlockReason reason);
+void readiness_describe_chat_gate(const DesktopReadinessSnapshot *snapshot,
+                                  ChatGateInfo *out);
 
 #endif /* OPENCLAW_LINUX_READINESS_H */

--- a/apps/linux/src/section_agents.c
+++ b/apps/linux/src/section_agents.c
@@ -8,9 +8,12 @@
 
 #include <adwaita.h>
 
-#include "format_utils.h"
+#include "gateway_data.h"
 #include "gateway_rpc.h"
 #include "json_access.h"
+#include "log.h"
+#include "format_utils.h"
+#include "ui_model_utils.h"
 
 typedef struct {
     gchar *id;
@@ -74,6 +77,41 @@ static gint agents_selected_index = -1;
 static gchar *agents_selected_agent_id = NULL;
 static gboolean agents_fetch_in_flight = FALSE;
 static gint64 agents_last_fetch_us = 0;
+static guint agents_generation = 1;
+
+typedef struct {
+    guint generation;
+} AgentsRequestContext;
+
+static AgentsRequestContext* agents_request_context_new(void) {
+    AgentsRequestContext *ctx = g_new0(AgentsRequestContext, 1);
+    ctx->generation = agents_generation;
+    return ctx;
+}
+
+static gboolean agents_request_context_is_stale(const AgentsRequestContext *ctx) {
+    return !ctx || ctx->generation != agents_generation;
+}
+
+static void agents_request_context_free(gpointer data) {
+    g_free(data);
+}
+
+static void agents_attach_dropdown_model(GtkStringList *new_model, guint selected, gboolean sensitive) {
+    if (!new_model) return;
+    ui_dropdown_replace_model(agents_model_dropdown,
+                              (gpointer *)&agents_model_dropdown_model,
+                              G_LIST_MODEL(new_model),
+                              selected,
+                              sensitive);
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: model attach selected=%u sensitive=%d", selected, sensitive);
+}
+
+static void agents_set_model_dropdown_placeholder(const gchar *label, gboolean sensitive) {
+    GtkStringList *placeholder = gtk_string_list_new(NULL);
+    gtk_string_list_append(placeholder, label && label[0] != '\0' ? label : "Session default");
+    agents_attach_dropdown_model(placeholder, 0, sensitive);
+}
 
 static const gchar* agents_selected_agent_model(void) {
     if (!agents_cache || agents_selected_index < 0 || (guint)agents_selected_index >= agents_cache->len) {
@@ -103,12 +141,7 @@ static void agents_rebuild_model_dropdown(const gchar *preferred_model) {
             selected = i + 1;
         }
     }
-    if (agents_model_dropdown) {
-        gtk_drop_down_set_model(GTK_DROP_DOWN(agents_model_dropdown), G_LIST_MODEL(new_model));
-        gtk_drop_down_set_selected(GTK_DROP_DOWN(agents_model_dropdown), selected);
-    }
-    if (agents_model_dropdown_model) g_object_unref(agents_model_dropdown_model);
-    agents_model_dropdown_model = new_model;
+    agents_attach_dropdown_model(new_model, selected, TRUE);
 }
 
 static void agents_list_clear(void) {
@@ -146,7 +179,15 @@ static void agents_rebuild_files(const GPtrArray *files) {
 }
 
 static void on_agents_files_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    AgentsRequestContext *ctx = (AgentsRequestContext *)user_data;
+    if (agents_request_context_is_stale(ctx)) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: stale files callback dropped");
+        agents_request_context_free(ctx);
+        return;
+    }
+    agents_request_context_free(ctx);
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: files callback ok=%d", response ? response->ok : 0);
     g_autoptr(GPtrArray) files = g_ptr_array_new_with_free_func((GDestroyNotify)agent_file_row_free);
 
     if (response->ok && response->payload && JSON_NODE_HOLDS_OBJECT(response->payload)) {
@@ -210,10 +251,13 @@ static void agents_request_files_for_selected(void) {
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
+    AgentsRequestContext *ctx = agents_request_context_new();
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: request agents.files.list");
     g_autofree gchar *rid = gateway_rpc_request("agents.files.list", params, 0,
-                                                on_agents_files_response, NULL);
+                                                on_agents_files_response, ctx);
     json_node_unref(params);
     if (!rid) {
+        agents_request_context_free(ctx);
         agents_rebuild_files(NULL);
     }
 }
@@ -285,7 +329,14 @@ static void agents_rebuild_list(void) {
 }
 
 static void on_agents_update_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    AgentsRequestContext *ctx = (AgentsRequestContext *)user_data;
+    if (agents_request_context_is_stale(ctx)) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: stale update callback dropped");
+        agents_request_context_free(ctx);
+        return;
+    }
+    agents_request_context_free(ctx);
+
     if (!agents_status_label) return;
     if (response->ok) {
         gtk_label_set_text(GTK_LABEL(agents_status_label), "Agent updated");
@@ -338,16 +389,27 @@ static void on_agents_save_clicked(GtkButton *button, gpointer user_data) {
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
+    AgentsRequestContext *ctx = agents_request_context_new();
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: request agents.update");
     g_autofree gchar *rid = gateway_rpc_request("agents.update", params, 0,
-                                                on_agents_update_response, NULL);
+                                                on_agents_update_response, ctx);
     json_node_unref(params);
     if (!rid && agents_status_label) {
+        agents_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(agents_status_label), "Failed to send update");
     }
 }
 
 static void on_agents_list_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    AgentsRequestContext *ctx = (AgentsRequestContext *)user_data;
+    if (agents_request_context_is_stale(ctx)) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: stale agents.list callback dropped");
+        agents_request_context_free(ctx);
+        return;
+    }
+    agents_request_context_free(ctx);
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: agents.list callback ok=%d", response ? response->ok : 0);
     agents_fetch_in_flight = FALSE;
 
     if (!agents_status_label) return;
@@ -439,19 +501,27 @@ static void on_agents_list_response(const GatewayRpcResponse *response, gpointer
 }
 
 static void on_agents_models_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    AgentsRequestContext *ctx = (AgentsRequestContext *)user_data;
+    if (agents_request_context_is_stale(ctx)) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: stale models.list callback dropped");
+        agents_request_context_free(ctx);
+        return;
+    }
+    agents_request_context_free(ctx);
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: models.list callback ok=%d", response ? response->ok : 0);
     if (agent_models_cache) g_ptr_array_unref(agent_models_cache);
     agent_models_cache = g_ptr_array_new_with_free_func((GDestroyNotify)agent_model_choice_free);
 
     if (!response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
-        agents_rebuild_model_dropdown(NULL);
+        agents_set_model_dropdown_placeholder("Models unavailable", FALSE);
         return;
     }
 
     JsonObject *obj = json_node_get_object(response->payload);
     JsonNode *mn = json_object_get_member(obj, "models");
     if (!mn || !JSON_NODE_HOLDS_ARRAY(mn)) {
-        agents_rebuild_model_dropdown(NULL);
+        agents_set_model_dropdown_placeholder("No models available", FALSE);
         return;
     }
 
@@ -475,10 +545,16 @@ static void on_agents_models_response(const GatewayRpcResponse *response, gpoint
         if (m->id) g_ptr_array_add(agent_models_cache, m); else agent_model_choice_free(m);
     }
 
-    agents_rebuild_model_dropdown(agents_selected_agent_model());
+    if (!agent_models_cache || agent_models_cache->len == 0) {
+        agents_set_model_dropdown_placeholder("No models available", FALSE);
+    } else {
+        agents_rebuild_model_dropdown(agents_selected_agent_model());
+    }
 }
 
 static GtkWidget* agents_build(void) {
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: build");
+
     GtkWidget *scrolled = gtk_scrolled_window_new();
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
                                    GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
@@ -536,8 +612,9 @@ static GtkWidget* agents_build(void) {
     gtk_entry_set_placeholder_text(GTK_ENTRY(agents_avatar_entry), "Avatar URL or path");
     gtk_box_append(GTK_BOX(right), agents_avatar_entry);
 
-    agents_model_dropdown_model = gtk_string_list_new(NULL);
-    agents_model_dropdown = gtk_drop_down_new(G_LIST_MODEL(agents_model_dropdown_model), NULL);
+    agents_model_dropdown_model = NULL;
+    agents_model_dropdown = gtk_drop_down_new(NULL, NULL);
+    agents_set_model_dropdown_placeholder("Loading models…", FALSE);
     gtk_box_append(GTK_BOX(right), agents_model_dropdown);
 
     GtkWidget *save_btn = gtk_button_new_with_label("Save Agent");
@@ -563,6 +640,7 @@ static GtkWidget* agents_build(void) {
 }
 
 static void agents_refresh(void) {
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: refresh stale=%d inflight=%d", section_is_stale(&agents_last_fetch_us), agents_fetch_in_flight);
     if (!agents_status_label || agents_fetch_in_flight) return;
     if (!gateway_rpc_is_ready()) {
         gtk_label_set_text(GTK_LABEL(agents_status_label), "Gateway not connected");
@@ -571,21 +649,32 @@ static void agents_refresh(void) {
     if (!section_is_stale(&agents_last_fetch_us)) return;
 
     agents_fetch_in_flight = TRUE;
+    AgentsRequestContext *list_ctx = agents_request_context_new();
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: request agents.list");
     g_autofree gchar *rid = gateway_rpc_request("agents.list", NULL, 0,
-                                                on_agents_list_response, NULL);
+                                                on_agents_list_response, list_ctx);
+    AgentsRequestContext *models_ctx = agents_request_context_new();
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: request models.list");
     g_autofree gchar *mrid = gateway_rpc_request("models.list", NULL, 0,
-                                                 on_agents_models_response, NULL);
+                                                 on_agents_models_response, models_ctx);
     if (!rid) {
+        agents_request_context_free(list_ctx);
         agents_fetch_in_flight = FALSE;
         gtk_label_set_text(GTK_LABEL(agents_status_label), "Failed to request agents");
+    }
+    if (!mrid) {
+        agents_request_context_free(models_ctx);
+        agents_set_model_dropdown_placeholder("Models unavailable", FALSE);
     }
     (void)mrid;
 }
 
 static void agents_destroy(void) {
-    if (agents_model_dropdown) {
-        gtk_drop_down_set_model(GTK_DROP_DOWN(agents_model_dropdown), NULL);
-    }
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: destroy begin");
+    agents_generation++;
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: model detach");
+    ui_dropdown_detach_model(agents_model_dropdown, (gpointer *)&agents_model_dropdown_model);
 
     agents_status_label = NULL;
     agents_list_box = NULL;
@@ -594,7 +683,6 @@ static void agents_destroy(void) {
     agents_workspace_entry = NULL;
     agents_avatar_entry = NULL;
     agents_model_dropdown = NULL;
-    if (agents_model_dropdown_model) g_object_unref(agents_model_dropdown_model);
     agents_model_dropdown_model = NULL;
     agents_selected_label = NULL;
 
@@ -607,6 +695,7 @@ static void agents_destroy(void) {
     agents_selected_agent_id = NULL;
     agents_fetch_in_flight = FALSE;
     agents_last_fetch_us = 0;
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: destroy end");
 }
 
 static void agents_invalidate(void) {

--- a/apps/linux/src/section_channels.c
+++ b/apps/linux/src/section_channels.c
@@ -18,6 +18,7 @@
 #include "json_access.h"
 #include "section_controller.h"
 #include "test_seams.h"
+#include "ui_model_utils.h"
 #include <adwaita.h>
 
 /* ── State ───────────────────────────────────────────────────────── */
@@ -25,10 +26,53 @@
 static GtkWidget *channels_list_box = NULL;
 static GtkWidget *channels_status_label = NULL;
 static GtkWidget *channels_filter_dropdown = NULL;
+static GtkStringList *channels_filter_model = NULL;
 static GatewayChannelsData *channels_data_cache = NULL;
 static gboolean channels_fetch_in_flight = FALSE;
 static gint64 channels_last_fetch_us = 0;
 static gint current_filter = 0; /* 0: All, 1: Configured, 2: Available */
+static guint channels_generation = 1;
+
+typedef struct {
+    guint generation;
+    gchar *channel_id;
+} ChannelsIdContext;
+
+typedef struct {
+    guint generation;
+} ChannelsRequestContext;
+
+static ChannelsRequestContext* channels_request_context_new(void) {
+    ChannelsRequestContext *ctx = g_new0(ChannelsRequestContext, 1);
+    ctx->generation = channels_generation;
+    return ctx;
+}
+
+static gboolean channels_request_context_is_stale(const ChannelsRequestContext *ctx) {
+    return !ctx || ctx->generation != channels_generation;
+}
+
+static void channels_request_context_free(gpointer data) {
+    g_free(data);
+}
+
+static ChannelsIdContext* channels_id_context_new(const gchar *channel_id) {
+    ChannelsIdContext *ctx = g_new0(ChannelsIdContext, 1);
+    ctx->generation = channels_generation;
+    ctx->channel_id = g_strdup(channel_id);
+    return ctx;
+}
+
+static gboolean channels_id_context_is_stale(const ChannelsIdContext *ctx) {
+    return !ctx || ctx->generation != channels_generation;
+}
+
+static void channels_id_context_free(gpointer data) {
+    ChannelsIdContext *ctx = (ChannelsIdContext *)data;
+    if (!ctx) return;
+    g_free(ctx->channel_id);
+    g_free(ctx);
+}
 
 /* Forward declarations */
 static void channels_rebuild_list(void);
@@ -37,12 +81,18 @@ static void channels_force_refresh(void);
 /* ── Mutation callbacks ──────────────────────────────────────────── */
 
 static void on_mutation_done(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    ChannelsRequestContext *ctx = (ChannelsRequestContext *)user_data;
+    if (channels_request_context_is_stale(ctx)) {
+        channels_request_context_free(ctx);
+        return;
+    }
+    channels_request_context_free(ctx);
+
     if (!channels_status_label) return;
 
-    if (!response->ok) {
+    if (!response || !response->ok) {
         g_autofree gchar *msg = g_strdup_printf("Error: %s",
-            response->error_msg ? response->error_msg : "unknown");
+            response && response->error_msg ? response->error_msg : "unknown");
         gtk_label_set_text(GTK_LABEL(channels_status_label), msg);
     }
 
@@ -59,8 +109,10 @@ static void on_refresh_all_channels(GtkButton *btn, gpointer user_data) {
         gtk_label_set_text(GTK_LABEL(channels_status_label), "Refreshing all channels…");
     }
 
-    g_autofree gchar *req = mutation_channels_status(TRUE, on_mutation_done, NULL);
+    ChannelsRequestContext *ctx = channels_request_context_new();
+    g_autofree gchar *req = mutation_channels_status(TRUE, on_mutation_done, ctx);
     if (!req) {
+        channels_request_context_free(ctx);
         gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
         if (channels_status_label)
             gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to send refresh request");
@@ -75,6 +127,7 @@ typedef struct {
     JsonObject *full_config_obj;  /* Owned reference to full config object */
     gchar *base_hash;           /* Config hash for OCC */
     gchar *channel_id;          /* Channel being edited */
+    guint generation;
 } ConfigEditorSession;
 
 static void config_editor_session_free(ConfigEditorSession *session) {
@@ -92,11 +145,21 @@ static ConfigEditorSession* config_editor_session_new(JsonObject *full_config,
     session->full_config_obj = full_config ? json_object_ref(full_config) : NULL;
     session->base_hash = g_strdup(hash);
     session->channel_id = g_strdup(channel_id);
+    session->generation = channels_generation;
     return session;
+}
+
+static gboolean config_editor_session_is_stale(const ConfigEditorSession *session) {
+    return !session || session->generation != channels_generation;
 }
 
 static void on_config_save_done(const GatewayRpcResponse *response, gpointer user_data) {
     ConfigEditorSession *session = (ConfigEditorSession *)user_data;
+    if (config_editor_session_is_stale(session)) {
+        config_editor_session_free(session);
+        return;
+    }
+
     if (!response->ok && channels_status_label) {
         g_autofree gchar *msg = g_strdup_printf("Config Save Error: %s",
             response->error_msg ? response->error_msg : "unknown");
@@ -112,6 +175,11 @@ static void on_config_save_done(const GatewayRpcResponse *response, gpointer use
 static void on_config_dialog_response(GObject *source, GAsyncResult *result, gpointer user_data) {
     AdwAlertDialog *dialog = ADW_ALERT_DIALOG(source);
     ConfigEditorSession *session = (ConfigEditorSession *)user_data;
+
+    if (config_editor_session_is_stale(session)) {
+        config_editor_session_free(session);
+        return;
+    }
 
     const gchar *response_id = adw_alert_dialog_choose_finish(dialog, result);
     if (g_strcmp0(response_id, "save") != 0) {
@@ -245,7 +313,13 @@ static void on_config_dialog_response(GObject *source, GAsyncResult *result, gpo
 }
 
 static void on_config_get_done(const GatewayRpcResponse *response, gpointer user_data) {
-    gchar *channel_id = (gchar *)user_data;
+    ChannelsIdContext *ctx = (ChannelsIdContext *)user_data;
+    if (channels_id_context_is_stale(ctx)) {
+        channels_id_context_free(ctx);
+        return;
+    }
+    gchar *channel_id = g_strdup(ctx->channel_id);
+    channels_id_context_free(ctx);
     
     /* STRICT GUARDS: Check response state before any payload access */
     if (!response || !response->ok) {
@@ -254,7 +328,7 @@ static void on_config_get_done(const GatewayRpcResponse *response, gpointer user
                 response && response->error_msg ? response->error_msg : "unknown");
             gtk_label_set_text(GTK_LABEL(channels_status_label), msg);
         }
-        g_free(channel_id);
+        g_clear_pointer(&channel_id, g_free);
         return;
     }
     
@@ -354,7 +428,7 @@ static void on_config_get_done(const GatewayRpcResponse *response, gpointer user
     GtkWidget *toplevel = GTK_WIDGET(gtk_application_get_active_window(app));
     
     adw_alert_dialog_choose(dialog, toplevel, NULL, on_config_dialog_response, session);
-    g_free(channel_id);
+    g_clear_pointer(&channel_id, g_free);
 }
 
 static void on_edit_config(GtkButton *btn, gpointer user_data) {
@@ -369,8 +443,10 @@ static void on_edit_config(GtkButton *btn, gpointer user_data) {
      * Always returns full config document {hash, config: {...}}
      * We pass NULL for scope to comply with the empty params contract.
      */
-    g_autofree gchar *req = mutation_config_get(NULL, on_config_get_done, g_strdup(channel_id));
+    ChannelsIdContext *ctx = channels_id_context_new(channel_id);
+    g_autofree gchar *req = mutation_config_get(NULL, on_config_get_done, ctx);
     if (!req && channels_status_label) {
+        channels_id_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to request config");
     }
 }
@@ -378,7 +454,12 @@ static void on_edit_config(GtkButton *btn, gpointer user_data) {
 /* ── Web Login / QR Flow ─────────────────────────────────────────── */
 
 static void on_web_login_wait_done(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    ChannelsRequestContext *ctx = (ChannelsRequestContext *)user_data;
+    if (channels_request_context_is_stale(ctx)) {
+        channels_request_context_free(ctx);
+        return;
+    }
+    channels_request_context_free(ctx);
     
     /* STRICT GUARDS: Check response state before any payload access */
     if (!response || !response->ok) {
@@ -440,7 +521,13 @@ static void on_web_login_wait_done(const GatewayRpcResponse *response, gpointer 
 }
 
 static void on_web_login_start_done(const GatewayRpcResponse *response, gpointer user_data) {
-    gchar *channel_id = (gchar *)user_data;
+    ChannelsIdContext *ctx = (ChannelsIdContext *)user_data;
+    if (channels_id_context_is_stale(ctx)) {
+        channels_id_context_free(ctx);
+        return;
+    }
+    gchar *channel_id = g_strdup(ctx->channel_id);
+    channels_id_context_free(ctx);
     
     /* STRICT GUARDS: Check response state before any payload access */
     if (!response || !response->ok) {
@@ -514,12 +601,14 @@ static void on_web_login_start_done(const GatewayRpcResponse *response, gpointer
 
     /* Begin waiting for the actual login resolution */
     /* 120s timeout, null account_id since we are linking a primary account */
-    g_autofree gchar *req = mutation_web_login_wait(120000, NULL, on_web_login_wait_done, NULL);
+    ChannelsRequestContext *wait_ctx = channels_request_context_new();
+    g_autofree gchar *req = mutation_web_login_wait(120000, NULL, on_web_login_wait_done, wait_ctx);
     if (!req && channels_status_label) {
+        channels_request_context_free(wait_ctx);
         gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to send wait request");
     }
     
-    g_free(channel_id);
+    g_clear_pointer(&channel_id, g_free);
 }
 
 static void on_start_web_login(GtkButton *btn, gpointer user_data) {
@@ -530,8 +619,10 @@ static void on_start_web_login(GtkButton *btn, gpointer user_data) {
     if (channels_status_label)
         gtk_label_set_text(GTK_LABEL(channels_status_label), "Starting login flow\u2026");
 
-    g_autofree gchar *req = mutation_web_login_start(on_web_login_start_done, g_strdup(channel_id));
+    ChannelsIdContext *ctx = channels_id_context_new(channel_id);
+    g_autofree gchar *req = mutation_web_login_start(on_web_login_start_done, ctx);
     if (!req && channels_status_label) {
+        channels_id_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to start login");
     }
 }
@@ -551,8 +642,10 @@ static void on_logout_dialog_response(GObject *source, GAsyncResult *result, gpo
     if (channels_status_label)
         gtk_label_set_text(GTK_LABEL(channels_status_label), "Logging out\u2026");
 
-    g_autofree gchar *req = mutation_channels_logout(channel_id, account_id, on_mutation_done, NULL);
+    ChannelsRequestContext *ctx = channels_request_context_new();
+    g_autofree gchar *req = mutation_channels_logout(channel_id, account_id, on_mutation_done, ctx);
     if (!req && channels_status_label) {
+        channels_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to send request");
     }
 }
@@ -764,15 +857,21 @@ static void channels_rebuild_list(void) {
 /* ── RPC callback ────────────────────────────────────────────────── */
 
 static void on_channels_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    ChannelsRequestContext *ctx = (ChannelsRequestContext *)user_data;
+    if (channels_request_context_is_stale(ctx)) {
+        channels_request_context_free(ctx);
+        return;
+    }
+    channels_request_context_free(ctx);
+
     channels_fetch_in_flight = FALSE;
 
     if (!channels_list_box) return;
 
-    if (!response->ok) {
+    if (!response || !response->ok) {
         if (channels_status_label) {
             g_autofree gchar *msg = g_strdup_printf("Error: %s",
-                response->error_msg ? response->error_msg : "unknown");
+                response && response->error_msg ? response->error_msg : "unknown");
             gtk_label_set_text(GTK_LABEL(channels_status_label), msg);
         }
         return;
@@ -811,9 +910,11 @@ static void channels_force_refresh(void) {
     if (!gateway_rpc_is_ready()) return;
 
     channels_fetch_in_flight = TRUE;
+    ChannelsRequestContext *ctx = channels_request_context_new();
     g_autofree gchar *req_id = gateway_rpc_request(
-        "channels.status", NULL, 0, on_channels_rpc_response, NULL);
+        "channels.status", NULL, 0, on_channels_rpc_response, ctx);
     if (!req_id) {
+        channels_request_context_free(ctx);
         channels_fetch_in_flight = FALSE;
     }
 }
@@ -840,12 +941,14 @@ static GtkWidget* channels_build(void) {
     gtk_widget_set_hexpand(title, TRUE);
     gtk_box_append(GTK_BOX(hdr), title);
 
-    GtkStringList *filter_model = gtk_string_list_new((const char * const[]){
+    GtkStringList *new_filter_model = gtk_string_list_new((const char * const[]){
         "All", "Configured", "Available", NULL
     });
     channels_filter_dropdown = adw_combo_row_new();
-    adw_combo_row_set_model(ADW_COMBO_ROW(channels_filter_dropdown), G_LIST_MODEL(filter_model));
-    adw_combo_row_set_selected(ADW_COMBO_ROW(channels_filter_dropdown), current_filter);
+    ui_combo_row_replace_model(channels_filter_dropdown,
+                               (gpointer *)&channels_filter_model,
+                               G_LIST_MODEL(new_filter_model),
+                               current_filter);
     g_signal_connect(channels_filter_dropdown, "notify::selected", G_CALLBACK(on_filter_changed), NULL);
     gtk_widget_set_valign(channels_filter_dropdown, GTK_ALIGN_CENTER);
     gtk_box_append(GTK_BOX(hdr), channels_filter_dropdown);
@@ -884,9 +987,11 @@ static void channels_refresh(void) {
     }
 
     channels_fetch_in_flight = TRUE;
+    ChannelsRequestContext *ctx = channels_request_context_new();
     g_autofree gchar *req_id = gateway_rpc_request(
-        "channels.status", NULL, 0, on_channels_rpc_response, NULL);
+        "channels.status", NULL, 0, on_channels_rpc_response, ctx);
     if (!req_id) {
+        channels_request_context_free(ctx);
         channels_fetch_in_flight = FALSE;
         if (channels_status_label)
             gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to send request");
@@ -894,9 +999,13 @@ static void channels_refresh(void) {
 }
 
 static void channels_destroy(void) {
+    channels_generation++;
+
     channels_list_box = NULL;
     channels_status_label = NULL;
+    ui_combo_row_detach_model(channels_filter_dropdown, (gpointer *)&channels_filter_model);
     channels_filter_dropdown = NULL;
+    channels_filter_model = NULL;
     channels_fetch_in_flight = FALSE;
     gateway_channels_data_free(channels_data_cache);
     channels_data_cache = NULL;

--- a/apps/linux/src/section_chat.c
+++ b/apps/linux/src/section_chat.c
@@ -14,7 +14,10 @@
 #include "gateway_ws.h"
 #include "json_access.h"
 #include "markdown_render.h"
+#include "readiness.h"
 #include "session_filter.h"
+#include "state.h"
+#include "ui_model_utils.h"
 
 typedef struct {
     gchar *id;
@@ -72,6 +75,26 @@ static guint chat_event_listener_id = 0;
 static gboolean chat_guard_agent_change = FALSE;
 static gboolean chat_guard_model_change = FALSE;
 static gboolean chat_guard_session_change = FALSE;
+static guint chat_generation = 1;
+static ChatGateInfo chat_gate_info = {0};
+
+typedef struct {
+    guint generation;
+} ChatRequestContext;
+
+static ChatRequestContext* chat_request_context_new(void) {
+    ChatRequestContext *ctx = g_new0(ChatRequestContext, 1);
+    ctx->generation = chat_generation;
+    return ctx;
+}
+
+static gboolean chat_request_context_is_stale(const ChatRequestContext *ctx) {
+    return !ctx || ctx->generation != chat_generation;
+}
+
+static void chat_request_context_free(gpointer data) {
+    g_free(data);
+}
 
 static void chat_agent_choice_free(ChatAgentChoice *a) {
     if (!a) return;
@@ -89,7 +112,110 @@ static void chat_queued_assistant_free(ChatQueuedAssistant *m) {
 }
 
 static void chat_rebuild_model_dropdown(void);
+static void chat_set_model_dropdown_error_placeholder(const gchar *label);
+static void chat_clear_pending_state(void);
+static void chat_rebuild_messages_ui(void);
 static gboolean chat_pending_is_for_selected_session(void);
+
+static void chat_attach_agent_dropdown_model(GtkStringList *new_model,
+                                             guint selected,
+                                             gboolean enabled) {
+    if (!new_model) return;
+    if (chat_agent_dropdown && GTK_IS_DROP_DOWN(chat_agent_dropdown)) {
+        chat_guard_agent_change = TRUE;
+        ui_dropdown_replace_model(chat_agent_dropdown,
+                                  (gpointer *)&chat_agent_model,
+                                  G_LIST_MODEL(new_model),
+                                  selected,
+                                  enabled);
+        chat_guard_agent_change = FALSE;
+    } else {
+        ui_dropdown_replace_model(NULL,
+                                  (gpointer *)&chat_agent_model,
+                                  G_LIST_MODEL(new_model),
+                                  selected,
+                                  enabled);
+    }
+}
+
+static void chat_attach_model_dropdown_model(GtkStringList *new_model,
+                                             guint selected,
+                                             gboolean enabled) {
+    if (!new_model) return;
+    if (chat_model_dropdown && GTK_IS_DROP_DOWN(chat_model_dropdown)) {
+        chat_guard_model_change = TRUE;
+        ui_dropdown_replace_model(chat_model_dropdown,
+                                  (gpointer *)&chat_model_model,
+                                  G_LIST_MODEL(new_model),
+                                  selected,
+                                  enabled);
+        chat_guard_model_change = FALSE;
+    } else {
+        ui_dropdown_replace_model(NULL,
+                                  (gpointer *)&chat_model_model,
+                                  G_LIST_MODEL(new_model),
+                                  selected,
+                                  enabled);
+    }
+}
+
+static void chat_attach_session_dropdown_model(GtkStringList *new_model,
+                                               guint selected,
+                                               gboolean enabled) {
+    if (!new_model) return;
+    if (chat_session_dropdown && GTK_IS_DROP_DOWN(chat_session_dropdown)) {
+        chat_guard_session_change = TRUE;
+        ui_dropdown_replace_model(chat_session_dropdown,
+                                  (gpointer *)&chat_session_model,
+                                  G_LIST_MODEL(new_model),
+                                  selected,
+                                  enabled);
+        chat_guard_session_change = FALSE;
+    } else {
+        ui_dropdown_replace_model(NULL,
+                                  (gpointer *)&chat_session_model,
+                                  G_LIST_MODEL(new_model),
+                                  selected,
+                                  enabled);
+    }
+}
+
+static void chat_set_agent_dropdown_placeholder(const gchar *label, gboolean enabled) {
+    GtkStringList *new_model = gtk_string_list_new(NULL);
+    gtk_string_list_append(new_model, label && label[0] != '\0' ? label : "No agents available");
+    chat_attach_agent_dropdown_model(new_model, 0, enabled);
+}
+
+static void chat_set_session_dropdown_placeholder(const gchar *label, gboolean enabled) {
+    GtkStringList *new_model = gtk_string_list_new(NULL);
+    gtk_string_list_append(new_model, label && label[0] != '\0' ? label : "No sessions yet");
+    chat_attach_session_dropdown_model(new_model, 0, enabled);
+}
+
+static void chat_render_blocked_state(const ChatGateInfo *gate) {
+    const gchar *status = (gate && gate->status) ? gate->status : "Chat unavailable.";
+    const gchar *next_action = (gate && gate->next_action) ? gate->next_action : "Check gateway status.";
+
+    if (chat_status_label) {
+        g_autofree gchar *line = g_strdup_printf("%s Next: %s", status, next_action);
+        gtk_label_set_text(GTK_LABEL(chat_status_label), line);
+    }
+
+    chat_set_agent_dropdown_placeholder("Chat blocked", FALSE);
+    if (gate && gate->reason == CHAT_BLOCK_PROVIDER_MISSING) {
+        chat_set_model_dropdown_error_placeholder("No provider configured");
+    } else if (gate && gate->reason == CHAT_BLOCK_DEFAULT_MODEL_MISSING) {
+        chat_set_model_dropdown_error_placeholder("No model selected");
+    } else if (gate && gate->reason == CHAT_BLOCK_SELECTED_MODEL_UNRESOLVED) {
+        chat_set_model_dropdown_error_placeholder("Selected model unavailable");
+    } else {
+        chat_set_model_dropdown_error_placeholder("Model list unavailable");
+    }
+    chat_set_session_dropdown_placeholder("No sessions yet", FALSE);
+
+    chat_clear_pending_state();
+    chat_rebuild_messages_ui();
+}
 
 static void chat_model_choice_free(ChatModelChoice *m) {
     if (!m) return;
@@ -184,7 +310,7 @@ static void chat_render_message_object(JsonObject *msg_obj, gboolean is_pending)
 
 static void chat_set_send_enabled(void) {
     if (!chat_send_btn || !chat_compose_view) return;
-    gboolean connected = gateway_rpc_is_ready();
+    gboolean connected = chat_gate_info.ready;
     gboolean has_session = (chat_selected_session_key && chat_selected_session_key[0] != '\0');
     GtkTextBuffer *buf = gtk_text_view_get_buffer(GTK_TEXT_VIEW(chat_compose_view));
     GtkTextIter start, end;
@@ -197,8 +323,11 @@ static void chat_set_send_enabled(void) {
 static void chat_rebuild_messages_ui(void) {
     chat_clear_messages_ui();
 
-    if (!gateway_rpc_is_ready()) {
-        chat_append_line("<i>Gateway disconnected. Reconnect to send and stream messages.</i>", "dim-label");
+    if (!chat_gate_info.ready) {
+        const gchar *status = chat_gate_info.status ? chat_gate_info.status : "Chat is not ready.";
+        const gchar *next = chat_gate_info.next_action ? chat_gate_info.next_action : "Check gateway status.";
+        g_autofree gchar *line = g_strdup_printf("<i>%s %s</i>", status, next);
+        chat_append_line(line, "dim-label");
         return;
     }
 
@@ -373,14 +502,7 @@ static void chat_rebuild_agent_dropdown(void) {
             selected_index = i;
         }
     }
-    if (chat_agent_dropdown) {
-        chat_guard_agent_change = TRUE;
-        gtk_drop_down_set_model(GTK_DROP_DOWN(chat_agent_dropdown), G_LIST_MODEL(new_model));
-        gtk_drop_down_set_selected(GTK_DROP_DOWN(chat_agent_dropdown), selected_index);
-        chat_guard_agent_change = FALSE;
-    }
-    if (chat_agent_model) g_object_unref(chat_agent_model);
-    chat_agent_model = new_model;
+    chat_attach_agent_dropdown_model(new_model, selected_index, TRUE);
 }
 
 static void chat_rebuild_model_dropdown(void) {
@@ -394,14 +516,14 @@ static void chat_rebuild_model_dropdown(void) {
             selected_index = i + 1;
         }
     }
-    if (chat_model_dropdown) {
-        chat_guard_model_change = TRUE;
-        gtk_drop_down_set_model(GTK_DROP_DOWN(chat_model_dropdown), G_LIST_MODEL(new_model));
-        gtk_drop_down_set_selected(GTK_DROP_DOWN(chat_model_dropdown), selected_index);
-        chat_guard_model_change = FALSE;
-    }
-    if (chat_model_model) g_object_unref(chat_model_model);
-    chat_model_model = new_model;
+    chat_attach_model_dropdown_model(new_model, selected_index, TRUE);
+}
+
+static void chat_set_model_dropdown_error_placeholder(const gchar *label) {
+    GtkStringList *new_model = gtk_string_list_new(NULL);
+    gtk_string_list_append(new_model, label && label[0] != '\0' ? label : "Model list unavailable");
+
+    chat_attach_model_dropdown_model(new_model, 0, FALSE);
 }
 
 static void chat_rebuild_session_dropdown(void) {
@@ -412,23 +534,26 @@ static void chat_rebuild_session_dropdown(void) {
         gtk_string_list_append(new_model, choice->label);
         if (chat_selected_session_key && g_strcmp0(chat_selected_session_key, choice->key) == 0) selected_index = i;
     }
-    if (chat_session_dropdown) {
-        chat_guard_session_change = TRUE;
-        gtk_drop_down_set_model(GTK_DROP_DOWN(chat_session_dropdown), G_LIST_MODEL(new_model));
-        gtk_drop_down_set_selected(GTK_DROP_DOWN(chat_session_dropdown), selected_index);
-        chat_guard_session_change = FALSE;
-    }
-    if (chat_session_model) g_object_unref(chat_session_model);
-    chat_session_model = new_model;
+    chat_attach_session_dropdown_model(new_model, selected_index, TRUE);
 }
 
 static void on_chat_history_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    ChatRequestContext *ctx = (ChatRequestContext *)user_data;
+    if (chat_request_context_is_stale(ctx)) {
+        chat_request_context_free(ctx);
+        return;
+    }
+    chat_request_context_free(ctx);
+
+    if (!chat_status_label) {
+        return;
+    }
+
     chat_history_in_flight = FALSE;
 
     if (chat_history_messages) g_ptr_array_set_size(chat_history_messages, 0);
 
-    if (!response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
+    if (!response || !response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Failed to load chat.history");
         chat_rebuild_messages_ui();
         return;
@@ -474,9 +599,11 @@ static void chat_request_history_for_selected(void) {
     g_object_unref(b);
 
     chat_history_in_flight = TRUE;
-    g_autofree gchar *rid = gateway_rpc_request("chat.history", params, 0, on_chat_history_response, NULL);
+    ChatRequestContext *ctx = chat_request_context_new();
+    g_autofree gchar *rid = gateway_rpc_request("chat.history", params, 0, on_chat_history_response, ctx);
     json_node_unref(params);
     if (!rid) {
+        chat_request_context_free(ctx);
         chat_history_in_flight = FALSE;
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Gateway not connected");
         chat_rebuild_messages_ui();
@@ -484,11 +611,22 @@ static void chat_request_history_for_selected(void) {
 }
 
 static void on_chat_sessions_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    ChatRequestContext *ctx = (ChatRequestContext *)user_data;
+    if (chat_request_context_is_stale(ctx)) {
+        chat_request_context_free(ctx);
+        return;
+    }
+    chat_request_context_free(ctx);
+
+    if (!chat_status_label) {
+        return;
+    }
+
     chat_sessions_in_flight = FALSE;
 
-    if (!response->ok || !response->payload) {
+    if (!response || !response->ok || !response->payload) {
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Failed to load sessions.list");
+        chat_set_session_dropdown_placeholder("No sessions yet", FALSE);
         return;
     }
 
@@ -522,6 +660,8 @@ static void on_chat_sessions_response(const GatewayRpcResponse *response, gpoint
         SessionChoice *c = g_ptr_array_index(chat_session_choices, 0);
         g_free(chat_selected_session_key);
         chat_selected_session_key = g_strdup(c->key);
+    } else if (chat_session_choices->len == 0) {
+        g_clear_pointer(&chat_selected_session_key, g_free);
     }
     g_free(previous);
 
@@ -547,18 +687,31 @@ static void chat_request_sessions_for_selected_agent(void) {
     g_object_unref(b);
 
     chat_sessions_in_flight = TRUE;
-    g_autofree gchar *rid = gateway_rpc_request("sessions.list", params, 0, on_chat_sessions_response, NULL);
+    ChatRequestContext *ctx = chat_request_context_new();
+    g_autofree gchar *rid = gateway_rpc_request("sessions.list", params, 0, on_chat_sessions_response, ctx);
     json_node_unref(params);
     if (!rid) {
+        chat_request_context_free(ctx);
         chat_sessions_in_flight = FALSE;
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Failed to request sessions.list");
     }
 }
 
 static void on_models_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    ChatRequestContext *ctx = (ChatRequestContext *)user_data;
+    if (chat_request_context_is_stale(ctx)) {
+        chat_request_context_free(ctx);
+        return;
+    }
+    chat_request_context_free(ctx);
+
     g_autoptr(GPtrArray) parsed_models =
         g_ptr_array_new_with_free_func((GDestroyNotify)chat_model_choice_free);
+
+    if (!chat_status_label) {
+        chat_dependency_complete();
+        return;
+    }
 
     if (response->ok && response->payload && JSON_NODE_HOLDS_OBJECT(response->payload)) {
         JsonObject *obj = json_node_get_object(response->payload);
@@ -586,26 +739,44 @@ static void on_models_response(const GatewayRpcResponse *response, gpointer user
         }
     } else if (chat_status_label) {
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Failed to load models.list");
+        chat_set_model_dropdown_error_placeholder("Model list unavailable");
+        chat_dependency_complete();
+        return;
     }
 
-    if (parsed_models->len > 0) {
-        if (chat_models) g_ptr_array_unref(chat_models);
-        chat_models = g_steal_pointer(&parsed_models);
-        chat_rebuild_model_dropdown();
+    if (chat_models) g_ptr_array_unref(chat_models);
+    chat_models = g_steal_pointer(&parsed_models);
+    chat_rebuild_model_dropdown();
+
+    if (!chat_models || chat_models->len == 0) {
+        gtk_label_set_text(GTK_LABEL(chat_status_label), "No models available. Configure provider/model first.");
+        chat_set_model_dropdown_error_placeholder("No model selected");
     }
     chat_dependency_complete();
 }
 
 static void on_agents_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    ChatRequestContext *ctx = (ChatRequestContext *)user_data;
+    if (chat_request_context_is_stale(ctx)) {
+        chat_request_context_free(ctx);
+        return;
+    }
+    chat_request_context_free(ctx);
+
     g_autoptr(GPtrArray) parsed_agents =
         g_ptr_array_new_with_free_func((GDestroyNotify)chat_agent_choice_free);
     const gchar *default_id = NULL;
+
+    if (!chat_status_label) {
+        chat_dependency_complete();
+        return;
+    }
 
     if (!response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
         if (chat_status_label) {
             gtk_label_set_text(GTK_LABEL(chat_status_label), "Failed to load agents.list");
         }
+        chat_set_agent_dropdown_placeholder("No agents available", FALSE);
         chat_dependency_complete();
         return;
     }
@@ -652,14 +823,31 @@ static void on_agents_response(const GatewayRpcResponse *response, gpointer user
         }
     }
 
+    if (!chat_agents || chat_agents->len == 0) {
+        chat_set_agent_dropdown_placeholder("No agents available", FALSE);
+        gtk_label_set_text(GTK_LABEL(chat_status_label), "No agents available for chat.");
+        chat_dependency_complete();
+        return;
+    }
+
     chat_rebuild_agent_dropdown();
     chat_request_sessions_for_selected_agent();
     chat_dependency_complete();
 }
 
 static void on_chat_send_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
-    if (!response->ok) {
+    ChatRequestContext *ctx = (ChatRequestContext *)user_data;
+    if (chat_request_context_is_stale(ctx)) {
+        chat_request_context_free(ctx);
+        return;
+    }
+    chat_request_context_free(ctx);
+
+    if (!chat_status_label) {
+        return;
+    }
+
+    if (!response || !response->ok) {
         gtk_label_set_text(GTK_LABEL(chat_status_label), "chat.send failed");
         chat_clear_pending_state();
         chat_rebuild_messages_ui();
@@ -667,7 +855,7 @@ static void on_chat_send_response(const GatewayRpcResponse *response, gpointer u
 }
 
 static void chat_send_current_message(void) {
-    if (!gateway_rpc_is_ready() || !chat_selected_session_key || !chat_compose_view) return;
+    if (!chat_gate_info.ready || !chat_selected_session_key || !chat_compose_view) return;
 
     GtkTextBuffer *buf = gtk_text_view_get_buffer(GTK_TEXT_VIEW(chat_compose_view));
     GtkTextIter start, end;
@@ -701,9 +889,11 @@ static void chat_send_current_message(void) {
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
-    g_autofree gchar *rid = gateway_rpc_request("chat.send", params, 0, on_chat_send_response, NULL);
+    ChatRequestContext *ctx = chat_request_context_new();
+    g_autofree gchar *rid = gateway_rpc_request("chat.send", params, 0, on_chat_send_response, ctx);
     json_node_unref(params);
     if (!rid) {
+        chat_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Unable to send while disconnected");
         chat_clear_pending_state();
         chat_rebuild_messages_ui();
@@ -744,6 +934,8 @@ static void on_send_clicked(GtkButton *button, gpointer user_data) {
 
 static void on_chat_event(const gchar *event_type, const JsonNode *payload, gpointer user_data) {
     (void)user_data;
+    if (!chat_status_label || !chat_messages_box) return;
+
     /* Rust bridge handles both legacy chat events and unified agent stream events. */
     if (g_strcmp0(event_type, "chat") != 0 && g_strcmp0(event_type, "agent") != 0) return;
     if (!payload || json_node_get_node_type((JsonNode *)payload) != JSON_NODE_OBJECT) return;
@@ -878,8 +1070,18 @@ static void on_chat_session_changed(GtkDropDown *dropdown, GParamSpec *pspec, gp
 }
 
 static void on_chat_model_patch_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
-    if (response->ok) {
+    ChatRequestContext *ctx = (ChatRequestContext *)user_data;
+    if (chat_request_context_is_stale(ctx)) {
+        chat_request_context_free(ctx);
+        return;
+    }
+    chat_request_context_free(ctx);
+
+    if (!chat_status_label) {
+        return;
+    }
+
+    if (response && response->ok) {
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Session model updated");
     } else {
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Failed to patch session model");
@@ -900,7 +1102,7 @@ static void on_chat_model_changed(GtkDropDown *dropdown, GParamSpec *pspec, gpoi
     g_free(chat_selected_model_id);
     chat_selected_model_id = model_id ? g_strdup(model_id) : NULL;
 
-    if (!chat_selected_session_key || !gateway_rpc_is_ready()) return;
+    if (!chat_selected_session_key || !chat_gate_info.ready) return;
 
     JsonBuilder *b = json_builder_new();
     json_builder_begin_object(b);
@@ -912,10 +1114,12 @@ static void on_chat_model_changed(GtkDropDown *dropdown, GParamSpec *pspec, gpoi
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
+    ChatRequestContext *ctx = chat_request_context_new();
     g_autofree gchar *rid = gateway_rpc_request("sessions.patch", params, 0,
-                                                on_chat_model_patch_response, NULL);
+                                                on_chat_model_patch_response, ctx);
     json_node_unref(params);
     if (!rid) {
+        chat_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Failed to send sessions.patch");
     }
 }
@@ -953,14 +1157,18 @@ static GtkWidget* chat_build(void) {
     gtk_box_append(GTK_BOX(page), chat_status_label);
 
     GtkWidget *controls = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
-    chat_agent_model = gtk_string_list_new(NULL);
-    chat_model_model = gtk_string_list_new(NULL);
-    chat_session_model = gtk_string_list_new(NULL);
+    chat_agent_model = NULL;
+    chat_model_model = NULL;
+    chat_session_model = NULL;
 
-    chat_agent_dropdown = gtk_drop_down_new(G_LIST_MODEL(chat_agent_model), NULL);
-    chat_model_dropdown = gtk_drop_down_new(G_LIST_MODEL(chat_model_model), NULL);
-    chat_session_dropdown = gtk_drop_down_new(G_LIST_MODEL(chat_session_model), NULL);
+    chat_agent_dropdown = gtk_drop_down_new(NULL, NULL);
+    chat_model_dropdown = gtk_drop_down_new(NULL, NULL);
+    chat_session_dropdown = gtk_drop_down_new(NULL, NULL);
     gtk_widget_set_hexpand(chat_session_dropdown, TRUE);
+
+    chat_attach_agent_dropdown_model(gtk_string_list_new(NULL), 0, TRUE);
+    chat_attach_model_dropdown_model(gtk_string_list_new(NULL), 0, TRUE);
+    chat_attach_session_dropdown_model(gtk_string_list_new(NULL), 0, TRUE);
 
     g_signal_connect(chat_agent_dropdown, "notify::selected", G_CALLBACK(on_chat_agent_changed), NULL);
     g_signal_connect(chat_model_dropdown, "notify::selected", G_CALLBACK(on_chat_model_changed), NULL);
@@ -1005,6 +1213,10 @@ static GtkWidget* chat_build(void) {
     }
     chat_event_listener_id = gateway_ws_event_subscribe(on_chat_event, NULL);
 
+    chat_rebuild_agent_dropdown();
+    chat_rebuild_model_dropdown();
+    chat_rebuild_session_dropdown();
+
     gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
     chat_set_send_enabled();
     return scrolled;
@@ -1012,47 +1224,57 @@ static GtkWidget* chat_build(void) {
 
 static void chat_refresh(void) {
     if (!chat_status_label || chat_fetch_in_flight || chat_sessions_in_flight || chat_history_in_flight) return;
-    if (!gateway_rpc_is_ready()) {
-        gtk_label_set_text(GTK_LABEL(chat_status_label), "Gateway not connected");
-        chat_clear_pending_state();
-        chat_rebuild_messages_ui();
+
+    const DesktopReadinessSnapshot *snapshot = state_get_readiness_snapshot();
+    readiness_describe_chat_gate(snapshot, &chat_gate_info);
+    if (!chat_gate_info.ready) {
+        chat_render_blocked_state(&chat_gate_info);
         chat_set_send_enabled();
         return;
     }
+
     if (!section_is_stale(&chat_last_fetch_us)) {
+        if (!chat_selected_session_key) {
+            chat_set_session_dropdown_placeholder("No sessions yet", FALSE);
+        }
         chat_set_send_enabled();
         return;
     }
 
     chat_fetch_in_flight = TRUE;
     chat_dependencies_pending = 0;
-    g_autofree gchar *agents_rid = gateway_rpc_request("agents.list", NULL, 0, on_agents_response, NULL);
+    ChatRequestContext *agents_ctx = chat_request_context_new();
+    g_autofree gchar *agents_rid = gateway_rpc_request("agents.list", NULL, 0, on_agents_response, agents_ctx);
     if (agents_rid) chat_dependencies_pending++;
-    g_autofree gchar *models_rid = gateway_rpc_request("models.list", NULL, 0, on_models_response, NULL);
+    else chat_request_context_free(agents_ctx);
+
+    ChatRequestContext *models_ctx = chat_request_context_new();
+    g_autofree gchar *models_rid = gateway_rpc_request("models.list", NULL, 0, on_models_response, models_ctx);
     if (models_rid) chat_dependencies_pending++;
+    else chat_request_context_free(models_ctx);
+
     if (!agents_rid || !models_rid) {
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Failed to request chat dependencies");
         chat_fetch_in_flight = FALSE;
         chat_dependencies_pending = 0;
+        chat_set_agent_dropdown_placeholder("No agents available", FALSE);
+        chat_set_model_dropdown_error_placeholder("Model list unavailable");
+        chat_set_session_dropdown_placeholder("No sessions yet", FALSE);
     }
     chat_set_send_enabled();
 }
 
 static void chat_destroy(void) {
+    chat_generation++;
+
     if (chat_event_listener_id) {
         gateway_ws_event_unsubscribe(chat_event_listener_id);
         chat_event_listener_id = 0;
     }
 
-    if (chat_agent_dropdown) {
-        gtk_drop_down_set_model(GTK_DROP_DOWN(chat_agent_dropdown), NULL);
-    }
-    if (chat_model_dropdown) {
-        gtk_drop_down_set_model(GTK_DROP_DOWN(chat_model_dropdown), NULL);
-    }
-    if (chat_session_dropdown) {
-        gtk_drop_down_set_model(GTK_DROP_DOWN(chat_session_dropdown), NULL);
-    }
+    ui_dropdown_detach_model(chat_agent_dropdown, (gpointer *)&chat_agent_model);
+    ui_dropdown_detach_model(chat_model_dropdown, (gpointer *)&chat_model_model);
+    ui_dropdown_detach_model(chat_session_dropdown, (gpointer *)&chat_session_model);
 
     chat_status_label = NULL;
     chat_messages_box = NULL;
@@ -1064,9 +1286,6 @@ static void chat_destroy(void) {
     chat_compose_view = NULL;
     chat_send_btn = NULL;
 
-    if (chat_agent_model) g_object_unref(chat_agent_model);
-    if (chat_model_model) g_object_unref(chat_model_model);
-    if (chat_session_model) g_object_unref(chat_session_model);
     chat_agent_model = NULL;
     chat_model_model = NULL;
     chat_session_model = NULL;
@@ -1098,6 +1317,10 @@ static void chat_destroy(void) {
     chat_last_fetch_us = 0;
     chat_show_thinking = FALSE;
     chat_show_tools = TRUE;
+    chat_gate_info.ready = FALSE;
+    chat_gate_info.reason = CHAT_BLOCK_UNKNOWN;
+    chat_gate_info.status = NULL;
+    chat_gate_info.next_action = NULL;
 }
 
 static void chat_invalidate(void) {

--- a/apps/linux/src/section_control_room.c
+++ b/apps/linux/src/section_control_room.c
@@ -31,6 +31,25 @@ static gboolean control_nodes_fetch_in_flight = FALSE;
 static gboolean control_agents_fetch_in_flight = FALSE;
 static gboolean control_sessions_fetch_in_flight = FALSE;
 static gint64 control_last_fetch_us = 0;
+static guint control_generation = 1;
+
+typedef struct {
+    guint generation;
+} ControlRequestContext;
+
+static ControlRequestContext* control_request_context_new(void) {
+    ControlRequestContext *ctx = g_new0(ControlRequestContext, 1);
+    ctx->generation = control_generation;
+    return ctx;
+}
+
+static gboolean control_request_context_is_stale(const ControlRequestContext *ctx) {
+    return !ctx || ctx->generation != control_generation;
+}
+
+static void control_request_context_free(gpointer data) {
+    g_free(data);
+}
 
 static void control_request_snapshot(void);
 
@@ -45,7 +64,9 @@ static void control_set_summary_from_state(void) {
 
     AppState app = state_get_current();
     RuntimeMode mode = state_get_runtime_mode();
-    gboolean ws = gateway_rpc_is_ready();
+    const DesktopReadinessSnapshot *snapshot = state_get_readiness_snapshot();
+    ChatGateInfo gate = {0};
+    readiness_describe_chat_gate(snapshot, &gate);
     HealthState *health = state_get_health();
     SystemdState *sys = state_get_systemd();
     ReadinessInfo info = {0};
@@ -54,10 +75,10 @@ static void control_set_summary_from_state(void) {
     RuntimeModePresentation mode_presentation = {0};
     runtime_mode_describe(mode, &mode_presentation);
 
-    g_autofree gchar *summary = g_strdup_printf("%s | %s | RPC %s",
+    g_autofree gchar *summary = g_strdup_printf("%s | %s | Chat %s",
                                                 info.classification ? info.classification : "Unknown",
                                                 mode_presentation.label ? mode_presentation.label : "Runtime unknown",
-                                                ws ? "connected" : "disconnected");
+                                                gate.ready ? "ready" : readiness_chat_block_reason_to_string(gate.reason));
     gtk_label_set_text(GTK_LABEL(control_summary_label), summary);
 
     if (control_gateway_health_label) {
@@ -68,6 +89,9 @@ static void control_set_summary_from_state(void) {
             gateway_health = "Gateway: Connected";
         } else if (health && health->http_ok) {
             gateway_health = "Gateway: Degraded";
+        }
+        if (!gate.ready && gate.status) {
+            gateway_health = gate.status;
         }
         gtk_label_set_text(GTK_LABEL(control_gateway_health_label), gateway_health);
     }
@@ -83,10 +107,14 @@ static void control_set_summary_from_state(void) {
     }
 
     if (control_details_label) {
-        g_autofree gchar *details = g_strdup_printf("State: %s | Setup: %s | Model config: %s",
+        g_autofree gchar *details = g_strdup_printf("State: %s | Setup: %s | Provider: %s | Default model: %s | Catalog: %s | Selected: %s | Agents: %s",
                                                     state_get_current_string(),
-                                                    health && health->setup_detected ? "yes" : "no",
-                                                    health && health->has_model_config ? "present" : "missing");
+                                                    snapshot && snapshot->config_present ? "yes" : "no",
+                                                    snapshot && snapshot->provider_configured ? "configured" : "missing",
+                                                    snapshot && snapshot->default_model_configured ? "configured" : "missing",
+                                                    snapshot && snapshot->model_catalog_available ? "ready" : "unavailable",
+                                                    snapshot && snapshot->selected_model_resolved ? "resolved" : "unresolved",
+                                                    snapshot && snapshot->agents_available ? "available" : "unavailable");
         gtk_label_set_text(GTK_LABEL(control_details_label), details);
     }
 }
@@ -97,9 +125,16 @@ static void control_nodes_clear(void) {
 }
 
 static void on_control_mutation_done(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    ControlRequestContext *ctx = (ControlRequestContext *)user_data;
+    if (control_request_context_is_stale(ctx)) {
+        control_request_context_free(ctx);
+        return;
+    }
+    control_request_context_free(ctx);
+
     if (!control_status_label) return;
-    gtk_label_set_text(GTK_LABEL(control_status_label), response->ok ? "Action applied" : "Action failed");
+    gtk_label_set_text(GTK_LABEL(control_status_label),
+                       (response && response->ok) ? "Action applied" : "Action failed");
     section_mark_stale(&control_last_fetch_us);
 }
 
@@ -126,7 +161,13 @@ static void on_refresh_snapshot_clicked(GtkButton *button, gpointer user_data) {
 }
 
 static void on_control_agents_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    ControlRequestContext *ctx = (ControlRequestContext *)user_data;
+    if (control_request_context_is_stale(ctx)) {
+        control_request_context_free(ctx);
+        return;
+    }
+    control_request_context_free(ctx);
+
     control_agents_fetch_in_flight = FALSE;
 
     gint count = 0;
@@ -143,7 +184,13 @@ static void on_control_agents_response(const GatewayRpcResponse *response, gpoin
 }
 
 static void on_control_sessions_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    ControlRequestContext *ctx = (ControlRequestContext *)user_data;
+    if (control_request_context_is_stale(ctx)) {
+        control_request_context_free(ctx);
+        return;
+    }
+    control_request_context_free(ctx);
+
     control_sessions_fetch_in_flight = FALSE;
 
     gint count = 0;
@@ -180,8 +227,10 @@ static void on_run_cron_clicked(GtkButton *button, gpointer user_data) {
         return;
     }
 
-    g_autofree gchar *rid = mutation_cron_run(job_id, on_control_mutation_done, NULL);
+    ControlRequestContext *ctx = control_request_context_new();
+    g_autofree gchar *rid = mutation_cron_run(job_id, on_control_mutation_done, ctx);
     if (!rid && control_status_label) {
+        control_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(control_status_label), "Cron run request failed");
     }
 }
@@ -210,16 +259,24 @@ static void on_abort_session_clicked(GtkButton *button, gpointer user_data) {
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
+    ControlRequestContext *ctx = control_request_context_new();
     g_autofree gchar *rid = gateway_rpc_request("chat.abort", params, 0,
-                                                on_control_mutation_done, NULL);
+                                                on_control_mutation_done, ctx);
     json_node_unref(params);
     if (!rid) {
+        control_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(control_status_label), "Abort request failed");
     }
 }
 
 static void on_control_nodes_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    ControlRequestContext *ctx = (ControlRequestContext *)user_data;
+    if (control_request_context_is_stale(ctx)) {
+        control_request_context_free(ctx);
+        return;
+    }
+    control_request_context_free(ctx);
+
     control_nodes_fetch_in_flight = FALSE;
 
     if (!control_status_label) return;
@@ -227,7 +284,7 @@ static void on_control_nodes_response(const GatewayRpcResponse *response, gpoint
     control_nodes_clear();
     control_set_summary_from_state();
 
-    if (!response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
+    if (!response || !response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
         gtk_label_set_text(GTK_LABEL(control_status_label), "Failed to load node snapshot");
         control_maybe_finish_refresh();
         return;
@@ -287,27 +344,33 @@ static void control_request_snapshot(void) {
 
     if (!control_nodes_fetch_in_flight) {
         control_nodes_fetch_in_flight = TRUE;
+        ControlRequestContext *nodes_ctx = control_request_context_new();
         g_autofree gchar *rid_nodes = gateway_rpc_request("node.list", NULL, 0,
-                                                          on_control_nodes_response, NULL);
+                                                          on_control_nodes_response, nodes_ctx);
         if (!rid_nodes) {
+            control_request_context_free(nodes_ctx);
             control_nodes_fetch_in_flight = FALSE;
         }
     }
 
     if (!control_agents_fetch_in_flight) {
         control_agents_fetch_in_flight = TRUE;
+        ControlRequestContext *agents_ctx = control_request_context_new();
         g_autofree gchar *rid_agents = gateway_rpc_request("agents.list", NULL, 0,
-                                                           on_control_agents_response, NULL);
+                                                           on_control_agents_response, agents_ctx);
         if (!rid_agents) {
+            control_request_context_free(agents_ctx);
             control_agents_fetch_in_flight = FALSE;
         }
     }
 
     if (!control_sessions_fetch_in_flight) {
         control_sessions_fetch_in_flight = TRUE;
+        ControlRequestContext *sessions_ctx = control_request_context_new();
         g_autofree gchar *rid_sessions = gateway_rpc_request("sessions.list", NULL, 0,
-                                                             on_control_sessions_response, NULL);
+                                                             on_control_sessions_response, sessions_ctx);
         if (!rid_sessions) {
+            control_request_context_free(sessions_ctx);
             control_sessions_fetch_in_flight = FALSE;
         }
     }
@@ -406,6 +469,8 @@ static void control_refresh(void) {
 }
 
 static void control_destroy(void) {
+    control_generation++;
+
     control_status_label = NULL;
     control_summary_label = NULL;
     control_details_label = NULL;

--- a/apps/linux/src/section_instances.c
+++ b/apps/linux/src/section_instances.c
@@ -46,6 +46,25 @@ static GtkWidget *inst_pairing_box = NULL;
 static GtkWidget *inst_pairing_status_label = NULL;
 static GatewayPairingList *inst_pairing_cache = NULL;
 static gboolean inst_pairing_fetch_in_flight = FALSE;
+static guint inst_generation = 1;
+
+typedef struct {
+    guint generation;
+} InstancesRequestContext;
+
+static InstancesRequestContext* instances_request_context_new(void) {
+    InstancesRequestContext *ctx = g_new0(InstancesRequestContext, 1);
+    ctx->generation = inst_generation;
+    return ctx;
+}
+
+static gboolean instances_request_context_is_stale(const InstancesRequestContext *ctx) {
+    return !ctx || ctx->generation != inst_generation;
+}
+
+static void instances_request_context_free(gpointer data) {
+    g_free(data);
+}
 
 /* Forward declarations */
 static void inst_rebuild_remote_nodes(void);
@@ -93,11 +112,17 @@ static void add_detail_row(GtkWidget *parent, const gchar *label, const gchar *v
 /* ── Mutation callbacks ──────────────────────────────────────────── */
 
 static void on_mutation_done(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
-    if (!response->ok) {
+    InstancesRequestContext *ctx = (InstancesRequestContext *)user_data;
+    if (instances_request_context_is_stale(ctx)) {
+        instances_request_context_free(ctx);
+        return;
+    }
+    instances_request_context_free(ctx);
+
+    if (!response || !response->ok) {
         if (inst_remote_status_label) {
             g_autofree gchar *msg = g_strdup_printf("Error: %s",
-                response->error_msg ? response->error_msg : "unknown");
+                response && response->error_msg ? response->error_msg : "unknown");
             gtk_label_set_text(GTK_LABEL(inst_remote_status_label), msg);
         }
     }
@@ -116,8 +141,10 @@ static void on_pair_approve(GtkButton *btn, gpointer user_data) {
     if (inst_pairing_status_label)
         gtk_label_set_text(GTK_LABEL(inst_pairing_status_label), "Approving\u2026");
 
-    g_autofree gchar *req = mutation_node_pair_approve(req_id, on_mutation_done, NULL);
+    InstancesRequestContext *ctx = instances_request_context_new();
+    g_autofree gchar *req = mutation_node_pair_approve(req_id, on_mutation_done, ctx);
     if (!req) {
+        instances_request_context_free(ctx);
         gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
         if (inst_pairing_status_label)
             gtk_label_set_text(GTK_LABEL(inst_pairing_status_label), "Failed to send request");
@@ -133,8 +160,10 @@ static void on_pair_reject(GtkButton *btn, gpointer user_data) {
     if (inst_pairing_status_label)
         gtk_label_set_text(GTK_LABEL(inst_pairing_status_label), "Rejecting\u2026");
 
-    g_autofree gchar *req = mutation_node_pair_reject(req_id, on_mutation_done, NULL);
+    InstancesRequestContext *ctx = instances_request_context_new();
+    g_autofree gchar *req = mutation_node_pair_reject(req_id, on_mutation_done, ctx);
     if (!req) {
+        instances_request_context_free(ctx);
         gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
         if (inst_pairing_status_label)
             gtk_label_set_text(GTK_LABEL(inst_pairing_status_label), "Failed to send request");
@@ -417,15 +446,21 @@ static void inst_rebuild_pairing(void) {
 /* ── RPC callbacks ───────────────────────────────────────────────── */
 
 static void on_nodes_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    InstancesRequestContext *ctx = (InstancesRequestContext *)user_data;
+    if (instances_request_context_is_stale(ctx)) {
+        instances_request_context_free(ctx);
+        return;
+    }
+    instances_request_context_free(ctx);
+
     inst_nodes_fetch_in_flight = FALSE;
 
     if (!inst_remote_box) return;
 
-    if (!response->ok) {
+    if (!response || !response->ok) {
         if (inst_remote_status_label) {
             g_autofree gchar *msg = g_strdup_printf("Error: %s",
-                response->error_msg ? response->error_msg : "unknown");
+                response && response->error_msg ? response->error_msg : "unknown");
             gtk_label_set_text(GTK_LABEL(inst_remote_status_label), msg);
         }
         return;
@@ -458,15 +493,21 @@ static void on_nodes_rpc_response(const GatewayRpcResponse *response, gpointer u
 }
 
 static void on_pairing_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    InstancesRequestContext *ctx = (InstancesRequestContext *)user_data;
+    if (instances_request_context_is_stale(ctx)) {
+        instances_request_context_free(ctx);
+        return;
+    }
+    instances_request_context_free(ctx);
+
     inst_pairing_fetch_in_flight = FALSE;
 
     if (!inst_pairing_box) return;
 
-    if (!response->ok) {
+    if (!response || !response->ok) {
         if (inst_pairing_status_label) {
             g_autofree gchar *msg = g_strdup_printf("Error: %s",
-                response->error_msg ? response->error_msg : "unknown");
+                response && response->error_msg ? response->error_msg : "unknown");
             gtk_label_set_text(GTK_LABEL(inst_pairing_status_label), msg);
         }
         return;
@@ -485,8 +526,10 @@ static void inst_fetch_pairing(void) {
     if (!gateway_rpc_is_ready()) return;
 
     inst_pairing_fetch_in_flight = TRUE;
-    g_autofree gchar *req = mutation_node_pair_list(on_pairing_rpc_response, NULL);
+    InstancesRequestContext *ctx = instances_request_context_new();
+    g_autofree gchar *req = mutation_node_pair_list(on_pairing_rpc_response, ctx);
     if (!req) {
+        instances_request_context_free(ctx);
         inst_pairing_fetch_in_flight = FALSE;
     }
 }
@@ -502,15 +545,19 @@ static void inst_force_refresh(void) {
     if (!gateway_rpc_is_ready()) return;
 
     inst_nodes_fetch_in_flight = TRUE;
+    InstancesRequestContext *nodes_ctx = instances_request_context_new();
     g_autofree gchar *req_id = gateway_rpc_request(
-        "node.list", NULL, 0, on_nodes_rpc_response, NULL);
+        "node.list", NULL, 0, on_nodes_rpc_response, nodes_ctx);
     if (!req_id) {
+        instances_request_context_free(nodes_ctx);
         inst_nodes_fetch_in_flight = FALSE;
     }
 
     inst_pairing_fetch_in_flight = TRUE;
-    g_autofree gchar *req_id_pair = mutation_node_pair_list(on_pairing_rpc_response, NULL);
+    InstancesRequestContext *pair_ctx = instances_request_context_new();
+    g_autofree gchar *req_id_pair = mutation_node_pair_list(on_pairing_rpc_response, pair_ctx);
     if (!req_id_pair) {
+        instances_request_context_free(pair_ctx);
         inst_pairing_fetch_in_flight = FALSE;
     }
 }
@@ -678,9 +725,11 @@ static void instances_refresh(void) {
     }
 
     inst_nodes_fetch_in_flight = TRUE;
+    InstancesRequestContext *nodes_ctx = instances_request_context_new();
     g_autofree gchar *req_id = gateway_rpc_request(
-        "node.list", NULL, 0, on_nodes_rpc_response, NULL);
+        "node.list", NULL, 0, on_nodes_rpc_response, nodes_ctx);
     if (!req_id) {
+        instances_request_context_free(nodes_ctx);
         inst_nodes_fetch_in_flight = FALSE;
         if (inst_remote_status_label)
             gtk_label_set_text(GTK_LABEL(inst_remote_status_label), "Failed to send request");
@@ -692,6 +741,8 @@ static void instances_refresh(void) {
 }
 
 static void instances_destroy(void) {
+    inst_generation++;
+
     inst_hostname_label = NULL;
     inst_platform_label = NULL;
     inst_version_label = NULL;

--- a/apps/linux/src/section_logs.c
+++ b/apps/linux/src/section_logs.c
@@ -16,6 +16,25 @@ static GtkWidget *logs_text_view = NULL;
 static GtkWidget *logs_filter_entry = NULL;
 static gboolean logs_fetch_in_flight = FALSE;
 static gint64 logs_last_fetch_us = 0;
+static guint logs_generation = 1;
+
+typedef struct {
+    guint generation;
+} LogsRequestContext;
+
+static LogsRequestContext* logs_request_context_new(void) {
+    LogsRequestContext *ctx = g_new0(LogsRequestContext, 1);
+    ctx->generation = logs_generation;
+    return ctx;
+}
+
+static gboolean logs_request_context_is_stale(const LogsRequestContext *ctx) {
+    return !ctx || ctx->generation != logs_generation;
+}
+
+static void logs_request_context_free(gpointer data) {
+    g_free(data);
+}
 
 static void logs_trigger_fetch(gboolean force);
 
@@ -26,12 +45,18 @@ static void logs_set_text(const gchar *text) {
 }
 
 static void on_logs_tail_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    LogsRequestContext *ctx = (LogsRequestContext *)user_data;
+    if (logs_request_context_is_stale(ctx)) {
+        logs_request_context_free(ctx);
+        return;
+    }
+    logs_request_context_free(ctx);
+
     logs_fetch_in_flight = FALSE;
 
     if (!logs_status_label) return;
 
-    if (!response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
+    if (!response || !response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
         gtk_label_set_text(GTK_LABEL(logs_status_label), "Failed to load logs");
         logs_set_text("Could not fetch logs.tail");
         return;
@@ -181,10 +206,12 @@ static void logs_trigger_fetch(gboolean force) {
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
+    LogsRequestContext *ctx = logs_request_context_new();
     g_autofree gchar *rid = gateway_rpc_request("logs.tail", params, 0,
-                                                on_logs_tail_response, NULL);
+                                                on_logs_tail_response, ctx);
     json_node_unref(params);
     if (!rid) {
+        logs_request_context_free(ctx);
         logs_fetch_in_flight = FALSE;
         gtk_label_set_text(GTK_LABEL(logs_status_label), "Failed to request logs.tail");
     }
@@ -195,6 +222,8 @@ static void logs_refresh(void) {
 }
 
 static void logs_destroy(void) {
+    logs_generation++;
+
     logs_status_label = NULL;
     logs_text_view = NULL;
     logs_filter_entry = NULL;

--- a/apps/linux/src/section_sessions.c
+++ b/apps/linux/src/section_sessions.c
@@ -26,6 +26,7 @@ static GtkWidget *sessions_status_label = NULL;
 static GatewaySessionsData *sessions_data_cache = NULL;
 static gboolean sessions_fetch_in_flight = FALSE;
 static gint64 sessions_last_fetch_us = 0;
+static guint sessions_generation = 1;
 
 typedef struct {
     gchar *id;
@@ -33,6 +34,24 @@ typedef struct {
 } SessionModelChoice;
 
 static GPtrArray *session_model_choices = NULL;
+
+typedef struct {
+    guint generation;
+} SessionsRequestContext;
+
+static SessionsRequestContext* sessions_request_context_new(void) {
+    SessionsRequestContext *ctx = g_new0(SessionsRequestContext, 1);
+    ctx->generation = sessions_generation;
+    return ctx;
+}
+
+static gboolean sessions_request_context_is_stale(const SessionsRequestContext *ctx) {
+    return !ctx || ctx->generation != sessions_generation;
+}
+
+static void sessions_request_context_free(gpointer data) {
+    g_free(data);
+}
 
 static void session_model_choice_free(SessionModelChoice *choice) {
     if (!choice) return;
@@ -69,12 +88,18 @@ static gchar* sessions_default_model_label(void) {
 /* ── Mutation callbacks ──────────────────────────────────────────── */
 
 static void on_mutation_done(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    SessionsRequestContext *ctx = (SessionsRequestContext *)user_data;
+    if (sessions_request_context_is_stale(ctx)) {
+        sessions_request_context_free(ctx);
+        return;
+    }
+    sessions_request_context_free(ctx);
+
     if (!sessions_status_label) return;
 
-    if (!response->ok) {
+    if (!response || !response->ok) {
         g_autofree gchar *msg = g_strdup_printf("Error: %s",
-            response->error_msg ? response->error_msg : "unknown");
+            response && response->error_msg ? response->error_msg : "unknown");
         gtk_label_set_text(GTK_LABEL(sessions_status_label), msg);
     }
 
@@ -117,8 +142,10 @@ static void on_session_reset_response(GObject *source, GAsyncResult *result, gpo
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Resetting…");
 
-    g_autofree gchar *req = mutation_sessions_reset(key, on_mutation_done, NULL);
+    SessionsRequestContext *ctx = sessions_request_context_new();
+    g_autofree gchar *req = mutation_sessions_reset(key, on_mutation_done, ctx);
     if (!req && sessions_status_label) {
+        sessions_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
 }
@@ -132,8 +159,10 @@ static void on_session_compact(GtkButton *btn, gpointer user_data) {
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Compacting\u2026");
 
-    g_autofree gchar *req = mutation_sessions_compact(key, on_mutation_done, NULL);
+    SessionsRequestContext *ctx = sessions_request_context_new();
+    g_autofree gchar *req = mutation_sessions_compact(key, on_mutation_done, ctx);
     if (!req) {
+        sessions_request_context_free(ctx);
         gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
         if (sessions_status_label)
             gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
@@ -153,8 +182,10 @@ static void on_thinking_changed(GObject *gobject, GParamSpec *pspec, gpointer us
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Updating\u2026");
 
-    g_autofree gchar *req = mutation_sessions_patch(key, level, NULL, NULL, on_mutation_done, NULL);
+    SessionsRequestContext *ctx = sessions_request_context_new();
+    g_autofree gchar *req = mutation_sessions_patch(key, level, NULL, NULL, on_mutation_done, ctx);
     if (!req && sessions_status_label) {
+        sessions_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
 }
@@ -172,8 +203,10 @@ static void on_verbose_changed(GObject *gobject, GParamSpec *pspec, gpointer use
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Updating\u2026");
 
-    g_autofree gchar *req = mutation_sessions_patch(key, NULL, level, NULL, on_mutation_done, NULL);
+    SessionsRequestContext *ctx = sessions_request_context_new();
+    g_autofree gchar *req = mutation_sessions_patch(key, NULL, level, NULL, on_mutation_done, ctx);
     if (!req && sessions_status_label) {
+        sessions_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
 }
@@ -193,8 +226,10 @@ static void on_model_changed(GObject *gobject, GParamSpec *pspec, gpointer user_
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Updating…");
 
-    g_autofree gchar *req = mutation_sessions_patch(key, NULL, NULL, model, on_mutation_done, NULL);
+    SessionsRequestContext *ctx = sessions_request_context_new();
+    g_autofree gchar *req = mutation_sessions_patch(key, NULL, NULL, model, on_mutation_done, ctx);
     if (!req && sessions_status_label) {
+        sessions_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
 }
@@ -213,8 +248,10 @@ static void on_delete_dialog_response(GObject *source, GAsyncResult *result, gpo
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Deleting\u2026");
 
-    g_autofree gchar *req = mutation_sessions_delete(key, TRUE, on_mutation_done, NULL);
+    SessionsRequestContext *ctx = sessions_request_context_new();
+    g_autofree gchar *req = mutation_sessions_delete(key, TRUE, on_mutation_done, ctx);
     if (!req && sessions_status_label) {
+        sessions_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
 }
@@ -546,7 +583,12 @@ static void sessions_rebuild_list(void) {
 }
 
 static void on_sessions_models_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    SessionsRequestContext *ctx = (SessionsRequestContext *)user_data;
+    if (sessions_request_context_is_stale(ctx)) {
+        sessions_request_context_free(ctx);
+        return;
+    }
+    sessions_request_context_free(ctx);
 
     if (session_model_choices) g_ptr_array_unref(session_model_choices);
     session_model_choices = g_ptr_array_new_with_free_func((GDestroyNotify)session_model_choice_free);
@@ -594,15 +636,21 @@ static void on_sessions_models_response(const GatewayRpcResponse *response, gpoi
 /* ── RPC callback ────────────────────────────────────────────────── */
 
 static void on_sessions_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    SessionsRequestContext *ctx = (SessionsRequestContext *)user_data;
+    if (sessions_request_context_is_stale(ctx)) {
+        sessions_request_context_free(ctx);
+        return;
+    }
+    sessions_request_context_free(ctx);
+
     sessions_fetch_in_flight = FALSE;
 
     if (!sessions_list_box) return;
 
-    if (!response->ok) {
+    if (!response || !response->ok) {
         if (sessions_status_label) {
             g_autofree gchar *msg = g_strdup_printf("Error: %s",
-                response->error_msg ? response->error_msg : "unknown");
+                response && response->error_msg ? response->error_msg : "unknown");
             gtk_label_set_text(GTK_LABEL(sessions_status_label), msg);
         }
         return;
@@ -636,12 +684,18 @@ static void sessions_force_refresh(void) {
     if (!gateway_rpc_is_ready()) return;
 
     sessions_fetch_in_flight = TRUE;
+    SessionsRequestContext *sessions_ctx = sessions_request_context_new();
     g_autofree gchar *req_id = gateway_rpc_request(
-        "sessions.list", NULL, 0, on_sessions_rpc_response, NULL);
+        "sessions.list", NULL, 0, on_sessions_rpc_response, sessions_ctx);
+    SessionsRequestContext *models_ctx = sessions_request_context_new();
     g_autofree gchar *models_req_id = gateway_rpc_request(
-        "models.list", NULL, 0, on_sessions_models_response, NULL);
+        "models.list", NULL, 0, on_sessions_models_response, models_ctx);
     if (!req_id) {
+        sessions_request_context_free(sessions_ctx);
         sessions_fetch_in_flight = FALSE;
+    }
+    if (!models_req_id) {
+        sessions_request_context_free(models_ctx);
     }
     (void)models_req_id;
 }
@@ -699,19 +753,27 @@ static void sessions_refresh(void) {
     if (!section_is_stale(&sessions_last_fetch_us)) return;
 
     sessions_fetch_in_flight = TRUE;
+    SessionsRequestContext *sessions_ctx = sessions_request_context_new();
     g_autofree gchar *req_id = gateway_rpc_request(
-        "sessions.list", NULL, 0, on_sessions_rpc_response, NULL);
+        "sessions.list", NULL, 0, on_sessions_rpc_response, sessions_ctx);
+    SessionsRequestContext *models_ctx = sessions_request_context_new();
     g_autofree gchar *models_req_id = gateway_rpc_request(
-        "models.list", NULL, 0, on_sessions_models_response, NULL);
+        "models.list", NULL, 0, on_sessions_models_response, models_ctx);
     if (!req_id) {
+        sessions_request_context_free(sessions_ctx);
         sessions_fetch_in_flight = FALSE;
         if (sessions_status_label)
             gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
+    }
+    if (!models_req_id) {
+        sessions_request_context_free(models_ctx);
     }
     (void)models_req_id;
 }
 
 static void sessions_destroy(void) {
+    sessions_generation++;
+
     sessions_list_box = NULL;
     sessions_status_label = NULL;
     sessions_fetch_in_flight = FALSE;

--- a/apps/linux/src/section_skills.c
+++ b/apps/linux/src/section_skills.c
@@ -15,6 +15,7 @@
 #include "gateway_rpc.h"
 #include "gateway_data.h"
 #include "gateway_mutations.h"
+#include "ui_model_utils.h"
 #include <adwaita.h>
 
 /* ── State ───────────────────────────────────────────────────────── */
@@ -22,10 +23,30 @@
 static GtkWidget *skills_list_box = NULL;
 static GtkWidget *skills_status_label = NULL;
 static GtkWidget *skills_filter_dropdown = NULL;
+static GtkStringList *skills_filter_model = NULL;
 static GatewaySkillsData *skills_data_cache = NULL;
 static gboolean skills_fetch_in_flight = FALSE;
 static gint64 skills_last_fetch_us = 0;
 static gint current_filter = 0; /* 0: All, 1: Ready, 2: Needs Setup, 3: Disabled */
+static guint skills_generation = 1;
+
+typedef struct {
+    guint generation;
+} SkillsRequestContext;
+
+static SkillsRequestContext* skills_request_context_new(void) {
+    SkillsRequestContext *ctx = g_new0(SkillsRequestContext, 1);
+    ctx->generation = skills_generation;
+    return ctx;
+}
+
+static gboolean skills_request_context_is_stale(const SkillsRequestContext *ctx) {
+    return !ctx || ctx->generation != skills_generation;
+}
+
+static void skills_request_context_free(gpointer data) {
+    g_free(data);
+}
 
 /* Forward declarations */
 static void skills_rebuild_list(void);
@@ -34,12 +55,18 @@ static void skills_force_refresh(void);
 /* ── Mutation callbacks ──────────────────────────────────────────── */
 
 static void on_mutation_done(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    SkillsRequestContext *ctx = (SkillsRequestContext *)user_data;
+    if (skills_request_context_is_stale(ctx)) {
+        skills_request_context_free(ctx);
+        return;
+    }
+    skills_request_context_free(ctx);
+
     if (!skills_status_label) return;
 
-    if (!response->ok) {
+    if (!response || !response->ok) {
         g_autofree gchar *msg = g_strdup_printf("Error: %s",
-            response->error_msg ? response->error_msg : "unknown");
+            response && response->error_msg ? response->error_msg : "unknown");
         gtk_label_set_text(GTK_LABEL(skills_status_label), msg);
     }
 
@@ -57,8 +84,10 @@ static void on_toggle_enable(GtkButton *btn, gpointer user_data) {
     if (!key) return;
 
     gtk_widget_set_sensitive(GTK_WIDGET(btn), FALSE);
-    g_autofree gchar *req = mutation_skills_enable(key, !currently_enabled, on_mutation_done, NULL);
+    SkillsRequestContext *ctx = skills_request_context_new();
+    g_autofree gchar *req = mutation_skills_enable(key, !currently_enabled, on_mutation_done, ctx);
     if (!req) {
+        skills_request_context_free(ctx);
         gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
         if (skills_status_label)
             gtk_label_set_text(GTK_LABEL(skills_status_label), "Failed to send request");
@@ -76,8 +105,10 @@ static void on_install(GtkButton *btn, gpointer user_data) {
     if (skills_status_label)
         gtk_label_set_text(GTK_LABEL(skills_status_label), "Installing\u2026");
 
-    g_autofree gchar *req = mutation_skills_install(name, install_id, on_mutation_done, NULL);
+    SkillsRequestContext *ctx = skills_request_context_new();
+    g_autofree gchar *req = mutation_skills_install(name, install_id, on_mutation_done, ctx);
     if (!req) {
+        skills_request_context_free(ctx);
         gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
         if (skills_status_label)
             gtk_label_set_text(GTK_LABEL(skills_status_label), "Failed to send install request");
@@ -93,8 +124,10 @@ static void on_update(GtkButton *btn, gpointer user_data) {
     if (skills_status_label)
         gtk_label_set_text(GTK_LABEL(skills_status_label), "Updating\u2026");
 
-    g_autofree gchar *req = mutation_skills_update(key, on_mutation_done, NULL);
+    SkillsRequestContext *ctx = skills_request_context_new();
+    g_autofree gchar *req = mutation_skills_update(key, on_mutation_done, ctx);
     if (!req) {
+        skills_request_context_free(ctx);
         gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
         if (skills_status_label)
             gtk_label_set_text(GTK_LABEL(skills_status_label), "Failed to send update request");
@@ -105,6 +138,11 @@ static void on_update(GtkButton *btn, gpointer user_data) {
 static void on_env_dialog_response(GObject *source, GAsyncResult *result, gpointer user_data) {
     AdwAlertDialog *dialog = ADW_ALERT_DIALOG(source);
     (void)user_data;
+
+    guint dialog_generation = GPOINTER_TO_UINT(g_object_get_data(G_OBJECT(dialog), "skills-generation"));
+    if (dialog_generation != skills_generation) {
+        return;
+    }
 
     const gchar *response_id = adw_alert_dialog_choose_finish(dialog, result);
     if (g_strcmp0(response_id, "save") != 0) return;
@@ -123,9 +161,13 @@ static void on_env_dialog_response(GObject *source, GAsyncResult *result, gpoint
 
     g_autofree gchar *req = NULL;
     if (is_api_key) {
-        req = mutation_skills_update_api_key(key, value, on_mutation_done, NULL);
+        SkillsRequestContext *ctx = skills_request_context_new();
+        req = mutation_skills_update_api_key(key, value, on_mutation_done, ctx);
+        if (!req) skills_request_context_free(ctx);
     } else {
-        req = mutation_skills_update_env(key, env_name, value, on_mutation_done, NULL);
+        SkillsRequestContext *ctx = skills_request_context_new();
+        req = mutation_skills_update_env(key, env_name, value, on_mutation_done, ctx);
+        if (!req) skills_request_context_free(ctx);
     }
     
     if (!req && skills_status_label) {
@@ -169,6 +211,7 @@ static void on_set_env(GtkButton *btn, gpointer user_data) {
     g_object_set_data_full(G_OBJECT(dialog), "env-name", g_strdup(env_name), g_free);
     g_object_set_data(G_OBJECT(dialog), "env-entry", entry);
     g_object_set_data(G_OBJECT(dialog), "is-api-key", GINT_TO_POINTER(is_api_key));
+    g_object_set_data(G_OBJECT(dialog), "skills-generation", GUINT_TO_POINTER(skills_generation));
 
     GtkWidget *toplevel = GTK_WIDGET(gtk_widget_get_root(GTK_WIDGET(btn)));
     adw_alert_dialog_choose(dialog, toplevel, NULL,
@@ -427,15 +470,21 @@ static void skills_rebuild_list(void) {
 /* ── RPC callback ────────────────────────────────────────────────── */
 
 static void on_skills_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    SkillsRequestContext *ctx = (SkillsRequestContext *)user_data;
+    if (skills_request_context_is_stale(ctx)) {
+        skills_request_context_free(ctx);
+        return;
+    }
+    skills_request_context_free(ctx);
+
     skills_fetch_in_flight = FALSE;
 
     if (!skills_list_box) return;
 
-    if (!response->ok) {
+    if (!response || !response->ok) {
         if (skills_status_label) {
             g_autofree gchar *msg = g_strdup_printf("Error: %s",
-                response->error_msg ? response->error_msg : "unknown");
+                response && response->error_msg ? response->error_msg : "unknown");
             gtk_label_set_text(GTK_LABEL(skills_status_label), msg);
         }
         return;
@@ -475,9 +524,11 @@ static void skills_force_refresh(void) {
     if (!gateway_rpc_is_ready()) return;
 
     skills_fetch_in_flight = TRUE;
+    SkillsRequestContext *ctx = skills_request_context_new();
     g_autofree gchar *req_id = gateway_rpc_request(
-        "skills.status", NULL, 0, on_skills_rpc_response, NULL);
+        "skills.status", NULL, 0, on_skills_rpc_response, ctx);
     if (!req_id) {
+        skills_request_context_free(ctx);
         skills_fetch_in_flight = FALSE;
     }
 }
@@ -511,12 +562,14 @@ static GtkWidget* skills_build(void) {
     gtk_widget_set_hexpand(title, TRUE);
     gtk_box_append(GTK_BOX(hdr), title);
 
-    GtkStringList *filter_model = gtk_string_list_new((const char * const[]){
+    GtkStringList *new_filter_model = gtk_string_list_new((const char * const[]){
         "All", "Ready", "Needs Setup", "Disabled", NULL
     });
     skills_filter_dropdown = adw_combo_row_new();
-    adw_combo_row_set_model(ADW_COMBO_ROW(skills_filter_dropdown), G_LIST_MODEL(filter_model));
-    adw_combo_row_set_selected(ADW_COMBO_ROW(skills_filter_dropdown), current_filter);
+    ui_combo_row_replace_model(skills_filter_dropdown,
+                               (gpointer *)&skills_filter_model,
+                               G_LIST_MODEL(new_filter_model),
+                               current_filter);
     g_signal_connect(skills_filter_dropdown, "notify::selected", G_CALLBACK(on_filter_changed), NULL);
     gtk_widget_set_valign(skills_filter_dropdown, GTK_ALIGN_CENTER);
     gtk_box_append(GTK_BOX(hdr), skills_filter_dropdown);
@@ -549,9 +602,11 @@ static void skills_refresh(void) {
     if (!section_is_stale(&skills_last_fetch_us)) return;
 
     skills_fetch_in_flight = TRUE;
+    SkillsRequestContext *ctx = skills_request_context_new();
     g_autofree gchar *req_id = gateway_rpc_request(
-        "skills.status", NULL, 0, on_skills_rpc_response, NULL);
+        "skills.status", NULL, 0, on_skills_rpc_response, ctx);
     if (!req_id) {
+        skills_request_context_free(ctx);
         skills_fetch_in_flight = FALSE;
         if (skills_status_label)
             gtk_label_set_text(GTK_LABEL(skills_status_label), "Failed to send request");
@@ -559,9 +614,13 @@ static void skills_refresh(void) {
 }
 
 static void skills_destroy(void) {
+    skills_generation++;
+
     skills_list_box = NULL;
     skills_status_label = NULL;
+    ui_combo_row_detach_model(skills_filter_dropdown, (gpointer *)&skills_filter_model);
     skills_filter_dropdown = NULL;
+    skills_filter_model = NULL;
     skills_fetch_in_flight = FALSE;
     gateway_skills_data_free(skills_data_cache);
     skills_data_cache = NULL;

--- a/apps/linux/src/section_usage.c
+++ b/apps/linux/src/section_usage.c
@@ -11,17 +11,38 @@
 #include "format_utils.h"
 #include "gateway_rpc.h"
 #include "json_access.h"
+#include "ui_model_utils.h"
 
 static GtkWidget *usage_status_label = NULL;
 static GtkWidget *usage_summary_label = NULL;
 static GtkWidget *usage_cost_label = NULL;
 static GtkWidget *usage_retros_box = NULL;
 static GtkWidget *usage_days_dropdown = NULL;
+static GtkStringList *usage_days_model = NULL;
 
 static gboolean usage_fetch_in_flight = FALSE;
 static gint64 usage_last_fetch_us = 0;
+static guint usage_generation = 1;
 
 static gint usage_selected_days = 30;
+
+typedef struct {
+    guint generation;
+} UsageRequestContext;
+
+static UsageRequestContext* usage_request_context_new(void) {
+    UsageRequestContext *ctx = g_new0(UsageRequestContext, 1);
+    ctx->generation = usage_generation;
+    return ctx;
+}
+
+static gboolean usage_request_context_is_stale(const UsageRequestContext *ctx) {
+    return !ctx || ctx->generation != usage_generation;
+}
+
+static void usage_request_context_free(gpointer data) {
+    g_free(data);
+}
 
 static void usage_clear_retros(void) {
     if (!usage_retros_box) return;
@@ -39,10 +60,16 @@ static void usage_add_retros_line(const gchar *text) {
 static void usage_request_sessions_usage(void);
 
 static void on_usage_sessions_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    UsageRequestContext *ctx = (UsageRequestContext *)user_data;
+    if (usage_request_context_is_stale(ctx)) {
+        usage_request_context_free(ctx);
+        return;
+    }
+    usage_request_context_free(ctx);
+
     usage_clear_retros();
 
-    if (!response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
+    if (!response || !response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
         usage_add_retros_line("Failed to load session usage details.");
         return;
     }
@@ -107,20 +134,27 @@ static void usage_request_sessions_usage(void) {
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
+    UsageRequestContext *ctx = usage_request_context_new();
     g_autofree gchar *rid = gateway_rpc_request("sessions.usage", params, 0,
-                                                on_usage_sessions_response, NULL);
+                                                on_usage_sessions_response, ctx);
     json_node_unref(params);
     if (!rid) {
+        usage_request_context_free(ctx);
         usage_add_retros_line("Failed to request sessions.usage.");
     }
 }
 
 static void on_usage_cost_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    UsageRequestContext *ctx = (UsageRequestContext *)user_data;
+    if (usage_request_context_is_stale(ctx)) {
+        usage_request_context_free(ctx);
+        return;
+    }
+    usage_request_context_free(ctx);
 
     if (!usage_cost_label) return;
 
-    if (!response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
+    if (!response || !response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
         gtk_label_set_text(GTK_LABEL(usage_cost_label), "Cost: unavailable");
         usage_request_sessions_usage();
         return;
@@ -153,12 +187,18 @@ static void on_usage_cost_response(const GatewayRpcResponse *response, gpointer 
 }
 
 static void on_usage_status_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    UsageRequestContext *ctx = (UsageRequestContext *)user_data;
+    if (usage_request_context_is_stale(ctx)) {
+        usage_request_context_free(ctx);
+        return;
+    }
+    usage_request_context_free(ctx);
+
     usage_fetch_in_flight = FALSE;
 
     if (!usage_status_label || !usage_summary_label) return;
 
-    if (!response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
+    if (!response || !response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
         gtk_label_set_text(GTK_LABEL(usage_status_label), "Failed to load usage status");
         return;
     }
@@ -221,10 +261,12 @@ static void on_usage_status_response(const GatewayRpcResponse *response, gpointe
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
+    UsageRequestContext *cost_ctx = usage_request_context_new();
     g_autofree gchar *rid = gateway_rpc_request("usage.cost", params, 0,
-                                                on_usage_cost_response, NULL);
+                                                on_usage_cost_response, cost_ctx);
     json_node_unref(params);
     if (!rid) {
+        usage_request_context_free(cost_ctx);
         gtk_label_set_text(GTK_LABEL(usage_cost_label), "Cost: unavailable");
         usage_request_sessions_usage();
     }
@@ -267,13 +309,12 @@ static GtkWidget* usage_build(void) {
     gtk_label_set_xalign(GTK_LABEL(usage_cost_label), 0.0);
     gtk_box_append(GTK_BOX(page), usage_cost_label);
 
-    GtkStringList *days_model = gtk_string_list_new((const char*[]){"7 days", "14 days", "30 days", NULL});
-    usage_days_dropdown = gtk_drop_down_new(G_LIST_MODEL(days_model), NULL);
+    usage_days_model = gtk_string_list_new((const char*[]){"7 days", "14 days", "30 days", NULL});
+    usage_days_dropdown = gtk_drop_down_new(G_LIST_MODEL(usage_days_model), NULL);
     gtk_drop_down_set_selected(GTK_DROP_DOWN(usage_days_dropdown), 2);
     g_signal_connect(usage_days_dropdown, "notify::selected",
                      G_CALLBACK(on_usage_days_changed), NULL);
     gtk_box_append(GTK_BOX(page), usage_days_dropdown);
-    g_object_unref(days_model);
 
     GtkWidget *retros_title = gtk_label_new("Session Usage (Top 10)");
     gtk_widget_add_css_class(retros_title, "heading");
@@ -299,20 +340,26 @@ static void usage_refresh(void) {
     if (!section_is_stale(&usage_last_fetch_us)) return;
 
     usage_fetch_in_flight = TRUE;
+    UsageRequestContext *ctx = usage_request_context_new();
     g_autofree gchar *rid = gateway_rpc_request("usage.status", NULL, 0,
-                                                on_usage_status_response, NULL);
+                                                on_usage_status_response, ctx);
     if (!rid) {
+        usage_request_context_free(ctx);
         usage_fetch_in_flight = FALSE;
         gtk_label_set_text(GTK_LABEL(usage_status_label), "Failed to request usage.status");
     }
 }
 
 static void usage_destroy(void) {
+    usage_generation++;
+
     usage_status_label = NULL;
     usage_summary_label = NULL;
     usage_cost_label = NULL;
     usage_retros_box = NULL;
+    ui_dropdown_detach_model(usage_days_dropdown, (gpointer *)&usage_days_model);
     usage_days_dropdown = NULL;
+    usage_days_model = NULL;
     usage_fetch_in_flight = FALSE;
     usage_last_fetch_us = 0;
     usage_selected_days = 30;

--- a/apps/linux/src/section_workflows.c
+++ b/apps/linux/src/section_workflows.c
@@ -16,6 +16,25 @@ static GtkWidget *workflows_status_label = NULL;
 static GtkWidget *workflows_list_box = NULL;
 static gboolean workflows_fetch_in_flight = FALSE;
 static gint64 workflows_last_fetch_us = 0;
+static guint workflows_generation = 1;
+
+typedef struct {
+    guint generation;
+} WorkflowsRequestContext;
+
+static WorkflowsRequestContext* workflows_request_context_new(void) {
+    WorkflowsRequestContext *ctx = g_new0(WorkflowsRequestContext, 1);
+    ctx->generation = workflows_generation;
+    return ctx;
+}
+
+static gboolean workflows_request_context_is_stale(const WorkflowsRequestContext *ctx) {
+    return !ctx || ctx->generation != workflows_generation;
+}
+
+static void workflows_request_context_free(gpointer data) {
+    g_free(data);
+}
 
 static void workflows_clear(void) {
     if (!workflows_list_box) return;
@@ -97,14 +116,20 @@ static void workflows_render_from_config(const GatewayConfigSnapshot *cfg) {
 }
 
 static void on_workflows_response(const GatewayRpcResponse *response, gpointer user_data) {
-    (void)user_data;
+    WorkflowsRequestContext *ctx = (WorkflowsRequestContext *)user_data;
+    if (workflows_request_context_is_stale(ctx)) {
+        workflows_request_context_free(ctx);
+        return;
+    }
+    workflows_request_context_free(ctx);
+
     workflows_fetch_in_flight = FALSE;
 
     if (!workflows_status_label) return;
 
     workflows_clear();
 
-    if (!response->ok || !response->payload) {
+    if (!response || !response->ok || !response->payload) {
         gtk_label_set_text(GTK_LABEL(workflows_status_label), "Failed to load config.get");
         workflows_add_line("Unable to inspect bindings from gateway config.", TRUE);
         return;
@@ -155,15 +180,19 @@ static void workflows_refresh(void) {
     if (!section_is_stale(&workflows_last_fetch_us)) return;
 
     workflows_fetch_in_flight = TRUE;
+    WorkflowsRequestContext *ctx = workflows_request_context_new();
     g_autofree gchar *rid = gateway_rpc_request("config.get", NULL, 0,
-                                                on_workflows_response, NULL);
+                                                on_workflows_response, ctx);
     if (!rid) {
+        workflows_request_context_free(ctx);
         workflows_fetch_in_flight = FALSE;
         gtk_label_set_text(GTK_LABEL(workflows_status_label), "Failed to request config.get");
     }
 }
 
 static void workflows_destroy(void) {
+    workflows_generation++;
+
     workflows_status_label = NULL;
     workflows_list_box = NULL;
     workflows_fetch_in_flight = FALSE;

--- a/apps/linux/src/state.c
+++ b/apps/linux/src/state.c
@@ -27,6 +27,18 @@ static AppState current_state = STATE_NEEDS_SETUP;
 static RuntimeMode current_runtime_mode = RUNTIME_NONE;
 static SystemdState current_sys_state = {0};
 static HealthState current_health_state = {0};
+static DesktopReadinessSnapshot current_readiness_snapshot = {0};
+
+typedef struct {
+    gboolean models_fetch_succeeded;
+    guint models_count;
+    gboolean selected_model_resolved;
+    gboolean agents_fetch_succeeded;
+    guint agents_count;
+} DesktopResolvedFacts;
+
+static DesktopResolvedFacts current_resolved_facts = {0};
+
 static guint64 current_health_generation = 0;
 static gboolean initial_hydration_done = FALSE;
 static gboolean initial_refresh_fired = FALSE;
@@ -45,7 +57,81 @@ static gboolean config_requires_onboarding(const HealthState *health) {
     if (!health || !health->config_valid) {
         return FALSE;
     }
+
     return !health->has_wizard_onboard_marker;
+}
+
+static void recompute_resolved_health_fields(void) {
+    const gboolean has_health_data = (current_health_state.last_updated > 0);
+    const gboolean provider_configured = has_health_data && current_health_state.has_provider_config;
+    const gboolean default_model_configured = has_health_data && current_health_state.has_default_model_config;
+
+    current_health_state.model_catalog_available =
+        provider_configured &&
+        current_resolved_facts.models_fetch_succeeded &&
+        current_resolved_facts.models_count > 0;
+
+    current_health_state.selected_model_resolved =
+        default_model_configured &&
+        current_health_state.model_catalog_available &&
+        current_resolved_facts.selected_model_resolved;
+
+    current_health_state.agents_available =
+        current_resolved_facts.agents_fetch_succeeded &&
+        current_resolved_facts.agents_count > 0;
+}
+
+static void compute_readiness_snapshot(void) {
+    DesktopReadinessSnapshot snap = {0};
+
+    const gboolean has_health_data = (current_health_state.last_updated > 0);
+    const gboolean has_setup = has_health_data && current_health_state.setup_detected;
+
+    snap.config_present = has_setup;
+    snap.config_valid = has_health_data && current_health_state.config_valid;
+    snap.wizard_completed = snap.config_valid && current_health_state.has_wizard_onboard_marker;
+    snap.service_installed = current_sys_state.installed;
+    snap.service_active = current_sys_state.active;
+    snap.gateway_http_ok = has_health_data && current_health_state.http_ok;
+    snap.gateway_ws_ok = has_health_data && current_health_state.ws_connected;
+    snap.gateway_rpc_ok = has_health_data && current_health_state.rpc_ok;
+    snap.gateway_auth_ok = has_health_data && current_health_state.auth_ok;
+    snap.provider_configured = has_health_data && current_health_state.has_provider_config;
+    snap.default_model_configured = has_health_data && current_health_state.has_default_model_config;
+    snap.model_catalog_available = has_health_data && current_health_state.model_catalog_available;
+    snap.selected_model_resolved = has_health_data && current_health_state.selected_model_resolved;
+    snap.agents_available = has_health_data && current_health_state.agents_available;
+    snap.desktop_chat_ready = FALSE;
+    snap.chat_block_reason = CHAT_BLOCK_UNKNOWN;
+
+    if (!snap.config_present) {
+        snap.chat_block_reason = CHAT_BLOCK_NO_CONFIG;
+    } else if (!snap.config_valid) {
+        snap.chat_block_reason = CHAT_BLOCK_CONFIG_INVALID;
+    } else if (!snap.wizard_completed) {
+        snap.chat_block_reason = CHAT_BLOCK_BOOTSTRAP_INCOMPLETE;
+    } else if (!snap.service_active) {
+        snap.chat_block_reason = CHAT_BLOCK_SERVICE_INACTIVE;
+    } else if (!snap.gateway_http_ok || !snap.gateway_ws_ok || !snap.gateway_rpc_ok) {
+        snap.chat_block_reason = CHAT_BLOCK_GATEWAY_UNREACHABLE;
+    } else if (!snap.gateway_auth_ok) {
+        snap.chat_block_reason = CHAT_BLOCK_AUTH_INVALID;
+    } else if (!snap.provider_configured) {
+        snap.chat_block_reason = CHAT_BLOCK_PROVIDER_MISSING;
+    } else if (!snap.default_model_configured) {
+        snap.chat_block_reason = CHAT_BLOCK_DEFAULT_MODEL_MISSING;
+    } else if (!snap.model_catalog_available) {
+        snap.chat_block_reason = CHAT_BLOCK_MODEL_CATALOG_EMPTY;
+    } else if (!snap.selected_model_resolved) {
+        snap.chat_block_reason = CHAT_BLOCK_SELECTED_MODEL_UNRESOLVED;
+    } else if (!snap.agents_available) {
+        snap.chat_block_reason = CHAT_BLOCK_AGENTS_UNAVAILABLE;
+    } else {
+        snap.chat_block_reason = CHAT_BLOCK_NONE;
+        snap.desktop_chat_ready = TRUE;
+    }
+
+    current_readiness_snapshot = snap;
 }
 
 gboolean state_connection_transition_step(GatewayConnectionTransitionTracker *tracker,
@@ -169,10 +255,13 @@ static AppState compute_state(void) {
 void state_init(void) {
     current_state = STATE_NEEDS_SETUP;
     current_runtime_mode = RUNTIME_NONE;
+    memset(&current_readiness_snapshot, 0, sizeof(current_readiness_snapshot));
+    current_readiness_snapshot.chat_block_reason = CHAT_BLOCK_UNKNOWN;
     initial_hydration_done = FALSE;
     initial_refresh_fired = FALSE;
     connection_transition_tracker.initialized = FALSE;
     connection_transition_tracker.connected = FALSE;
+    memset(&current_resolved_facts, 0, sizeof(current_resolved_facts));
 
     g_free(current_sys_state.active_state);
     g_free(current_sys_state.sub_state);
@@ -252,6 +341,7 @@ void health_state_clear(HealthState *hs) {
     g_free(hs->gateway_version);
     g_free(hs->auth_source);
     g_free(hs->last_error);
+    g_free(hs->configured_default_model_id);
     g_free(hs->wizard_last_run_command);
     g_free(hs->wizard_last_run_at);
     g_free(hs->wizard_last_run_mode);
@@ -291,6 +381,7 @@ void state_update_systemd(const SystemdState *sys_state) {
 
     AppState new_state = compute_state();
     current_runtime_mode = runtime_mode_compute(&current_sys_state, &current_health_state);
+    compute_readiness_snapshot();
 
     gboolean should_trigger_refresh = (!initial_refresh_fired || became_active || became_inactive || unit_changed);
     if (should_trigger_refresh) {
@@ -308,6 +399,8 @@ void state_update_health(const HealthState *health_state) {
     current_health_state.config_audit_ok = health_state->config_audit_ok;
     current_health_state.config_issues_count = health_state->config_issues_count;
     current_health_state.has_model_config = health_state->has_model_config;
+    current_health_state.has_provider_config = health_state->has_provider_config;
+    current_health_state.has_default_model_config = health_state->has_default_model_config;
 
     /* Feature B: Wizard onboard marker fields */
     current_health_state.has_wizard_onboard_marker = health_state->has_wizard_onboard_marker;
@@ -317,6 +410,7 @@ void state_update_health(const HealthState *health_state) {
     g_free(current_health_state.gateway_version);
     g_free(current_health_state.auth_source);
     g_free(current_health_state.last_error);
+    g_free(current_health_state.configured_default_model_id);
     g_free(current_health_state.wizard_last_run_command);
     g_free(current_health_state.wizard_last_run_at);
     g_free(current_health_state.wizard_last_run_mode);
@@ -326,6 +420,7 @@ void state_update_health(const HealthState *health_state) {
     current_health_state.gateway_version = g_strdup(health_state->gateway_version);
     current_health_state.auth_source = g_strdup(health_state->auth_source);
     current_health_state.last_error = g_strdup(health_state->last_error);
+    current_health_state.configured_default_model_id = g_strdup(health_state->configured_default_model_id);
     current_health_state.wizard_last_run_command = g_strdup(health_state->wizard_last_run_command);
     current_health_state.wizard_last_run_at = g_strdup(health_state->wizard_last_run_at);
     current_health_state.wizard_last_run_mode = g_strdup(health_state->wizard_last_run_mode);
@@ -339,12 +434,61 @@ void state_update_health(const HealthState *health_state) {
     current_health_state.rpc_ok = health_state->rpc_ok;
     current_health_state.auth_ok = health_state->auth_ok;
 
+    if (health_state->model_catalog_available) {
+        current_resolved_facts.models_fetch_succeeded = TRUE;
+        if (current_resolved_facts.models_count == 0) {
+            current_resolved_facts.models_count = 1;
+        }
+    }
+    if (health_state->selected_model_resolved) {
+        current_resolved_facts.selected_model_resolved = TRUE;
+    }
+    if (health_state->agents_available) {
+        current_resolved_facts.agents_fetch_succeeded = TRUE;
+        if (current_resolved_facts.agents_count == 0) {
+            current_resolved_facts.agents_count = 1;
+        }
+    }
+
+    recompute_resolved_health_fields();
+
     current_health_generation++;
     OC_LOG_INFO(OPENCLAW_LOG_CAT_STATE, "health updated: gen=%" G_GUINT64_FORMAT " ok=%d ws=%d",
               current_health_generation, health_state->http_ok, health_state->ws_connected);
     AppState new_state = compute_state();
     current_runtime_mode = runtime_mode_compute(&current_sys_state, &current_health_state);
+    compute_readiness_snapshot();
     trigger_updates(new_state);
+}
+
+void state_set_model_catalog_fact(gboolean fetch_succeeded,
+                                  guint model_count,
+                                  gboolean selected_model_resolved) {
+    current_resolved_facts.models_fetch_succeeded = fetch_succeeded;
+    current_resolved_facts.models_count = fetch_succeeded ? model_count : 0;
+    current_resolved_facts.selected_model_resolved =
+        fetch_succeeded && model_count > 0 && selected_model_resolved;
+
+    recompute_resolved_health_fields();
+    compute_readiness_snapshot();
+    trigger_updates(current_state);
+}
+
+void state_set_agents_fact(gboolean fetch_succeeded,
+                           guint agent_count) {
+    current_resolved_facts.agents_fetch_succeeded = fetch_succeeded;
+    current_resolved_facts.agents_count = fetch_succeeded ? agent_count : 0;
+
+    recompute_resolved_health_fields();
+    compute_readiness_snapshot();
+    trigger_updates(current_state);
+}
+
+void state_reset_resolved_facts(void) {
+    memset(&current_resolved_facts, 0, sizeof(current_resolved_facts));
+    recompute_resolved_health_fields();
+    compute_readiness_snapshot();
+    trigger_updates(current_state);
 }
 
 AppState state_get_current(void) {
@@ -384,4 +528,8 @@ guint64 state_get_health_generation(void) {
 
 HealthState* state_get_health(void) {
     return &current_health_state;
+}
+
+const DesktopReadinessSnapshot* state_get_readiness_snapshot(void) {
+    return &current_readiness_snapshot;
 }

--- a/apps/linux/src/state.h
+++ b/apps/linux/src/state.h
@@ -81,6 +81,12 @@ typedef struct {
     int config_issues_count;
 
     gboolean has_model_config; /* diagnostic only: config has model/provider for runtime */
+    gboolean has_provider_config;
+    gboolean has_default_model_config;
+    gchar *configured_default_model_id;
+    gboolean model_catalog_available;
+    gboolean selected_model_resolved;
+    gboolean agents_available;
 
     /* Feature B: Wizard onboard marker fields */
     gboolean has_wizard_onboard_marker;
@@ -121,10 +127,51 @@ typedef struct {
     gboolean connected;
 } GatewayConnectionTransitionTracker;
 
+typedef enum {
+    CHAT_BLOCK_NONE = 0,
+    CHAT_BLOCK_NO_CONFIG,
+    CHAT_BLOCK_CONFIG_INVALID,
+    CHAT_BLOCK_BOOTSTRAP_INCOMPLETE,
+    CHAT_BLOCK_SERVICE_INACTIVE,
+    CHAT_BLOCK_GATEWAY_UNREACHABLE,
+    CHAT_BLOCK_AUTH_INVALID,
+    CHAT_BLOCK_PROVIDER_MISSING,
+    CHAT_BLOCK_DEFAULT_MODEL_MISSING,
+    CHAT_BLOCK_MODEL_CATALOG_EMPTY,
+    CHAT_BLOCK_SELECTED_MODEL_UNRESOLVED,
+    CHAT_BLOCK_AGENTS_UNAVAILABLE,
+    CHAT_BLOCK_UNKNOWN,
+} ChatBlockReason;
+
+typedef struct {
+    gboolean config_present;
+    gboolean config_valid;
+    gboolean wizard_completed;
+    gboolean service_installed;
+    gboolean service_active;
+    gboolean gateway_http_ok;
+    gboolean gateway_ws_ok;
+    gboolean gateway_rpc_ok;
+    gboolean gateway_auth_ok;
+    gboolean provider_configured;
+    gboolean default_model_configured;
+    gboolean model_catalog_available;
+    gboolean selected_model_resolved;
+    gboolean agents_available;
+    gboolean desktop_chat_ready;
+    ChatBlockReason chat_block_reason;
+} DesktopReadinessSnapshot;
+
 void state_init(void);
 void health_state_clear(HealthState *hs);
 void state_update_systemd(const SystemdState *sys_state);
 void state_update_health(const HealthState *health_state);
+void state_set_model_catalog_fact(gboolean fetch_succeeded,
+                                  guint model_count,
+                                  gboolean selected_model_resolved);
+void state_set_agents_fact(gboolean fetch_succeeded,
+                           guint agent_count);
+void state_reset_resolved_facts(void);
 
 AppState state_get_current(void);
 const char* state_get_current_string(void);
@@ -136,6 +183,7 @@ void runtime_mode_describe(RuntimeMode mode, RuntimeModePresentation *out);
 gboolean state_connection_transition_step(GatewayConnectionTransitionTracker *tracker,
                                           gboolean connected_now,
                                           gboolean *out_connected_now);
+const DesktopReadinessSnapshot* state_get_readiness_snapshot(void);
 
 SystemdState* state_get_systemd(void);
 HealthState* state_get_health(void);

--- a/apps/linux/src/test_seams.c
+++ b/apps/linux/src/test_seams.c
@@ -139,3 +139,16 @@ gchar* find_nearest_existing_ancestor(const gchar *path) {
     g_free(current);
     return NULL;
 }
+
+/* ── Tray dispatch decisions (from tray.c) ────────────────────────── */
+
+TrayUiAction tray_ui_dispatch_decide(TrayUiRequest request, gboolean onboarding_visible) {
+    (void)onboarding_visible;
+    switch (request) {
+        case TRAY_UI_REQUEST_DIAGNOSTICS:
+            return TRAY_UI_ACTION_SHOW_DIAGNOSTICS;
+        case TRAY_UI_REQUEST_SETTINGS:
+        default:
+            return TRAY_UI_ACTION_SHOW_SETTINGS;
+    }
+}

--- a/apps/linux/src/test_seams.h
+++ b/apps/linux/src/test_seams.h
@@ -62,4 +62,18 @@ gboolean config_monitor_can_skip_rearm(
  */
 gchar* find_nearest_existing_ancestor(const gchar *path);
 
+/* ── Tray dispatch decisions (from tray.c) ────────────────────────── */
+
+typedef enum {
+    TRAY_UI_REQUEST_SETTINGS = 0,
+    TRAY_UI_REQUEST_DIAGNOSTICS = 1,
+} TrayUiRequest;
+
+typedef enum {
+    TRAY_UI_ACTION_SHOW_SETTINGS = 0,
+    TRAY_UI_ACTION_SHOW_DIAGNOSTICS = 1,
+} TrayUiAction;
+
+TrayUiAction tray_ui_dispatch_decide(TrayUiRequest request, gboolean onboarding_visible);
+
 #endif /* TEST_SEAMS_H */

--- a/apps/linux/src/tray.c
+++ b/apps/linux/src/tray.c
@@ -21,6 +21,8 @@
 #include "gateway_client.h"
 #include "gateway_config.h"
 #include "display_model.h"
+#include "onboarding.h"
+#include "test_seams.h"
 
 static GSubprocess *helper_process = NULL;
 static GOutputStream *helper_stdin = NULL;
@@ -51,7 +53,29 @@ extern void systemd_start_gateway(void);
 extern void systemd_stop_gateway(void);
 extern void systemd_restart_gateway(void);
 extern void gateway_client_refresh(void);
-extern void diagnostics_show_window(void);
+
+static void handle_helper_action(const gchar *action);
+
+static void handle_open_settings_request(void) {
+    TrayUiAction action = tray_ui_dispatch_decide(TRAY_UI_REQUEST_SETTINGS, onboarding_is_visible());
+    if (action == TRAY_UI_ACTION_SHOW_SETTINGS) {
+        app_window_show();
+        app_window_navigate_to(SECTION_GENERAL);
+    }
+}
+
+static void handle_open_diagnostics_request(void) {
+    TrayUiAction action = tray_ui_dispatch_decide(TRAY_UI_REQUEST_DIAGNOSTICS, onboarding_is_visible());
+    if (action == TRAY_UI_ACTION_SHOW_DIAGNOSTICS) {
+        app_window_show();
+        app_window_navigate_to(SECTION_DIAGNOSTICS);
+    }
+}
+
+void tray_debug_dispatch_action(const gchar *action) {
+    if (!action) return;
+    handle_helper_action(action);
+}
 
 static void handle_helper_action(const gchar *action) {
     guint seq = ++helper_seq;
@@ -80,7 +104,9 @@ static void handle_helper_action(const gchar *action) {
             }
         }
     } else if (g_strcmp0(action, "OPEN_SETTINGS") == 0) {
-        app_window_navigate_to(SECTION_GENERAL);
+        handle_open_settings_request();
+    } else if (g_strcmp0(action, "OPEN_DIAGNOSTICS") == 0) {
+        handle_open_diagnostics_request();
     } else if (g_strcmp0(action, "QUIT") == 0) {
         GApplication *app = g_application_get_default();
         if (app) g_application_quit(app);

--- a/apps/linux/src/tray_helper.c
+++ b/apps/linux/src/tray_helper.c
@@ -55,6 +55,7 @@ static GtkWidget *refresh_item = NULL;
 
 /* App navigation */
 static GtkWidget *settings_item = NULL;
+static GtkWidget *diagnostics_item = NULL;
 
 static void send_action(const char *action) {
     g_print("ACTION:%s\n", action);
@@ -68,6 +69,7 @@ static void on_stop_clicked(GtkMenuItem *item, gpointer data) { (void)item; (voi
 static void on_restart_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("RESTART"); }
 static void on_refresh_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("REFRESH"); }
 static void on_settings_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("OPEN_SETTINGS"); }
+static void on_diagnostics_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("OPEN_DIAGNOSTICS"); }
 static void on_quit_clicked(GtkMenuItem *item, gpointer data) { 
     (void)item; (void)data;
     send_action("QUIT"); 
@@ -188,6 +190,10 @@ int main(int argc, char **argv) {
     settings_item = gtk_menu_item_new_with_label("Settings");
     g_signal_connect(settings_item, "activate", G_CALLBACK(on_settings_clicked), NULL);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), settings_item);
+
+    diagnostics_item = gtk_menu_item_new_with_label("Diagnostics");
+    g_signal_connect(diagnostics_item, "activate", G_CALLBACK(on_diagnostics_clicked), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), diagnostics_item);
 
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 

--- a/apps/linux/src/ui_model_utils.c
+++ b/apps/linux/src/ui_model_utils.c
@@ -1,0 +1,70 @@
+/*
+ * ui_model_utils.c
+ *
+ * Shared widget/model lifecycle helpers for GTK drop-downs and
+ * Adwaita combo rows.
+ */
+
+#include "ui_model_utils.h"
+
+gboolean ui_dropdown_replace_model(GtkWidget *dropdown,
+                                   gpointer *model_slot,
+                                   GListModel *new_model,
+                                   guint selected,
+                                   gboolean sensitive)
+{
+    if (!model_slot || !new_model) return FALSE;
+
+    if (dropdown && GTK_IS_DROP_DOWN(dropdown)) {
+        gtk_drop_down_set_model(GTK_DROP_DOWN(dropdown), new_model);
+        gtk_drop_down_set_selected(GTK_DROP_DOWN(dropdown), selected);
+        gtk_widget_set_sensitive(dropdown, sensitive);
+    }
+
+    if (*model_slot && G_IS_OBJECT(*model_slot)) {
+        g_object_unref(*model_slot);
+    }
+    *model_slot = new_model;
+    return TRUE;
+}
+
+void ui_dropdown_detach_model(GtkWidget *dropdown, gpointer *model_slot) {
+    if (dropdown && GTK_IS_DROP_DOWN(dropdown)) {
+        gtk_drop_down_set_model(GTK_DROP_DOWN(dropdown), NULL);
+    }
+
+    if (model_slot && *model_slot && G_IS_OBJECT(*model_slot)) {
+        g_object_unref(*model_slot);
+        *model_slot = NULL;
+    }
+}
+
+gboolean ui_combo_row_replace_model(GtkWidget *combo_row,
+                                    gpointer *model_slot,
+                                    GListModel *new_model,
+                                    guint selected)
+{
+    if (!model_slot || !new_model) return FALSE;
+
+    if (combo_row && ADW_IS_COMBO_ROW(combo_row)) {
+        adw_combo_row_set_model(ADW_COMBO_ROW(combo_row), new_model);
+        adw_combo_row_set_selected(ADW_COMBO_ROW(combo_row), selected);
+    }
+
+    if (*model_slot && G_IS_OBJECT(*model_slot)) {
+        g_object_unref(*model_slot);
+    }
+    *model_slot = new_model;
+    return TRUE;
+}
+
+void ui_combo_row_detach_model(GtkWidget *combo_row, gpointer *model_slot) {
+    if (combo_row && ADW_IS_COMBO_ROW(combo_row)) {
+        adw_combo_row_set_model(ADW_COMBO_ROW(combo_row), NULL);
+    }
+
+    if (model_slot && *model_slot && G_IS_OBJECT(*model_slot)) {
+        g_object_unref(*model_slot);
+        *model_slot = NULL;
+    }
+}

--- a/apps/linux/src/ui_model_utils.h
+++ b/apps/linux/src/ui_model_utils.h
@@ -1,0 +1,26 @@
+/*
+ * ui_model_utils.h
+ *
+ * Shared widget/model lifecycle helpers for GTK drop-downs and
+ * Adwaita combo rows.
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+#include <adwaita.h>
+
+gboolean ui_dropdown_replace_model(GtkWidget *dropdown,
+                                   gpointer *model_slot,
+                                   GListModel *new_model,
+                                   guint selected,
+                                   gboolean sensitive);
+
+void ui_dropdown_detach_model(GtkWidget *dropdown, gpointer *model_slot);
+
+gboolean ui_combo_row_replace_model(GtkWidget *combo_row,
+                                    gpointer *model_slot,
+                                    GListModel *new_model,
+                                    guint selected);
+
+void ui_combo_row_detach_model(GtkWidget *combo_row, gpointer *model_slot);

--- a/apps/linux/tests/test_config.c
+++ b/apps/linux/tests/test_config.c
@@ -10,6 +10,7 @@
 #include <glib/gstdio.h>
 #include <string.h>
 #include "../src/gateway_config.h"
+#include "../src/config_setup_transform.h"
 #include <json-glib/json-glib.h>
 
 /* Mock the gateway_config_load internals for testing just the parsing */
@@ -42,6 +43,203 @@ static void test_wizard_present_valid(void) {
     g_assert_cmpstr(cfg->wizard_last_run_at, ==, "2023-10-27T10:00:00Z");
     g_assert_false(cfg->wizard_is_local);
     
+    gateway_config_free(cfg);
+}
+
+static void test_setup_apply_provider_writes_richer_shape(void) {
+    const gchar *raw = "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},\"models\":{\"providers\":{\"openai\":{\"organization\":\"acme\"}}}}";
+    g_autoptr(GError) err = NULL;
+    g_autofree gchar *updated = config_setup_apply_provider(raw, "openai", "https://api.openai.com/v1", &err);
+    g_assert_no_error(err);
+    g_assert_nonnull(updated);
+
+    g_autoptr(JsonParser) parser = json_parser_new();
+    g_assert_true(json_parser_load_from_data(parser, updated, -1, &err));
+    JsonObject *root = json_node_get_object(json_parser_get_root(parser));
+
+    JsonObject *models = json_node_get_object(json_object_get_member(root, "models"));
+    JsonObject *providers = json_node_get_object(json_object_get_member(models, "providers"));
+    JsonObject *openai = json_node_get_object(json_object_get_member(providers, "openai"));
+    g_assert_cmpstr(json_object_get_string_member(openai, "baseUrl"), ==, "https://api.openai.com/v1");
+    g_assert_cmpstr(json_object_get_string_member(openai, "api"), ==, "openai-responses");
+    g_assert_cmpstr(json_object_get_string_member(openai, "organization"), ==, "acme");
+
+    JsonObject *plugins = json_node_get_object(json_object_get_member(root, "plugins"));
+    JsonObject *entries = json_node_get_object(json_object_get_member(plugins, "entries"));
+    JsonObject *provider_entry = json_node_get_object(json_object_get_member(entries, "openai"));
+    g_assert_true(json_object_get_boolean_member(provider_entry, "enabled"));
+
+    JsonObject *auth = json_node_get_object(json_object_get_member(root, "auth"));
+    JsonObject *profiles = json_node_get_object(json_object_get_member(auth, "profiles"));
+    JsonObject *profile = json_node_get_object(json_object_get_member(profiles, "openai:default"));
+    g_assert_cmpstr(json_object_get_string_member(profile, "provider"), ==, "openai");
+    g_assert_cmpstr(json_object_get_string_member(profile, "mode"), ==, "api_key");
+
+    JsonObject *order = json_node_get_object(json_object_get_member(auth, "order"));
+    JsonArray *openai_order = json_node_get_array(json_object_get_member(order, "openai"));
+    g_assert_cmpuint(json_array_get_length(openai_order), ==, 1);
+    g_assert_cmpstr(json_array_get_string_element(openai_order, 0), ==, "openai:default");
+}
+
+static void test_setup_apply_default_model_writes_models_map(void) {
+    const gchar *raw = "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},\"agents\":{\"defaults\":{\"model\":{\"primary\":\"old/model\"},\"models\":{\"old/model\":{\"temperature\":0.1}}}}}";
+    g_autoptr(GError) err = NULL;
+    g_autofree gchar *updated = config_setup_apply_default_model(raw, "openai", "openai/gpt-4.1", &err);
+    g_assert_no_error(err);
+    g_assert_nonnull(updated);
+
+    g_autoptr(JsonParser) parser = json_parser_new();
+    g_assert_true(json_parser_load_from_data(parser, updated, -1, &err));
+    JsonObject *root = json_node_get_object(json_parser_get_root(parser));
+    JsonObject *agents = json_node_get_object(json_object_get_member(root, "agents"));
+    JsonObject *defaults = json_node_get_object(json_object_get_member(agents, "defaults"));
+    JsonObject *model = json_node_get_object(json_object_get_member(defaults, "model"));
+    JsonObject *models_map = json_node_get_object(json_object_get_member(defaults, "models"));
+
+    g_assert_cmpstr(json_object_get_string_member(model, "primary"), ==, "openai/gpt-4.1");
+    g_assert_cmpstr(json_object_get_string_member(defaults, "modelProvider"), ==, "openai");
+    g_assert_true(json_object_has_member(models_map, "openai/gpt-4.1"));
+    g_assert_true(json_object_has_member(models_map, "old/model"));
+}
+
+static void test_setup_apply_provider_malformed_recoverable(void) {
+    const gchar *raw = "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},\"models\":{\"providers\":\"oops\"},\"plugins\":\"oops\",\"auth\":{\"profiles\":\"oops\"}}";
+    g_autoptr(GError) err = NULL;
+    g_autofree gchar *updated = config_setup_apply_provider(raw, "ollama", "http://127.0.0.1:11434", &err);
+    g_assert_no_error(err);
+    g_assert_nonnull(updated);
+
+    g_autoptr(JsonParser) parser = json_parser_new();
+    g_assert_true(json_parser_load_from_data(parser, updated, -1, &err));
+    JsonObject *root = json_node_get_object(json_parser_get_root(parser));
+
+    JsonObject *models = json_node_get_object(json_object_get_member(root, "models"));
+    JsonObject *providers = json_node_get_object(json_object_get_member(models, "providers"));
+    JsonObject *ollama = json_node_get_object(json_object_get_member(providers, "ollama"));
+    g_assert_cmpstr(json_object_get_string_member(ollama, "baseUrl"), ==, "http://127.0.0.1:11434");
+    g_assert_cmpstr(json_object_get_string_member(ollama, "api"), ==, "ollama");
+    g_assert_cmpstr(json_object_get_string_member(ollama, "apiKey"), ==, "ollama-local");
+
+    JsonObject *plugins = json_node_get_object(json_object_get_member(root, "plugins"));
+    JsonObject *entries = json_node_get_object(json_object_get_member(plugins, "entries"));
+    g_assert_true(json_object_has_member(entries, "ollama"));
+
+    JsonObject *auth = json_node_get_object(json_object_get_member(root, "auth"));
+    JsonObject *profiles = json_node_get_object(json_object_get_member(auth, "profiles"));
+    JsonObject *profile = json_node_get_object(json_object_get_member(profiles, "ollama:default"));
+    g_assert_cmpstr(json_object_get_string_member(profile, "provider"), ==, "ollama");
+    g_assert_cmpstr(json_object_get_string_member(profile, "mode"), ==, "api_key");
+}
+
+static void test_setup_apply_provider_preserves_auth_order(void) {
+    const gchar *raw =
+        "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},"
+        "\"auth\":{\"order\":{\"openai\":[\"openai:work\"]}},"
+        "\"models\":{\"providers\":{\"openai\":{}}}}";
+    g_autoptr(GError) err = NULL;
+    g_autofree gchar *updated = config_setup_apply_provider(raw, "openai", NULL, &err);
+    g_assert_no_error(err);
+    g_assert_nonnull(updated);
+
+    g_autoptr(JsonParser) parser = json_parser_new();
+    g_assert_true(json_parser_load_from_data(parser, updated, -1, &err));
+    JsonObject *root = json_node_get_object(json_parser_get_root(parser));
+
+    JsonObject *auth = json_node_get_object(json_object_get_member(root, "auth"));
+    JsonObject *order = json_node_get_object(json_object_get_member(auth, "order"));
+    JsonArray *openai_order = json_node_get_array(json_object_get_member(order, "openai"));
+    g_assert_cmpuint(json_array_get_length(openai_order), ==, 2);
+    g_assert_cmpstr(json_array_get_string_element(openai_order, 0), ==, "openai:work");
+    g_assert_cmpstr(json_array_get_string_element(openai_order, 1), ==, "openai:default");
+}
+
+static void test_model_config_default_present_provider_malformed(void) {
+    const gchar *json = "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},\"models\":{\"providers\":\"invalid\"},\"agents\":{\"defaults\":{\"model\":{\"primary\":\"openai/gpt-4.1\"}}}}";
+    GatewayConfig *cfg = load_config_from_json(json);
+
+    g_assert_false(cfg->has_provider_config);
+    g_assert_true(cfg->has_default_model_config);
+    g_assert_true(cfg->has_model_config);
+    gateway_config_free(cfg);
+}
+
+static void test_model_config_agents_defaults_model_primary(void) {
+    const gchar *json = "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},\"agents\":{\"defaults\":{\"model\":{\"primary\":\"ollama/gpt-oss:20b\"}}}}";
+    GatewayConfig *cfg = load_config_from_json(json);
+
+    g_assert_true(cfg->has_model_config);
+    g_assert_false(cfg->has_provider_config);
+    g_assert_true(cfg->has_default_model_config);
+    gateway_config_free(cfg);
+}
+
+static void test_model_config_minimal_onboard_false(void) {
+    const gchar *json = "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},\"wizard\":{\"lastRunCommand\":\"onboard\",\"lastRunAt\":\"2026-04-01T10:00:00Z\"}}";
+    GatewayConfig *cfg = load_config_from_json(json);
+
+    g_assert_false(cfg->has_model_config);
+    gateway_config_free(cfg);
+}
+
+static void test_model_config_agents_defaults_models_empty_false(void) {
+    const gchar *json = "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},\"agents\":{\"defaults\":{\"models\":{}}}}";
+    GatewayConfig *cfg = load_config_from_json(json);
+
+    g_assert_false(cfg->has_model_config);
+    gateway_config_free(cfg);
+}
+
+static void test_model_config_root_providers_empty_false(void) {
+    const gchar *json = "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},\"models\":{\"providers\":{}}}";
+    GatewayConfig *cfg = load_config_from_json(json);
+
+    g_assert_false(cfg->has_model_config);
+    gateway_config_free(cfg);
+}
+
+static void test_model_config_agents_defaults_model_malformed_false(void) {
+    const gchar *json = "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},\"agents\":{\"defaults\":{\"model\":{\"primary\":42}}}}";
+    GatewayConfig *cfg = load_config_from_json(json);
+
+    g_assert_false(cfg->has_model_config);
+    gateway_config_free(cfg);
+}
+
+static void test_model_config_agents_defaults_models_map(void) {
+    const gchar *json = "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},\"agents\":{\"defaults\":{\"models\":{\"ollama/gpt-oss:20b\":{}}}}}";
+    GatewayConfig *cfg = load_config_from_json(json);
+
+    g_assert_true(cfg->has_model_config);
+    gateway_config_free(cfg);
+}
+
+static void test_model_config_root_models_providers(void) {
+    const gchar *json = "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},\"models\":{\"providers\":{\"ollama\":{\"baseUrl\":\"http://127.0.0.1:11434\"}}}}";
+    GatewayConfig *cfg = load_config_from_json(json);
+
+    g_assert_true(cfg->has_model_config);
+    g_assert_true(cfg->has_provider_config);
+    g_assert_false(cfg->has_default_model_config);
+    gateway_config_free(cfg);
+}
+
+static void test_model_config_provider_present_default_absent(void) {
+    const gchar *json = "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},\"models\":{\"providers\":{\"openai\":{\"apiKey\":\"test\"}}},\"agents\":{\"defaults\":{}}}";
+    GatewayConfig *cfg = load_config_from_json(json);
+
+    g_assert_true(cfg->has_provider_config);
+    g_assert_false(cfg->has_default_model_config);
+    g_assert_true(cfg->has_model_config);
+    gateway_config_free(cfg);
+}
+
+static void test_model_config_default_present_provider_absent(void) {
+    const gchar *json = "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},\"agents\":{\"defaults\":{\"model\":{\"primary\":\"openai/gpt-4.1\"}}}}";
+    GatewayConfig *cfg = load_config_from_json(json);
+
+    g_assert_false(cfg->has_provider_config);
+    g_assert_true(cfg->has_default_model_config);
+    g_assert_true(cfg->has_model_config);
     gateway_config_free(cfg);
 }
 
@@ -130,6 +328,21 @@ int main(int argc, char **argv) {
     g_test_add_func("/config/wizard/remote_mode", test_wizard_remote_mode);
     g_test_add_func("/config/wizard/absent_model_present", test_wizard_absent_model_present);
     g_test_add_func("/config/wizard/empty_last_run_at", test_wizard_empty_last_run_at);
+    g_test_add_func("/config/model/agents_defaults_model_primary", test_model_config_agents_defaults_model_primary);
+    g_test_add_func("/config/model/agents_defaults_models_map", test_model_config_agents_defaults_models_map);
+    g_test_add_func("/config/model/root_models_providers", test_model_config_root_models_providers);
+    g_test_add_func("/config/model/provider_present_default_absent", test_model_config_provider_present_default_absent);
+    g_test_add_func("/config/model/default_present_provider_absent", test_model_config_default_present_provider_absent);
+    g_test_add_func("/config/model/default_present_provider_malformed", test_model_config_default_present_provider_malformed);
+    g_test_add_func("/config/setup/apply_provider_richer", test_setup_apply_provider_writes_richer_shape);
+    g_test_add_func("/config/setup/apply_default_model", test_setup_apply_default_model_writes_models_map);
+    g_test_add_func("/config/setup/apply_provider_malformed_recoverable", test_setup_apply_provider_malformed_recoverable);
+    g_test_add_func("/config/setup/apply_provider_preserves_auth_order", test_setup_apply_provider_preserves_auth_order);
+    g_test_add_func("/config/readiness/model_config_default_present_provider_malformed", test_model_config_default_present_provider_malformed);
+    g_test_add_func("/config/model/agents_defaults_models_empty_false", test_model_config_agents_defaults_models_empty_false);
+    g_test_add_func("/config/model/root_providers_empty_false", test_model_config_root_providers_empty_false);
+    g_test_add_func("/config/model/agents_defaults_model_malformed_false", test_model_config_agents_defaults_model_malformed_false);
+    g_test_add_func("/config/model/minimal_onboard_false", test_model_config_minimal_onboard_false);
 
     return g_test_run();
 }

--- a/apps/linux/tests/test_display_model.c
+++ b/apps/linux/tests/test_display_model.c
@@ -382,7 +382,7 @@ static void test_env_all_ok(void) {
     /* Use /tmp as a writable dir and /dev/null as a readable file */
     environment_check_build(&sys, "/dev/null", "/tmp", &ecr);
 
-    g_assert_cmpint(ecr.count, >=, 7);
+    g_assert_cmpint(ecr.count, >=, 8);
     /* systemd session */
     g_assert_true(ecr.rows[0].passed);
     /* D-Bus */
@@ -391,12 +391,16 @@ static void test_env_all_ok(void) {
     g_assert_true(ecr.rows[2].passed);
     /* Config exists */
     g_assert_true(ecr.rows[3].passed);
-    /* State dir resolved */
+    /* Config dir exists */
     g_assert_true(ecr.rows[4].passed);
-    /* State dir exists */
+    /* State dir resolved */
     g_assert_true(ecr.rows[5].passed);
-    /* Unit present */
+    /* State dir exists */
     g_assert_true(ecr.rows[6].passed);
+    /* Unit present */
+    g_assert_true(ecr.rows[7].passed);
+
+    environment_check_result_clear(&ecr);
 }
 
 static void test_env_systemd_unavailable(void) {
@@ -408,6 +412,8 @@ static void test_env_systemd_unavailable(void) {
 
     g_assert_false(ecr.rows[0].passed); /* systemd */
     g_assert_false(ecr.rows[1].passed); /* D-Bus */
+
+    environment_check_result_clear(&ecr);
 }
 
 static void test_env_no_config_path(void) {
@@ -417,13 +423,17 @@ static void test_env_no_config_path(void) {
 
     g_assert_false(ecr.rows[2].passed); /* config path resolved */
     g_assert_false(ecr.rows[3].passed); /* config exists */
-    g_assert_false(ecr.rows[4].passed); /* state dir resolved */
-    g_assert_false(ecr.rows[5].passed); /* state dir exists */
+    g_assert_false(ecr.rows[4].passed); /* config dir exists */
+    g_assert_false(ecr.rows[5].passed); /* state dir resolved */
+    g_assert_false(ecr.rows[6].passed); /* state dir exists */
 
     g_assert_cmpstr(ecr.rows[2].detail, ==, "No config path resolved.");
     g_assert_cmpstr(ecr.rows[3].detail, ==, "No (path unresolved)");
-    g_assert_cmpstr(ecr.rows[4].detail, ==, "No state directory resolved.");
-    g_assert_cmpstr(ecr.rows[5].detail, ==, "No (path unresolved)");
+    g_assert_cmpstr(ecr.rows[4].detail, ==, "No (path unresolved)");
+    g_assert_cmpstr(ecr.rows[5].detail, ==, "No state directory resolved.");
+    g_assert_cmpstr(ecr.rows[6].detail, ==, "No (path unresolved)");
+
+    environment_check_result_clear(&ecr);
 }
 
 static void test_env_resolved_but_missing_targets(void) {
@@ -437,8 +447,63 @@ static void test_env_resolved_but_missing_targets(void) {
 
     g_assert_true(ecr.rows[2].passed);  /* config path resolved */
     g_assert_false(ecr.rows[3].passed); /* config exists */
-    g_assert_true(ecr.rows[4].passed);  /* state dir resolved */
-    g_assert_false(ecr.rows[5].passed); /* state dir exists */
+    g_assert_true(ecr.rows[4].passed);  /* config dir exists */
+    g_assert_true(ecr.rows[5].passed);  /* state dir resolved */
+    g_assert_false(ecr.rows[6].passed); /* state dir exists */
+
+    environment_check_result_clear(&ecr);
+}
+
+static void test_runtime_path_status_uses_loaded_path_precedence(void) {
+    RuntimePathStatus status = {0};
+    runtime_path_status_build("/tmp/runtime-config.json",
+                              "/tmp/state-dir",
+                              "/tmp/loaded-config.json",
+                              &status);
+
+    g_assert_true(status.config_path_resolved);
+    g_assert_cmpstr(status.config_path, ==, "/tmp/loaded-config.json");
+    g_assert_true(status.state_dir_resolved);
+    g_assert_cmpstr(status.state_dir, ==, "/tmp/state-dir");
+    runtime_path_status_clear(&status);
+}
+
+static void test_runtime_path_status_derives_state_dir_from_config(void) {
+    RuntimePathStatus status = {0};
+    runtime_path_status_build("/tmp/openclaw-test/config.json", NULL, NULL, &status);
+
+    g_assert_true(status.config_path_resolved);
+    g_assert_true(status.state_dir_resolved);
+    g_assert_cmpstr(status.state_dir, ==, "/tmp/openclaw-test");
+    runtime_path_status_clear(&status);
+}
+
+static void test_runtime_path_status_invalid_utf8_paths_are_display_safe(void) {
+    const gchar invalid_path[] = {'/', 't', 'm', 'p', '/', 'x', (gchar)0xFF, '\0'};
+    RuntimePathStatus status = {0};
+    runtime_path_status_build(invalid_path, NULL, NULL, &status);
+
+    g_assert_true(status.config_path_resolved);
+    g_assert_nonnull(status.config_path);
+    g_assert_true(g_utf8_validate(status.config_path, -1, NULL));
+    g_assert_true(status.state_dir_resolved);
+    g_assert_nonnull(status.state_dir);
+    g_assert_true(g_utf8_validate(status.state_dir, -1, NULL));
+
+    runtime_path_status_clear(&status);
+}
+
+static void test_environment_check_result_clear_resets_owned_details(void) {
+    SystemdState sys = {0};
+    EnvironmentCheckResult ecr;
+    environment_check_build(&sys, "/dev/null", "/tmp", &ecr);
+
+    g_assert_cmpint(ecr.count, >, 0);
+    g_assert_nonnull(ecr.rows[0].detail);
+
+    environment_check_result_clear(&ecr);
+    g_assert_cmpint(ecr.count, ==, 0);
+    g_assert_null(ecr.rows[0].detail);
 }
 
 /* ══════════════════════════════════════════════════════════════════
@@ -654,6 +719,10 @@ int main(int argc, char **argv) {
     g_test_add_func("/display_model/env/systemd_unavailable", test_env_systemd_unavailable);
     g_test_add_func("/display_model/env/no_config_path", test_env_no_config_path);
     g_test_add_func("/display_model/env/resolved_but_missing_targets", test_env_resolved_but_missing_targets);
+    g_test_add_func("/display_model/runtime_paths/loaded_path_precedence", test_runtime_path_status_uses_loaded_path_precedence);
+    g_test_add_func("/display_model/runtime_paths/derive_state_dir_from_config", test_runtime_path_status_derives_state_dir_from_config);
+    g_test_add_func("/display_model/runtime_paths/invalid_utf8_display_safe", test_runtime_path_status_invalid_utf8_paths_are_display_safe);
+    g_test_add_func("/display_model/env/result_clear_resets_details", test_environment_check_result_clear_resets_owned_details);
 
     /* Onboarding routing */
     g_test_add_func("/display_model/onboarding/first_run_healthy",

--- a/apps/linux/tests/test_readiness.c
+++ b/apps/linux/tests/test_readiness.c
@@ -397,6 +397,185 @@ static void test_onboarding_progress_operational_ready_only_when_running(void) {
     g_assert_true(progress.operational_ready);
 }
 
+static void test_chat_gate_bootstrap_complete_but_model_missing(void) {
+    DesktopReadinessSnapshot snap = {0};
+    snap.config_present = TRUE;
+    snap.config_valid = TRUE;
+    snap.wizard_completed = TRUE;
+    snap.service_installed = TRUE;
+    snap.service_active = TRUE;
+    snap.gateway_http_ok = TRUE;
+    snap.gateway_ws_ok = TRUE;
+    snap.gateway_rpc_ok = TRUE;
+    snap.gateway_auth_ok = TRUE;
+    snap.provider_configured = TRUE;
+    snap.default_model_configured = FALSE;
+    snap.desktop_chat_ready = FALSE;
+    snap.chat_block_reason = CHAT_BLOCK_DEFAULT_MODEL_MISSING;
+
+    ChatGateInfo gate = {0};
+    readiness_describe_chat_gate(&snap, &gate);
+
+    g_assert_false(gate.ready);
+    g_assert_cmpint(gate.reason, ==, CHAT_BLOCK_DEFAULT_MODEL_MISSING);
+    assert_contains(gate.status, "default model", "chat_gate_model_missing.status");
+    g_assert_nonnull(gate.next_action);
+    assert_contains(gate.next_action, "default model", "chat_gate_model_missing.next_action");
+}
+
+static void test_chat_gate_provider_missing(void) {
+    DesktopReadinessSnapshot snap = {0};
+    snap.config_present = TRUE;
+    snap.config_valid = TRUE;
+    snap.wizard_completed = TRUE;
+    snap.service_installed = TRUE;
+    snap.service_active = TRUE;
+    snap.gateway_http_ok = TRUE;
+    snap.gateway_ws_ok = TRUE;
+    snap.gateway_rpc_ok = TRUE;
+    snap.gateway_auth_ok = TRUE;
+    snap.provider_configured = FALSE;
+    snap.default_model_configured = FALSE;
+    snap.desktop_chat_ready = FALSE;
+    snap.chat_block_reason = CHAT_BLOCK_PROVIDER_MISSING;
+
+    ChatGateInfo gate = {0};
+    readiness_describe_chat_gate(&snap, &gate);
+
+    g_assert_false(gate.ready);
+    g_assert_cmpint(gate.reason, ==, CHAT_BLOCK_PROVIDER_MISSING);
+    assert_contains(gate.status, "provider", "chat_gate_provider_missing.status");
+    g_assert_nonnull(gate.next_action);
+}
+
+static void test_chat_gate_service_down(void) {
+    DesktopReadinessSnapshot snap = {0};
+    snap.config_present = TRUE;
+    snap.config_valid = TRUE;
+    snap.wizard_completed = TRUE;
+    snap.service_installed = TRUE;
+    snap.service_active = FALSE;
+    snap.desktop_chat_ready = FALSE;
+    snap.chat_block_reason = CHAT_BLOCK_SERVICE_INACTIVE;
+
+    ChatGateInfo gate = {0};
+    readiness_describe_chat_gate(&snap, &gate);
+
+    g_assert_false(gate.ready);
+    g_assert_cmpint(gate.reason, ==, CHAT_BLOCK_SERVICE_INACTIVE);
+    assert_contains(gate.status, "not active", "chat_gate_service_inactive.status");
+}
+
+static void test_chat_gate_catalog_unavailable(void) {
+    DesktopReadinessSnapshot snap = {0};
+    snap.config_present = TRUE;
+    snap.config_valid = TRUE;
+    snap.wizard_completed = TRUE;
+    snap.service_installed = TRUE;
+    snap.service_active = TRUE;
+    snap.gateway_http_ok = TRUE;
+    snap.gateway_ws_ok = TRUE;
+    snap.gateway_rpc_ok = TRUE;
+    snap.gateway_auth_ok = TRUE;
+    snap.provider_configured = TRUE;
+    snap.default_model_configured = TRUE;
+    snap.model_catalog_available = FALSE;
+    snap.selected_model_resolved = FALSE;
+    snap.desktop_chat_ready = FALSE;
+    snap.chat_block_reason = CHAT_BLOCK_MODEL_CATALOG_EMPTY;
+
+    ChatGateInfo gate = {0};
+    readiness_describe_chat_gate(&snap, &gate);
+
+    g_assert_false(gate.ready);
+    g_assert_cmpint(gate.reason, ==, CHAT_BLOCK_MODEL_CATALOG_EMPTY);
+    assert_contains(gate.status, "catalog", "chat_gate_catalog_unavailable.status");
+    assert_contains(gate.next_action, "Reload models", "chat_gate_catalog_unavailable.next_action");
+}
+
+static void test_chat_gate_selected_model_unresolved(void) {
+    DesktopReadinessSnapshot snap = {0};
+    snap.config_present = TRUE;
+    snap.config_valid = TRUE;
+    snap.wizard_completed = TRUE;
+    snap.service_installed = TRUE;
+    snap.service_active = TRUE;
+    snap.gateway_http_ok = TRUE;
+    snap.gateway_ws_ok = TRUE;
+    snap.gateway_rpc_ok = TRUE;
+    snap.gateway_auth_ok = TRUE;
+    snap.provider_configured = TRUE;
+    snap.default_model_configured = TRUE;
+    snap.model_catalog_available = TRUE;
+    snap.selected_model_resolved = FALSE;
+    snap.desktop_chat_ready = FALSE;
+    snap.chat_block_reason = CHAT_BLOCK_SELECTED_MODEL_UNRESOLVED;
+
+    ChatGateInfo gate = {0};
+    readiness_describe_chat_gate(&snap, &gate);
+
+    g_assert_false(gate.ready);
+    g_assert_cmpint(gate.reason, ==, CHAT_BLOCK_SELECTED_MODEL_UNRESOLVED);
+    assert_contains(gate.status, "not available", "chat_gate_selected_model_unresolved.status");
+    assert_contains(gate.next_action, "choose", "chat_gate_selected_model_unresolved.next_action");
+}
+
+static void test_chat_gate_agents_unavailable(void) {
+    DesktopReadinessSnapshot snap = {0};
+    snap.config_present = TRUE;
+    snap.config_valid = TRUE;
+    snap.wizard_completed = TRUE;
+    snap.service_installed = TRUE;
+    snap.service_active = TRUE;
+    snap.gateway_http_ok = TRUE;
+    snap.gateway_ws_ok = TRUE;
+    snap.gateway_rpc_ok = TRUE;
+    snap.gateway_auth_ok = TRUE;
+    snap.provider_configured = TRUE;
+    snap.default_model_configured = TRUE;
+    snap.model_catalog_available = TRUE;
+    snap.selected_model_resolved = TRUE;
+    snap.agents_available = FALSE;
+    snap.desktop_chat_ready = FALSE;
+    snap.chat_block_reason = CHAT_BLOCK_AGENTS_UNAVAILABLE;
+
+    ChatGateInfo gate = {0};
+    readiness_describe_chat_gate(&snap, &gate);
+
+    g_assert_false(gate.ready);
+    g_assert_cmpint(gate.reason, ==, CHAT_BLOCK_AGENTS_UNAVAILABLE);
+    assert_contains(gate.status, "agents", "chat_gate_agents_unavailable.status");
+    assert_contains(gate.next_action, "Agents", "chat_gate_agents_unavailable.next_action");
+}
+
+static void test_chat_gate_ready(void) {
+    DesktopReadinessSnapshot snap = {0};
+    snap.config_present = TRUE;
+    snap.config_valid = TRUE;
+    snap.wizard_completed = TRUE;
+    snap.service_installed = TRUE;
+    snap.service_active = TRUE;
+    snap.gateway_http_ok = TRUE;
+    snap.gateway_ws_ok = TRUE;
+    snap.gateway_rpc_ok = TRUE;
+    snap.gateway_auth_ok = TRUE;
+    snap.provider_configured = TRUE;
+    snap.default_model_configured = TRUE;
+    snap.model_catalog_available = TRUE;
+    snap.selected_model_resolved = TRUE;
+    snap.agents_available = TRUE;
+    snap.desktop_chat_ready = TRUE;
+    snap.chat_block_reason = CHAT_BLOCK_NONE;
+
+    ChatGateInfo gate = {0};
+    readiness_describe_chat_gate(&snap, &gate);
+
+    g_assert_true(gate.ready);
+    g_assert_cmpint(gate.reason, ==, CHAT_BLOCK_NONE);
+    assert_contains(gate.status, "ready", "chat_gate_ready.status");
+    g_assert_null(gate.next_action);
+}
+
 /* ── Registration ── */
 
 int main(int argc, char **argv) {
@@ -434,6 +613,13 @@ int main(int argc, char **argv) {
     g_test_add_func("/readiness/onboarding_progress/service_inactive", test_onboarding_progress_service_inactive);
     g_test_add_func("/readiness/onboarding_progress/connecting_service_active", test_onboarding_progress_connecting_service_active);
     g_test_add_func("/readiness/onboarding_progress/operational_ready_running", test_onboarding_progress_operational_ready_only_when_running);
+    g_test_add_func("/readiness/chat_gate/bootstrap_complete_model_missing", test_chat_gate_bootstrap_complete_but_model_missing);
+    g_test_add_func("/readiness/chat_gate/provider_missing", test_chat_gate_provider_missing);
+    g_test_add_func("/readiness/chat_gate/service_inactive", test_chat_gate_service_down);
+    g_test_add_func("/readiness/chat_gate/catalog_unavailable", test_chat_gate_catalog_unavailable);
+    g_test_add_func("/readiness/chat_gate/selected_model_unresolved", test_chat_gate_selected_model_unresolved);
+    g_test_add_func("/readiness/chat_gate/agents_unavailable", test_chat_gate_agents_unavailable);
+    g_test_add_func("/readiness/chat_gate/ready", test_chat_gate_ready);
 
     return g_test_run();
 }

--- a/apps/linux/tests/test_seams.c
+++ b/apps/linux/tests/test_seams.c
@@ -59,6 +59,34 @@ static void test_monitor_skip_dir_changed(void) {
     g_assert_false(skip);
 }
 
+/* ── Tray dispatch decision tests ── */
+
+static void test_tray_dispatch_settings_onboarding_visible(void) {
+    TrayUiAction action = tray_ui_dispatch_decide(TRAY_UI_REQUEST_SETTINGS, TRUE);
+    g_assert_cmpint(action, ==, TRAY_UI_ACTION_SHOW_SETTINGS);
+}
+
+static void test_tray_dispatch_settings_onboarding_hidden(void) {
+    TrayUiAction action = tray_ui_dispatch_decide(TRAY_UI_REQUEST_SETTINGS, FALSE);
+    g_assert_cmpint(action, ==, TRAY_UI_ACTION_SHOW_SETTINGS);
+}
+
+static void test_tray_dispatch_diagnostics_onboarding_visible(void) {
+    TrayUiAction action = tray_ui_dispatch_decide(TRAY_UI_REQUEST_DIAGNOSTICS, TRUE);
+    g_assert_cmpint(action, ==, TRAY_UI_ACTION_SHOW_DIAGNOSTICS);
+}
+
+static void test_tray_dispatch_repeated_requests_safe(void) {
+    for (int i = 0; i < 10; i++) {
+        TrayUiAction settings_action = tray_ui_dispatch_decide(TRAY_UI_REQUEST_SETTINGS, TRUE);
+        TrayUiAction diagnostics_action = tray_ui_dispatch_decide(TRAY_UI_REQUEST_DIAGNOSTICS, TRUE);
+        TrayUiAction startup_action = tray_ui_dispatch_decide(TRAY_UI_REQUEST_SETTINGS, FALSE);
+        g_assert_cmpint(settings_action, ==, TRAY_UI_ACTION_SHOW_SETTINGS);
+        g_assert_cmpint(diagnostics_action, ==, TRAY_UI_ACTION_SHOW_DIAGNOSTICS);
+        g_assert_cmpint(startup_action, ==, TRAY_UI_ACTION_SHOW_SETTINGS);
+    }
+}
+
 /* ── QR Payload Typed Access Tests ── */
 
 static JsonNode* parse_json_node(const gchar *json_str) {
@@ -125,6 +153,12 @@ int main(int argc, char **argv) {
     /* QR payload typed-access tests */
     g_test_add_func("/seams/web_login_start_payload_has_qr/valid_string", test_web_login_start_payload_has_qr_valid_string);
     g_test_add_func("/seams/web_login_start_payload_has_qr/wrong_type", test_web_login_start_payload_has_qr_wrong_type);
+
+    /* tray dispatch decision tests */
+    g_test_add_func("/seams/tray_dispatch/settings_onboarding_visible", test_tray_dispatch_settings_onboarding_visible);
+    g_test_add_func("/seams/tray_dispatch/settings_onboarding_hidden", test_tray_dispatch_settings_onboarding_hidden);
+    g_test_add_func("/seams/tray_dispatch/diagnostics_onboarding_visible", test_tray_dispatch_diagnostics_onboarding_visible);
+    g_test_add_func("/seams/tray_dispatch/repeated_requests_safe", test_tray_dispatch_repeated_requests_safe);
 
     return g_test_run();
 }

--- a/apps/linux/tests/test_state.c
+++ b/apps/linux/tests/test_state.c
@@ -579,6 +579,238 @@ static void test_readiness_startup_hydration_to_running(void) {
     g_assert_cmpint(state_get_current(), ==, STATE_RUNNING);
 }
 
+static void test_readiness_snapshot_no_setup(void) {
+    state_init();
+
+    SystemdState sys = {0};
+    sys.installed = FALSE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.setup_detected = FALSE;
+    hs.config_valid = FALSE;
+    state_update_health(&hs);
+
+    const DesktopReadinessSnapshot *snap = state_get_readiness_snapshot();
+    g_assert_false(snap->config_present);
+    g_assert_false(snap->desktop_chat_ready);
+    g_assert_cmpint(snap->chat_block_reason, ==, CHAT_BLOCK_NO_CONFIG);
+}
+
+static void test_readiness_snapshot_minimal_bootstrap_provider_missing(void) {
+    state_init();
+
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.setup_detected = TRUE;
+    hs.config_valid = TRUE;
+    hs.has_wizard_onboard_marker = TRUE;
+    hs.http_ok = TRUE;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    hs.has_provider_config = FALSE;
+    hs.has_default_model_config = FALSE;
+    state_update_health(&hs);
+
+    const DesktopReadinessSnapshot *snap = state_get_readiness_snapshot();
+    g_assert_true(snap->config_present);
+    g_assert_true(snap->wizard_completed);
+    g_assert_false(snap->provider_configured);
+    g_assert_false(snap->desktop_chat_ready);
+    g_assert_cmpint(snap->chat_block_reason, ==, CHAT_BLOCK_PROVIDER_MISSING);
+}
+
+static void test_readiness_snapshot_provider_present_default_model_missing(void) {
+    state_init();
+
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.setup_detected = TRUE;
+    hs.config_valid = TRUE;
+    hs.has_wizard_onboard_marker = TRUE;
+    hs.http_ok = TRUE;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    hs.has_provider_config = TRUE;
+    hs.has_default_model_config = FALSE;
+    hs.model_catalog_available = TRUE;
+    hs.selected_model_resolved = FALSE;
+    hs.agents_available = TRUE;
+    state_update_health(&hs);
+
+    const DesktopReadinessSnapshot *snap = state_get_readiness_snapshot();
+    g_assert_true(snap->provider_configured);
+    g_assert_false(snap->default_model_configured);
+    g_assert_false(snap->desktop_chat_ready);
+    g_assert_cmpint(snap->chat_block_reason, ==, CHAT_BLOCK_DEFAULT_MODEL_MISSING);
+}
+
+static void test_readiness_snapshot_fully_ready(void) {
+    state_init();
+
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.setup_detected = TRUE;
+    hs.config_valid = TRUE;
+    hs.has_wizard_onboard_marker = TRUE;
+    hs.http_ok = TRUE;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    hs.has_provider_config = TRUE;
+    hs.has_default_model_config = TRUE;
+    hs.model_catalog_available = TRUE;
+    hs.selected_model_resolved = TRUE;
+    hs.agents_available = TRUE;
+    state_update_health(&hs);
+
+    const DesktopReadinessSnapshot *snap = state_get_readiness_snapshot();
+    g_assert_true(snap->desktop_chat_ready);
+    g_assert_cmpint(snap->chat_block_reason, ==, CHAT_BLOCK_NONE);
+}
+
+static void test_readiness_snapshot_provider_default_set_catalog_unavailable(void) {
+    state_init();
+
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.setup_detected = TRUE;
+    hs.config_valid = TRUE;
+    hs.has_wizard_onboard_marker = TRUE;
+    hs.http_ok = TRUE;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    hs.has_provider_config = TRUE;
+    hs.has_default_model_config = TRUE;
+    state_update_health(&hs);
+
+    state_set_model_catalog_fact(FALSE, 0, FALSE);
+    state_set_agents_fact(TRUE, 1);
+
+    const DesktopReadinessSnapshot *snap = state_get_readiness_snapshot();
+    g_assert_false(snap->model_catalog_available);
+    g_assert_false(snap->desktop_chat_ready);
+    g_assert_cmpint(snap->chat_block_reason, ==, CHAT_BLOCK_MODEL_CATALOG_EMPTY);
+}
+
+static void test_readiness_snapshot_healthy_without_dependency_refresh(void) {
+    state_init();
+
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.setup_detected = TRUE;
+    hs.config_valid = TRUE;
+    hs.has_wizard_onboard_marker = TRUE;
+    hs.http_ok = TRUE;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    hs.has_provider_config = TRUE;
+    hs.has_default_model_config = TRUE;
+    hs.configured_default_model_id = "openai/gpt-4.1";
+    state_update_health(&hs);
+
+    const DesktopReadinessSnapshot *snap = state_get_readiness_snapshot();
+    g_assert_true(snap->provider_configured);
+    g_assert_true(snap->default_model_configured);
+    g_assert_false(snap->model_catalog_available);
+    g_assert_false(snap->selected_model_resolved);
+    g_assert_false(snap->desktop_chat_ready);
+    g_assert_cmpint(snap->chat_block_reason, ==, CHAT_BLOCK_MODEL_CATALOG_EMPTY);
+}
+
+static void test_readiness_snapshot_selected_model_unresolved(void) {
+    state_init();
+
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.setup_detected = TRUE;
+    hs.config_valid = TRUE;
+    hs.has_wizard_onboard_marker = TRUE;
+    hs.http_ok = TRUE;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    hs.has_provider_config = TRUE;
+    hs.has_default_model_config = TRUE;
+    hs.configured_default_model_id = "openai/gpt-4.1";
+    state_update_health(&hs);
+
+    state_set_model_catalog_fact(TRUE, 3, FALSE);
+    state_set_agents_fact(TRUE, 1);
+
+    const DesktopReadinessSnapshot *snap = state_get_readiness_snapshot();
+    g_assert_true(snap->model_catalog_available);
+    g_assert_false(snap->selected_model_resolved);
+    g_assert_cmpint(snap->chat_block_reason, ==, CHAT_BLOCK_SELECTED_MODEL_UNRESOLVED);
+}
+
+static void test_readiness_snapshot_agents_unavailable_with_resolved_model(void) {
+    state_init();
+
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.setup_detected = TRUE;
+    hs.config_valid = TRUE;
+    hs.has_wizard_onboard_marker = TRUE;
+    hs.http_ok = TRUE;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    hs.has_provider_config = TRUE;
+    hs.has_default_model_config = TRUE;
+    hs.configured_default_model_id = "openai/gpt-4.1";
+    state_update_health(&hs);
+
+    state_set_model_catalog_fact(TRUE, 2, TRUE);
+    state_set_agents_fact(TRUE, 0);
+
+    const DesktopReadinessSnapshot *snap = state_get_readiness_snapshot();
+    g_assert_true(snap->model_catalog_available);
+    g_assert_true(snap->selected_model_resolved);
+    g_assert_false(snap->agents_available);
+    g_assert_cmpint(snap->chat_block_reason, ==, CHAT_BLOCK_AGENTS_UNAVAILABLE);
+}
+
 /* ── Wizard Marker Tests (Task 9) ── */
 
 static void test_wizard_absent_needs_onboarding(void) {
@@ -744,6 +976,14 @@ int main(int argc, char **argv) {
     g_test_add_func("/state/wizard_marker/present_runtime_healthy", test_wizard_present_runtime_healthy);
     g_test_add_func("/state/wizard_marker/absent_model_config_present", test_wizard_absent_model_config_present);
     g_test_add_func("/state/wizard_marker/present_model_config_absent", test_wizard_present_model_config_absent);
+    g_test_add_func("/state/readiness_snapshot/no_setup", test_readiness_snapshot_no_setup);
+    g_test_add_func("/state/readiness_snapshot/minimal_bootstrap_provider_missing", test_readiness_snapshot_minimal_bootstrap_provider_missing);
+    g_test_add_func("/state/readiness_snapshot/provider_present_default_model_missing", test_readiness_snapshot_provider_present_default_model_missing);
+    g_test_add_func("/state/readiness_snapshot/fully_ready", test_readiness_snapshot_fully_ready);
+    g_test_add_func("/state/readiness_snapshot/provider_default_set_catalog_unavailable", test_readiness_snapshot_provider_default_set_catalog_unavailable);
+    g_test_add_func("/state/readiness_snapshot/healthy_without_dependency_refresh", test_readiness_snapshot_healthy_without_dependency_refresh);
+    g_test_add_func("/state/readiness_snapshot/selected_model_unresolved", test_readiness_snapshot_selected_model_unresolved);
+    g_test_add_func("/state/readiness_snapshot/agents_unavailable_with_resolved_model", test_readiness_snapshot_agents_unavailable_with_resolved_model);
 
     return g_test_run();
 }


### PR DESCRIPTION
- introduce a readiness-driven desktop flow for the Linux companion by extending `state.c` with `DesktopReadinessSnapshot`, `ChatBlockReason`, and resolved dependency facts, then mapping those invariants through `readiness.c` into a reusable `ChatGateInfo` description used by Chat, Onboarding, Control Room, and Diagnostics

- add `config_setup_transform.c` and `config_setup_transform.h` to apply provider and default-model changes to the config JSON in a testable module instead of embedding JSON mutation logic directly inside GTK handlers

- expand `app_window.c` to expose an in-app "Provider & Model Setup" surface inside Config, including provider fields, model reload, default-model selection, config save/reload orchestration, dependency invalidation, and readiness-aware summary/status text

- strengthen integrated window lifecycle handling in `app_window.c` by adding `window_shutting_down`, guarding all integrated refresh helpers, refreshing only the active integrated section on timers/navigation, and destroying section-owned resources before clearing widget globals during teardown

- remove the standalone diagnostics window from `diagnostics.c` so Diagnostics is represented only by the integrated dashboard tab, while preserving `build_diagnostics_text()` as the single canonical diagnostics payload generator

- unify Environment and Diagnostics path truth in `display_model.c` and `display_model.h` by introducing `RuntimePathStatus`, storing owned UTF-8-safe detail strings, adding `environment_check_result_clear()`, and separating config file existence from config directory existence

- centralize GTK drop-down and Adwaita combo-row model ownership in `ui_model_utils.c` and `ui_model_utils.h`, then apply those helpers across Config, Chat, Agents, Channels, Skills, and Usage to avoid stale model pointers during replace/detach flows

- harden async callback safety across lifecycle-sensitive sections by adding generation-scoped request contexts in Agents, Channels, Chat, Control Room, Instances, Logs, Sessions, Skills, Usage, and Workflows so responses received after teardown are dropped instead of mutating dead widget state

- extend `gateway_client.c` and `gateway_config.c` so the desktop can distinguish provider configuration from default-model configuration, track the configured default model id, refresh models/agents dependency facts through RPC, and invalidate or recompute those facts when config or transport state changes

- update tray behavior in `tray.c`, `tray_helper.c`, and `test_seams.*` so tray Settings and Diagnostics actions open the integrated dashboard sections without closing onboarding, and add a visible Diagnostics tray entry that maps to the main-window tab

- evolve onboarding in `onboarding.c` to support live readiness refresh, route-preserving page rebuilds, gateway-stage updates, and provider/model guidance that reflects the same chat-readiness contract shown elsewhere in the app

- add and update targeted tests in `test_config.c`, `test_display_model.c`, `test_readiness.c`, `test_state.c`, and `test_seams.c` to cover config transforms, provider/default-model detection, readiness snapshots, chat-gate messaging, runtime-path ownership, UTF-8-safe display behavior, and tray dispatch decisions

This change makes the Linux companion materially more trustworthy: it exposes the remaining config work needed to unlock chat, eliminates the duplicate diagnostics surface, aligns environment and diagnostics truth, and hardens GTK/C lifecycle behavior that previously produced criticals, stale updates, and user-visible crash paths.