### PR TITLE
fix(linux): unify runtime path derivation for diagnostics (#76)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -46,6 +46,7 @@ sources = [
   'src/notify.c',
   'src/diagnostics.c',
   'src/display_model.c',
+  'src/runtime_paths.c',
   'src/session_filter.c',
   'src/markdown_render.c',
   'src/chat_blocks.c',
@@ -134,7 +135,7 @@ test('gateway', test_gateway_exe)
 
 test_display_model_exe = executable('test_display_model',
   ['tests/test_display_model.c', 'src/display_model.c', 'src/readiness.c',
-   'src/runtime_mode.c', 'src/gateway_config.c', 'src/log.c'],
+   'src/runtime_mode.c', 'src/gateway_config.c', 'src/runtime_paths.c', 'src/log.c'],
   dependencies : [glib_dep, gio_dep, json_glib_dep])
 test('display_model', test_display_model_exe)
 

--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -41,6 +41,7 @@
 #include "section_control_room.h"
 #include "section_workflows.h"
 #include "ui_model_utils.h"
+#include "runtime_paths.h"
 #include "log.h"
 
 /* ── Section metadata ── */
@@ -2073,27 +2074,13 @@ static void populate_env_checks(GtkWidget *container) {
     systemd_get_runtime_context(&profile, &state_dir, &config_path);
 
     GatewayConfig *cfg = gateway_client_get_config();
-
-    GatewayConfigContext ctx = {0};
-    ctx.explicit_config_path = config_path;
-    ctx.effective_state_dir = state_dir;
-    ctx.profile = profile;
-
-    g_autofree gchar *resolved_config_path = gateway_config_resolve_path(&ctx);
-
-    const gchar *effective_config_path = NULL;
-    if (cfg && cfg->config_path && cfg->config_path[0] != '\0') {
-        effective_config_path = cfg->config_path;
-    } else if (resolved_config_path && resolved_config_path[0] != '\0') {
-        effective_config_path = resolved_config_path;
-    } else if (config_path && config_path[0] != '\0') {
-        effective_config_path = config_path;
-    }
+    RuntimeEffectivePaths effective_paths = {0};
+    runtime_effective_paths_resolve(cfg, profile, state_dir, config_path, &effective_paths);
 
     EnvironmentCheckResult ecr;
     environment_check_build(sys,
-                            effective_config_path,
-                            state_dir,
+                            effective_paths.effective_config_path,
+                            effective_paths.effective_state_dir,
                             &ecr);
 
     for (int i = 0; i < ecr.count; i++) {
@@ -2117,6 +2104,7 @@ static void populate_env_checks(GtkWidget *container) {
     }
 
     environment_check_result_clear(&ecr);
+    runtime_effective_paths_clear(&effective_paths);
 }
 
 static GtkWidget* build_environment_section(void) {

--- a/apps/linux/src/diagnostics.c
+++ b/apps/linux/src/diagnostics.c
@@ -15,6 +15,7 @@
 #include "state.h"
 #include "readiness.h"
 #include "display_model.h"
+#include "runtime_paths.h"
 
 static gchar* format_age(gint64 timestamp_us) {
     if (timestamp_us == 0) {
@@ -114,23 +115,14 @@ gchar* build_diagnostics_text(void) {
     extern void systemd_get_runtime_context(gchar **out_profile, gchar **out_state_dir, gchar **out_config_path);
     systemd_get_runtime_context(&profile, &state_dir, &config_path);
 
-    GatewayConfigContext cfg_ctx = {0};
-    cfg_ctx.explicit_config_path = config_path;
-    cfg_ctx.effective_state_dir = state_dir;
-    cfg_ctx.profile = profile;
-    g_autofree gchar *resolved_config_path = gateway_config_resolve_path(&cfg_ctx);
-
-    const gchar *effective_config_path = NULL;
-    if (cfg && cfg->config_path && cfg->config_path[0] != '\0') {
-        effective_config_path = cfg->config_path;
-    } else if (resolved_config_path && resolved_config_path[0] != '\0') {
-        effective_config_path = resolved_config_path;
-    } else if (config_path && config_path[0] != '\0') {
-        effective_config_path = config_path;
-    }
+    RuntimeEffectivePaths effective_paths = {0};
+    runtime_effective_paths_resolve(cfg, profile, state_dir, config_path, &effective_paths);
 
     RuntimePathStatus paths = {0};
-    runtime_path_status_build(effective_config_path, state_dir, NULL, &paths);
+    runtime_path_status_build(effective_paths.effective_config_path,
+                              effective_paths.effective_state_dir,
+                              NULL,
+                              &paths);
 
     g_string_append_printf(out, "Config Path: %s\n",
                            paths.config_path_resolved ? paths.config_path : "N/A");
@@ -157,6 +149,7 @@ gchar* build_diagnostics_text(void) {
     g_string_append_printf(out, "Last Error: %s\n", health->last_error ? health->last_error : "None");
 
     runtime_path_status_clear(&paths);
+    runtime_effective_paths_clear(&effective_paths);
 
     return g_string_free(out, FALSE);
 }

--- a/apps/linux/src/onboarding.c
+++ b/apps/linux/src/onboarding.c
@@ -23,9 +23,12 @@
 #include "onboarding.h"
 #include "display_model.h"
 #include "gateway_config.h"
+#include "gateway_client.h"
 #include "state.h"
 #include "readiness.h"
 #include "app_window.h"
+#include "runtime_paths.h"
+#include "test_seams.h"
 #include "log.h"
 
 /* ── Version marker persistence ── */
@@ -84,6 +87,7 @@ static GtkWidget *onboard_gateway_next_action_value = NULL;
 
 static GtkWidget *onboard_whats_next_guidance_label = NULL;
 static GtkWidget *onboard_whats_next_dashboard_button = NULL;
+static GtkWidget *onboard_environment_checks_box = NULL;
 
 typedef struct {
     AppState state;
@@ -109,6 +113,77 @@ static GtkWidget* build_gateway_page(GtkWidget *carousel);
 static GtkWidget* build_environment_page(GtkWidget *carousel);
 static GtkWidget* build_whats_next_page(GtkWidget *carousel);
 
+static void onboarding_snapshot_to_input(const OnboardingRenderSnapshot *snap,
+                                         OnboardingRefreshSnapshotInput *out) {
+    if (!snap || !out) return;
+    out->state = (gint)snap->state;
+    out->route = (gint)snap->route;
+    out->stage_configuration = (gint)snap->stage_configuration;
+    out->stage_service_gateway = (gint)snap->stage_service_gateway;
+    out->stage_connection = (gint)snap->stage_connection;
+    out->operational_ready = snap->operational_ready;
+    out->config_valid = snap->config_valid;
+    out->setup_detected = snap->setup_detected;
+    out->sys_installed = snap->sys_installed;
+    out->sys_active = snap->sys_active;
+    out->config_file_exists = snap->config_file_exists;
+    out->state_dir_exists = snap->state_dir_exists;
+    out->next_action = snap->next_action;
+}
+
+static void onboarding_render_environment_checks(GtkWidget *container) {
+    if (!container || !GTK_IS_BOX(container)) return;
+
+    GtkWidget *child = NULL;
+    while ((child = gtk_widget_get_first_child(container)) != NULL) {
+        gtk_box_remove(GTK_BOX(container), child);
+    }
+
+    SystemdState *sys = state_get_systemd();
+    g_autofree gchar *config_path = NULL;
+    g_autofree gchar *state_dir = NULL;
+    g_autofree gchar *profile = NULL;
+    extern void systemd_get_runtime_context(gchar **out_profile, gchar **out_state_dir, gchar **out_config_path);
+    systemd_get_runtime_context(&profile, &state_dir, &config_path);
+
+    GatewayConfig *cfg = gateway_client_get_config();
+    RuntimeEffectivePaths effective_paths = {0};
+    runtime_effective_paths_resolve(cfg, profile, state_dir, config_path, &effective_paths);
+
+    EnvironmentCheckResult ecr;
+    environment_check_build(sys,
+                            effective_paths.effective_config_path,
+                            effective_paths.effective_state_dir,
+                            &ecr);
+
+    for (int i = 0; i < ecr.count; i++) {
+        GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+        gtk_widget_set_margin_top(row, 4);
+
+        const char *icon = ecr.rows[i].passed ? "\u2705" : "\u274C";
+        GtkWidget *icon_label = gtk_label_new(icon);
+        gtk_box_append(GTK_BOX(row), icon_label);
+
+        g_autofree gchar *text = g_strdup_printf("%s: %s",
+            ecr.rows[i].label, ecr.rows[i].detail ? ecr.rows[i].detail : "");
+        GtkWidget *detail = gtk_label_new(text);
+        gtk_label_set_wrap(GTK_LABEL(detail), TRUE);
+        gtk_label_set_xalign(GTK_LABEL(detail), 0.0);
+        gtk_widget_set_hexpand(detail, TRUE);
+        gtk_box_append(GTK_BOX(row), detail);
+
+        gtk_box_append(GTK_BOX(container), row);
+    }
+
+    environment_check_result_clear(&ecr);
+    runtime_effective_paths_clear(&effective_paths);
+}
+
+static void onboarding_refresh_environment_content(void) {
+    if (!onboard_environment_checks_box) return;
+    onboarding_render_environment_checks(onboard_environment_checks_box);
+}
+
 static void snapshot_free(OnboardingRenderSnapshot *snap) {
     g_free(snap->next_action);
     snap->next_action = NULL;
@@ -131,6 +206,7 @@ static void on_onboard_destroy(GtkWindow *window, gpointer user_data) {
     onboard_gateway_next_action_value = NULL;
     onboard_whats_next_guidance_label = NULL;
     onboard_whats_next_dashboard_button = NULL;
+    onboard_environment_checks_box = NULL;
     onboard_has_render_snapshot = FALSE;
     snapshot_free(&onboard_last_snapshot);
 }
@@ -146,7 +222,6 @@ static void on_finish_clicked(GtkButton *btn, gpointer data) {
 
 static void on_open_dashboard_clicked(GtkButton *btn, gpointer data) {
     (void)btn; (void)data;
-    extern GatewayConfig* gateway_client_get_config(void); /* gateway_client.h */
     GatewayConfig *cfg = gateway_client_get_config();
     if (cfg) {
         g_autofree gchar *url = gateway_config_dashboard_url(cfg);
@@ -388,6 +463,7 @@ static void onboarding_refresh_live_content(void) {
 
     onboarding_update_gateway_content(current, &ri, &progress, &gate);
     onboarding_update_whats_next_content(&ri, &gate);
+    onboarding_refresh_environment_content();
 }
 
 static void onboarding_build_pages(OnboardingRoute route) {
@@ -433,6 +509,7 @@ static void onboarding_rebuild_pages(OnboardingRoute route) {
     onboard_gateway_next_action_value = NULL;
     onboard_whats_next_guidance_label = NULL;
     onboard_whats_next_dashboard_button = NULL;
+    onboard_environment_checks_box = NULL;
 
     onboarding_build_pages(route);
 
@@ -584,41 +661,10 @@ static GtkWidget* build_environment_page(GtkWidget *carousel) {
     gtk_label_set_xalign(GTK_LABEL(title), 0.0);
     gtk_box_append(GTK_BOX(page), title);
 
-    /* Build environment checks */
-    SystemdState *sys = state_get_systemd();
-    gchar *config_path = NULL;
-    gchar *state_dir = NULL;
-    gchar *profile = NULL;
-    extern void systemd_get_runtime_context(gchar **out_profile, gchar **out_state_dir, gchar **out_config_path);
-    systemd_get_runtime_context(&profile, &state_dir, &config_path);
-
-    EnvironmentCheckResult ecr;
-    environment_check_build(sys, config_path, state_dir, &ecr);
-
-    for (int i = 0; i < ecr.count; i++) {
-        GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
-        gtk_widget_set_margin_top(row, 4);
-
-        const char *icon = ecr.rows[i].passed ? "\u2705" : "\u274C";
-        GtkWidget *icon_label = gtk_label_new(icon);
-        gtk_box_append(GTK_BOX(row), icon_label);
-
-        g_autofree gchar *text = g_strdup_printf("%s: %s",
-            ecr.rows[i].label, ecr.rows[i].detail ? ecr.rows[i].detail : "");
-        GtkWidget *detail = gtk_label_new(text);
-        gtk_label_set_wrap(GTK_LABEL(detail), TRUE);
-        gtk_label_set_xalign(GTK_LABEL(detail), 0.0);
-        gtk_widget_set_hexpand(detail, TRUE);
-        gtk_box_append(GTK_BOX(row), detail);
-
-        gtk_box_append(GTK_BOX(page), row);
-    }
-
-    environment_check_result_clear(&ecr);
-
-    g_free(config_path);
-    g_free(state_dir);
-    g_free(profile);
+    GtkWidget *checks_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    onboard_environment_checks_box = checks_box;
+    onboarding_render_environment_checks(checks_box);
+    gtk_box_append(GTK_BOX(page), checks_box);
 
     GtkWidget *btn_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
     gtk_widget_set_halign(btn_row, GTK_ALIGN_CENTER);
@@ -800,8 +846,14 @@ void onboarding_refresh(void) {
     extern void systemd_get_runtime_context(gchar **out_profile, gchar **out_state_dir, gchar **out_config_path);
     systemd_get_runtime_context(&profile, &state_dir, &config_path);
 
-    gboolean config_file_exists = config_path && g_file_test(config_path, G_FILE_TEST_EXISTS);
-    gboolean state_dir_exists = state_dir && g_file_test(state_dir, G_FILE_TEST_IS_DIR);
+    GatewayConfig *cfg = gateway_client_get_config();
+    RuntimeEffectivePaths effective_paths = {0};
+    runtime_effective_paths_resolve(cfg, profile, state_dir, config_path, &effective_paths);
+
+    gboolean config_file_exists = effective_paths.effective_config_path &&
+                                  g_file_test(effective_paths.effective_config_path, G_FILE_TEST_EXISTS);
+    gboolean state_dir_exists = effective_paths.effective_state_dir &&
+                                g_file_test(effective_paths.effective_state_dir, G_FILE_TEST_IS_DIR);
 
     ReadinessInfo ri;
     readiness_evaluate(current, health, sys, &ri);
@@ -840,29 +892,29 @@ void onboarding_refresh(void) {
     g_free(profile);
     g_free(state_dir);
     g_free(config_path);
+    runtime_effective_paths_clear(&effective_paths);
 
-    if (onboard_has_render_snapshot &&
-        onboard_last_snapshot.state == new_snap.state &&
-        onboard_last_snapshot.route == new_snap.route &&
-        onboard_last_snapshot.stage_configuration == new_snap.stage_configuration &&
-        onboard_last_snapshot.stage_service_gateway == new_snap.stage_service_gateway &&
-        onboard_last_snapshot.stage_connection == new_snap.stage_connection &&
-        onboard_last_snapshot.operational_ready == new_snap.operational_ready &&
-        onboard_last_snapshot.config_valid == new_snap.config_valid &&
-        onboard_last_snapshot.setup_detected == new_snap.setup_detected &&
-        onboard_last_snapshot.sys_installed == new_snap.sys_installed &&
-        onboard_last_snapshot.sys_active == new_snap.sys_active &&
-        onboard_last_snapshot.config_file_exists == new_snap.config_file_exists &&
-        onboard_last_snapshot.state_dir_exists == new_snap.state_dir_exists &&
-        g_strcmp0(onboard_last_snapshot.next_action, new_snap.next_action) == 0) {
-        
+    gboolean snapshots_equal = FALSE;
+    if (onboard_has_render_snapshot) {
+        OnboardingRefreshSnapshotInput prev_input = {0};
+        OnboardingRefreshSnapshotInput next_input = {0};
+        onboarding_snapshot_to_input(&onboard_last_snapshot, &prev_input);
+        onboarding_snapshot_to_input(&new_snap, &next_input);
+        snapshots_equal = onboarding_refresh_snapshot_equal(&prev_input, &next_input);
+    }
+
+    if (snapshots_equal) {
         snapshot_free(&new_snap);
         return; /* No material change, skip rebuild */
     }
 
-    if (new_snap.route != onboard_current_route) {
+    OnboardingRefreshAction action = onboarding_refresh_action_decide(
+        snapshots_equal,
+        new_snap.route != onboard_current_route);
+
+    if (action == ONBOARDING_REFRESH_ACTION_REBUILD_PAGES) {
         onboarding_rebuild_pages(new_snap.route);
-    } else {
+    } else if (action == ONBOARDING_REFRESH_ACTION_REFRESH_LIVE) {
         onboarding_refresh_live_content();
     }
 

--- a/apps/linux/src/runtime_paths.c
+++ b/apps/linux/src/runtime_paths.c
@@ -2,6 +2,8 @@
  * runtime_paths.c
  *
  * Canonical runtime path derivation contract for Linux companion surfaces.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
  */
 
 #include "runtime_paths.h"

--- a/apps/linux/src/runtime_paths.c
+++ b/apps/linux/src/runtime_paths.c
@@ -1,0 +1,59 @@
+/*
+ * runtime_paths.c
+ *
+ * Canonical runtime path derivation contract for Linux companion surfaces.
+ */
+
+#include "runtime_paths.h"
+
+#include <string.h>
+
+static gboolean non_empty(const gchar *value) {
+    return value && value[0] != '\0';
+}
+
+void runtime_effective_paths_resolve(const GatewayConfig *loaded_config,
+                                     const gchar *profile,
+                                     const gchar *runtime_state_dir,
+                                     const gchar *runtime_config_path,
+                                     RuntimeEffectivePaths *out) {
+    if (!out) return;
+    memset(out, 0, sizeof(*out));
+
+    GatewayConfigContext ctx = {0};
+    ctx.explicit_config_path = runtime_config_path;
+    ctx.effective_state_dir = runtime_state_dir;
+    ctx.profile = profile;
+
+    g_autofree gchar *resolved_config_path = gateway_config_resolve_path(&ctx);
+
+    const gchar *effective_config_path = NULL;
+    if (loaded_config && non_empty(loaded_config->config_path)) {
+        effective_config_path = loaded_config->config_path;
+    } else if (non_empty(resolved_config_path)) {
+        effective_config_path = resolved_config_path;
+    } else if (non_empty(runtime_config_path)) {
+        effective_config_path = runtime_config_path;
+    }
+
+    if (effective_config_path) {
+        out->effective_config_path = g_strdup(effective_config_path);
+    }
+
+    if (non_empty(runtime_state_dir)) {
+        out->effective_state_dir = g_strdup(runtime_state_dir);
+    } else if (non_empty(out->effective_config_path)) {
+        gchar *derived = g_path_get_dirname(out->effective_config_path);
+        if (non_empty(derived)) {
+            out->effective_state_dir = derived;
+            derived = NULL;
+        }
+        g_free(derived);
+    }
+}
+
+void runtime_effective_paths_clear(RuntimeEffectivePaths *paths) {
+    if (!paths) return;
+    g_clear_pointer(&paths->effective_config_path, g_free);
+    g_clear_pointer(&paths->effective_state_dir, g_free);
+}

--- a/apps/linux/src/runtime_paths.h
+++ b/apps/linux/src/runtime_paths.h
@@ -1,0 +1,40 @@
+/*
+ * runtime_paths.h
+ *
+ * Canonical runtime path derivation contract for Linux companion surfaces.
+ *
+ * This API is the single source of truth for deriving:
+ *   - effective config path
+ *   - effective state directory
+ *
+ * Precedence contract:
+ *   1) loaded gateway config path (if available)
+ *   2) resolved runtime config path (gateway_config_resolve_path)
+ *   3) raw runtime config path from systemd context
+ *
+ * State-dir contract:
+ *   1) runtime state dir from systemd context
+ *   2) dirname(effective config path)
+ *
+ * Ownership contract:
+ *   - All fields in RuntimeEffectivePaths are owned by the caller.
+ *   - Call runtime_effective_paths_clear() to free/reset the struct.
+ */
+
+#pragma once
+
+#include <glib.h>
+#include "gateway_config.h"
+
+typedef struct {
+    gchar *effective_config_path;
+    gchar *effective_state_dir;
+} RuntimeEffectivePaths;
+
+void runtime_effective_paths_resolve(const GatewayConfig *loaded_config,
+                                     const gchar *profile,
+                                     const gchar *runtime_state_dir,
+                                     const gchar *runtime_config_path,
+                                     RuntimeEffectivePaths *out);
+
+void runtime_effective_paths_clear(RuntimeEffectivePaths *paths);

--- a/apps/linux/src/test_seams.c
+++ b/apps/linux/src/test_seams.c
@@ -152,3 +152,37 @@ TrayUiAction tray_ui_dispatch_decide(TrayUiRequest request, gboolean onboarding_
             return TRAY_UI_ACTION_SHOW_SETTINGS;
     }
 }
+
+/* ── Onboarding refresh decisions (from onboarding.c) ─────────────── */
+
+gboolean onboarding_refresh_snapshot_equal(const OnboardingRefreshSnapshotInput *a,
+                                           const OnboardingRefreshSnapshotInput *b) {
+    if (!a || !b) return FALSE;
+
+    return a->state == b->state &&
+           a->route == b->route &&
+           a->stage_configuration == b->stage_configuration &&
+           a->stage_service_gateway == b->stage_service_gateway &&
+           a->stage_connection == b->stage_connection &&
+           a->operational_ready == b->operational_ready &&
+           a->config_valid == b->config_valid &&
+           a->setup_detected == b->setup_detected &&
+           a->sys_installed == b->sys_installed &&
+           a->sys_active == b->sys_active &&
+           a->config_file_exists == b->config_file_exists &&
+           a->state_dir_exists == b->state_dir_exists &&
+           g_strcmp0(a->next_action, b->next_action) == 0;
+}
+
+OnboardingRefreshAction onboarding_refresh_action_decide(gboolean snapshots_equal,
+                                                         gboolean route_changed) {
+    if (snapshots_equal) {
+        return ONBOARDING_REFRESH_ACTION_NOOP;
+    }
+
+    if (route_changed) {
+        return ONBOARDING_REFRESH_ACTION_REBUILD_PAGES;
+    }
+
+    return ONBOARDING_REFRESH_ACTION_REFRESH_LIVE;
+}

--- a/apps/linux/src/test_seams.h
+++ b/apps/linux/src/test_seams.h
@@ -76,4 +76,34 @@ typedef enum {
 
 TrayUiAction tray_ui_dispatch_decide(TrayUiRequest request, gboolean onboarding_visible);
 
+/* ── Onboarding refresh decisions (from onboarding.c) ─────────────── */
+
+typedef struct {
+    gint state;
+    gint route;
+    gint stage_configuration;
+    gint stage_service_gateway;
+    gint stage_connection;
+    gboolean operational_ready;
+    gboolean config_valid;
+    gboolean setup_detected;
+    gboolean sys_installed;
+    gboolean sys_active;
+    gboolean config_file_exists;
+    gboolean state_dir_exists;
+    const gchar *next_action;
+} OnboardingRefreshSnapshotInput;
+
+typedef enum {
+    ONBOARDING_REFRESH_ACTION_NOOP = 0,
+    ONBOARDING_REFRESH_ACTION_REBUILD_PAGES = 1,
+    ONBOARDING_REFRESH_ACTION_REFRESH_LIVE = 2,
+} OnboardingRefreshAction;
+
+gboolean onboarding_refresh_snapshot_equal(const OnboardingRefreshSnapshotInput *a,
+                                           const OnboardingRefreshSnapshotInput *b);
+
+OnboardingRefreshAction onboarding_refresh_action_decide(gboolean snapshots_equal,
+                                                         gboolean route_changed);
+
 #endif /* TEST_SEAMS_H */

--- a/apps/linux/src/ui_model_utils.c
+++ b/apps/linux/src/ui_model_utils.c
@@ -3,6 +3,8 @@
  *
  * Shared widget/model lifecycle helpers for GTK drop-downs and
  * Adwaita combo rows.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
  */
 
 #include "ui_model_utils.h"

--- a/apps/linux/tests/test_display_model.c
+++ b/apps/linux/tests/test_display_model.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include "../src/display_model.h"
 #include "../src/gateway_config.h"
+#include "../src/runtime_paths.h"
 
 /* ── Helper ── */
 static void assert_contains(const char *haystack, const char *needle, const char *ctx) {
@@ -506,6 +507,59 @@ static void test_environment_check_result_clear_resets_owned_details(void) {
     g_assert_null(ecr.rows[0].detail);
 }
 
+static void test_runtime_effective_paths_prefers_loaded_config_path(void) {
+    GatewayConfig cfg = {0};
+    cfg.config_path = g_strdup("/tmp/openclaw-loaded/openclaw.json");
+
+    RuntimeEffectivePaths paths = {0};
+    runtime_effective_paths_resolve(&cfg,
+                                    "default",
+                                    "/tmp/openclaw-state",
+                                    "/tmp/openclaw-runtime/openclaw.json",
+                                    &paths);
+
+    g_assert_cmpstr(paths.effective_config_path, ==, "/tmp/openclaw-loaded/openclaw.json");
+    g_assert_cmpstr(paths.effective_state_dir, ==, "/tmp/openclaw-state");
+
+    runtime_effective_paths_clear(&paths);
+    g_assert_null(paths.effective_config_path);
+    g_assert_null(paths.effective_state_dir);
+
+    g_free(cfg.config_path);
+}
+
+static void test_runtime_effective_paths_derives_state_dir_from_effective_config(void) {
+    GatewayConfig cfg = {0};
+    cfg.config_path = g_strdup("/tmp/openclaw-cfg/openclaw.json");
+
+    RuntimeEffectivePaths paths = {0};
+    runtime_effective_paths_resolve(&cfg,
+                                    "default",
+                                    NULL,
+                                    NULL,
+                                    &paths);
+
+    g_assert_cmpstr(paths.effective_config_path, ==, "/tmp/openclaw-cfg/openclaw.json");
+    g_assert_cmpstr(paths.effective_state_dir, ==, "/tmp/openclaw-cfg");
+
+    runtime_effective_paths_clear(&paths);
+    g_free(cfg.config_path);
+}
+
+static void test_runtime_effective_paths_resolves_from_runtime_state_dir_when_no_loaded_config(void) {
+    RuntimeEffectivePaths paths = {0};
+    runtime_effective_paths_resolve(NULL,
+                                    "default",
+                                    "/tmp/openclaw-runtime-state",
+                                    NULL,
+                                    &paths);
+
+    g_assert_cmpstr(paths.effective_config_path, ==, "/tmp/openclaw-runtime-state/openclaw.json");
+    g_assert_cmpstr(paths.effective_state_dir, ==, "/tmp/openclaw-runtime-state");
+
+    runtime_effective_paths_clear(&paths);
+}
+
 /* ══════════════════════════════════════════════════════════════════
  * Onboarding routing tests
  * ══════════════════════════════════════════════════════════════════ */
@@ -722,6 +776,9 @@ int main(int argc, char **argv) {
     g_test_add_func("/display_model/runtime_paths/loaded_path_precedence", test_runtime_path_status_uses_loaded_path_precedence);
     g_test_add_func("/display_model/runtime_paths/derive_state_dir_from_config", test_runtime_path_status_derives_state_dir_from_config);
     g_test_add_func("/display_model/runtime_paths/invalid_utf8_display_safe", test_runtime_path_status_invalid_utf8_paths_are_display_safe);
+    g_test_add_func("/display_model/runtime_paths/effective_prefers_loaded_config", test_runtime_effective_paths_prefers_loaded_config_path);
+    g_test_add_func("/display_model/runtime_paths/effective_derives_state_dir", test_runtime_effective_paths_derives_state_dir_from_effective_config);
+    g_test_add_func("/display_model/runtime_paths/effective_from_runtime_state_dir", test_runtime_effective_paths_resolves_from_runtime_state_dir_when_no_loaded_config);
     g_test_add_func("/display_model/env/result_clear_resets_details", test_environment_check_result_clear_resets_owned_details);
 
     /* Onboarding routing */

--- a/apps/linux/tests/test_seams.c
+++ b/apps/linux/tests/test_seams.c
@@ -19,6 +19,65 @@ static void test_ancestor_walk_existing_dir(void) {
     g_free(res);
 }
 
+/* ── Onboarding refresh route-stable environment regression tests ── */
+
+static OnboardingRefreshSnapshotInput make_onboarding_snapshot_seed(void) {
+    OnboardingRefreshSnapshotInput snap = {0};
+    snap.state = 1;
+    snap.route = 2;
+    snap.stage_configuration = 1;
+    snap.stage_service_gateway = 1;
+    snap.stage_connection = 0;
+    snap.operational_ready = FALSE;
+    snap.config_valid = TRUE;
+    snap.setup_detected = TRUE;
+    snap.sys_installed = TRUE;
+    snap.sys_active = TRUE;
+    snap.config_file_exists = TRUE;
+    snap.state_dir_exists = TRUE;
+    snap.next_action = "do thing";
+    return snap;
+}
+
+static void test_onboarding_refresh_route_stable_env_change_refreshes_live(void) {
+    OnboardingRefreshSnapshotInput prev = make_onboarding_snapshot_seed();
+    OnboardingRefreshSnapshotInput next = prev;
+
+    next.config_file_exists = FALSE;
+
+    gboolean equal = onboarding_refresh_snapshot_equal(&prev, &next);
+    g_assert_false(equal);
+
+    OnboardingRefreshAction action = onboarding_refresh_action_decide(equal, FALSE);
+    g_assert_cmpint(action, ==, ONBOARDING_REFRESH_ACTION_REFRESH_LIVE);
+}
+
+static void test_onboarding_refresh_route_stable_state_dir_change_refreshes_live(void) {
+    OnboardingRefreshSnapshotInput prev = make_onboarding_snapshot_seed();
+    OnboardingRefreshSnapshotInput next = prev;
+
+    next.state_dir_exists = FALSE;
+
+    gboolean equal = onboarding_refresh_snapshot_equal(&prev, &next);
+    g_assert_false(equal);
+
+    OnboardingRefreshAction action = onboarding_refresh_action_decide(equal, FALSE);
+    g_assert_cmpint(action, ==, ONBOARDING_REFRESH_ACTION_REFRESH_LIVE);
+}
+
+static void test_onboarding_refresh_route_changed_rebuilds_pages(void) {
+    OnboardingRefreshSnapshotInput prev = make_onboarding_snapshot_seed();
+    OnboardingRefreshSnapshotInput next = prev;
+
+    next.route = 3;
+
+    gboolean equal = onboarding_refresh_snapshot_equal(&prev, &next);
+    g_assert_false(equal);
+
+    OnboardingRefreshAction action = onboarding_refresh_action_decide(equal, TRUE);
+    g_assert_cmpint(action, ==, ONBOARDING_REFRESH_ACTION_REBUILD_PAGES);
+}
+
 static void test_ancestor_walk_nonexistent_child(void) {
     gchar *path = g_strdup_printf("/tmp/openclaw_test_nonexistent_%d/foo/bar", g_random_int());
     gchar *res = find_nearest_existing_ancestor(path);
@@ -159,6 +218,14 @@ int main(int argc, char **argv) {
     g_test_add_func("/seams/tray_dispatch/settings_onboarding_hidden", test_tray_dispatch_settings_onboarding_hidden);
     g_test_add_func("/seams/tray_dispatch/diagnostics_onboarding_visible", test_tray_dispatch_diagnostics_onboarding_visible);
     g_test_add_func("/seams/tray_dispatch/repeated_requests_safe", test_tray_dispatch_repeated_requests_safe);
+
+    /* onboarding refresh regression tests */
+    g_test_add_func("/seams/onboarding_refresh/route_stable_config_change_refreshes_live",
+                    test_onboarding_refresh_route_stable_env_change_refreshes_live);
+    g_test_add_func("/seams/onboarding_refresh/route_stable_state_dir_change_refreshes_live",
+                    test_onboarding_refresh_route_stable_state_dir_change_refreshes_live);
+    g_test_add_func("/seams/onboarding_refresh/route_changed_rebuilds_pages",
+                    test_onboarding_refresh_route_changed_rebuilds_pages);
 
     return g_test_run();
 }


### PR DESCRIPTION
Add a single canonical runtime-path contract for Linux
diagnostics-facing config and state directory resolution.

Refactor onboarding, integrated Environment, and Diagnostics
to consume the shared helper instead of maintaining local
effective-path precedence logic. Define explicit ownership
semantics for returned path strings so all three surfaces use
the same safe values.

Add dedicated onboarding refresh regression coverage for
route-stable Environment updates so state changes refresh
diagnostics correctly even when the onboarding route does not
change.