### PR TITLE
apps/linux: unify general path truth and tray sensitivity contract (#80)

### DIFF
--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -13,7 +13,7 @@ Current foundation:
 - native local gateway client over HTTP + WebSocket
 - `systemd --user` integration for `openclaw-gateway.service`
 - gateway start / stop / restart / refresh
-- diagnostics window with systemd + gateway runtime state
+- integrated main-window Diagnostics section with systemd + gateway runtime state
 
 This is still an early-stage foundation. The goal of this document is to describe the **current, tested baseline** from a clean Ubuntu machine up to a working local gateway + Linux companion flow.
 

--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -924,26 +924,39 @@ static void on_gen_quit(GtkButton *b, gpointer d) {
     if (app) g_application_quit(app);
 }
 
-static void on_gen_reveal_config(GtkButton *b, gpointer d) {
-    (void)b; (void)d;
-    GatewayConfig *cfg = gateway_client_get_config();
-    if (cfg && cfg->config_path) {
-        g_autofree gchar *dir = g_path_get_dirname(cfg->config_path);
-        g_autofree gchar *uri = g_filename_to_uri(dir, NULL, NULL);
-        if (uri) g_app_info_launch_default_for_uri(uri, NULL, NULL);
-    }
-}
+static void general_resolve_effective_paths(RuntimeEffectivePaths *out) {
+    if (!out) return;
 
-static void on_gen_reveal_state_dir(GtkButton *b, gpointer d) {
-    (void)b; (void)d;
     g_autofree gchar *profile = NULL;
     g_autofree gchar *state_dir = NULL;
     g_autofree gchar *config_path = NULL;
     systemd_get_runtime_context(&profile, &state_dir, &config_path);
-    if (state_dir) {
-        g_autofree gchar *uri = g_filename_to_uri(state_dir, NULL, NULL);
+
+    GatewayConfig *cfg = gateway_client_get_config();
+    runtime_effective_paths_resolve(cfg, profile, state_dir, config_path, out);
+}
+
+static void on_gen_reveal_config(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    RuntimeEffectivePaths effective_paths = {0};
+    general_resolve_effective_paths(&effective_paths);
+    if (effective_paths.effective_config_path) {
+        g_autofree gchar *dir = g_path_get_dirname(effective_paths.effective_config_path);
+        g_autofree gchar *uri = g_filename_to_uri(dir, NULL, NULL);
         if (uri) g_app_info_launch_default_for_uri(uri, NULL, NULL);
     }
+    runtime_effective_paths_clear(&effective_paths);
+}
+
+static void on_gen_reveal_state_dir(GtkButton *b, gpointer d) {
+    (void)b; (void)d;
+    RuntimeEffectivePaths effective_paths = {0};
+    general_resolve_effective_paths(&effective_paths);
+    if (effective_paths.effective_state_dir) {
+        g_autofree gchar *uri = g_filename_to_uri(effective_paths.effective_state_dir, NULL, NULL);
+        if (uri) g_app_info_launch_default_for_uri(uri, NULL, NULL);
+    }
+    runtime_effective_paths_clear(&effective_paths);
 }
 
 /* Helper: create a row with a bold label and a value label */
@@ -1164,12 +1177,16 @@ static void refresh_general_content(void) {
 
     /* Paths & profile */
     g_autofree gchar *profile = NULL;
-    g_autofree gchar *state_dir = NULL;
-    g_autofree gchar *config_path = NULL;
-    systemd_get_runtime_context(&profile, &state_dir, &config_path);
+    systemd_get_runtime_context(&profile, NULL, NULL);
+
+    RuntimeEffectivePaths effective_paths = {0};
+    general_resolve_effective_paths(&effective_paths);
 
     RuntimePathStatus general_paths = {0};
-    runtime_path_status_build(config_path, state_dir, NULL, &general_paths);
+    runtime_path_status_build(effective_paths.effective_config_path,
+                              effective_paths.effective_state_dir,
+                              NULL,
+                              &general_paths);
 
     g_autofree gchar *profile_display = NULL;
     if (profile && profile[0] != '\0') {
@@ -1190,6 +1207,7 @@ static void refresh_general_content(void) {
         profile_display);
 
     runtime_path_status_clear(&general_paths);
+    runtime_effective_paths_clear(&effective_paths);
 
     /* Button sensitivity */
     gtk_widget_set_sensitive(gen_btn_start, dm.can_start);
@@ -2227,8 +2245,6 @@ static void refresh_diagnostics_content(void) {
  * ══════════════════════════════════════════════════════════════════ */
 
 static GtkWidget *env_checks_box = NULL;
-
-extern void systemd_get_runtime_context(gchar **out_profile, gchar **out_state_dir, gchar **out_config_path);
 
 static void populate_env_checks(GtkWidget *container) {
     /* Clear previous children */

--- a/apps/linux/src/display_model.c
+++ b/apps/linux/src/display_model.c
@@ -229,6 +229,7 @@ void tray_display_model_build(
     AppState state,
     RuntimeMode runtime_mode,
     const HealthState *health,
+    gboolean service_controllable,
     TrayDisplayModel *out)
 {
     if (!out) return;
@@ -239,20 +240,35 @@ void tray_display_model_build(
     RuntimeModePresentation rmp;
     runtime_mode_describe(runtime_mode, &rmp);
     out->runtime_label = rmp.label;
+    (void)health;
 
-    /* Action sensitivities mirror dashboard logic but simplified */
-    gboolean can_act = (state != STATE_STARTING && state != STATE_STOPPING);
-    gboolean is_stoppable = (state == STATE_RUNNING ||
-                             state == STATE_RUNNING_WITH_WARNING ||
-                             state == STATE_DEGRADED);
-    gboolean is_startable = (state == STATE_STOPPED ||
-                             state == STATE_ERROR);
-
-    out->start_sensitive = is_startable && can_act;
-    out->stop_sensitive = is_stoppable && can_act;
-    out->restart_sensitive = is_stoppable && can_act;
     out->refresh_sensitive = TRUE;
-    out->open_dashboard_sensitive = (health && health->config_valid);
+
+    switch (state) {
+    case STATE_STOPPED:
+    case STATE_ERROR:
+        out->start_sensitive = service_controllable;
+        break;
+    case STATE_STARTING:
+        out->stop_sensitive = service_controllable;
+        break;
+    case STATE_RUNNING:
+    case STATE_RUNNING_WITH_WARNING:
+    case STATE_DEGRADED:
+        out->stop_sensitive = service_controllable;
+        out->restart_sensitive = service_controllable;
+        out->open_dashboard_sensitive = TRUE;
+        break;
+    case STATE_STOPPING:
+    case STATE_NEEDS_SETUP:
+    case STATE_NEEDS_GATEWAY_INSTALL:
+    case STATE_NEEDS_ONBOARDING:
+    case STATE_USER_SYSTEMD_UNAVAILABLE:
+    case STATE_SYSTEM_UNSUPPORTED:
+    case STATE_CONFIG_INVALID:
+    default:
+        break;
+    }
 }
 
 /* ── Pairing status (app footer) ──

--- a/apps/linux/src/display_model.h
+++ b/apps/linux/src/display_model.h
@@ -104,6 +104,7 @@ void tray_display_model_build(
     AppState state,
     RuntimeMode runtime_mode,
     const HealthState *health,
+    gboolean service_controllable,
     TrayDisplayModel *out);
 
 /* ── Pairing status (app footer) ──

--- a/apps/linux/src/tray.c
+++ b/apps/linux/src/tray.c
@@ -296,6 +296,7 @@ void tray_update_from_state(const AppState state) {
     
     /* Get systemd state via correct API */
     SystemdState *sys = state_get_systemd();
+    HealthState *health = state_get_health();
     
     /* A1: Compute service controllability - required for correct Stop/Restart gating.
      * A service is controllable only if:
@@ -315,50 +316,17 @@ void tray_update_from_state(const AppState state) {
     const gchar *status_str = state_get_current_string();
     g_autofree gchar *status_line = g_strdup_printf("STATE:%s\n", status_str);
     send_line_to_helper(status_line, NULL);
-    
     OC_LOG_TRACE(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state state=%s controllable=%d", 
                  status_str, service_controllable);
-    
-    /* A3: Compute action sensitivities from BOTH app state AND service controllability.
-     * Stop/Restart are only sensitive if the service is actually controllable.
-     */
-    gboolean can_start = FALSE;
-    gboolean can_stop = FALSE;
-    gboolean can_restart = FALSE;
-    gboolean can_open_dashboard = FALSE;
-    
-    switch (state) {
-        case STATE_NEEDS_SETUP:
-        case STATE_NEEDS_GATEWAY_INSTALL:
-        case STATE_NEEDS_ONBOARDING:
-        case STATE_USER_SYSTEMD_UNAVAILABLE:
-        case STATE_SYSTEM_UNSUPPORTED:
-        case STATE_CONFIG_INVALID:
-            /* No actions possible in these states */
-            break;
-        case STATE_STOPPED:
-        case STATE_ERROR:
-            can_start = service_controllable;
-            break;
-        case STATE_STARTING:
-            can_stop = service_controllable;
-            break;
-        case STATE_STOPPING:
-            /* In stopping state, no actions until settled */
-            break;
-        case STATE_RUNNING:
-        case STATE_RUNNING_WITH_WARNING:
-        case STATE_DEGRADED:
-            can_stop = service_controllable;
-            can_restart = service_controllable;
-            can_open_dashboard = TRUE;
-            break;
-    }
+
+    RuntimeMode rm = state_get_runtime_mode();
+    TrayDisplayModel tdm;
+    tray_display_model_build(state, rm, health, service_controllable, &tdm);
     
     /* A4: Send DASHBOARD_URL first (if available) with redacted logging.
      * Send real URL to helper but redact token fragment in logs.
      */
-    if (can_open_dashboard) {
+    if (tdm.open_dashboard_sensitive) {
         GatewayConfig *cfg = gateway_client_get_config();
         if (cfg) {
             g_autofree gchar *url = gateway_config_dashboard_url(cfg);
@@ -382,12 +350,12 @@ void tray_update_from_state(const AppState state) {
      * "Chat blocked" state, so we keep OPEN_CHAT sensitive whenever the
      * dashboard is too.
      */
-    gboolean can_open_chat = can_open_dashboard;
+    gboolean can_open_chat = tdm.open_dashboard_sensitive;
 
-    g_autofree gchar *sensitive_start = g_strdup_printf("SENSITIVE:START:%d\n", can_start ? 1 : 0);
-    g_autofree gchar *sensitive_stop = g_strdup_printf("SENSITIVE:STOP:%d\n", can_stop ? 1 : 0);
-    g_autofree gchar *sensitive_restart = g_strdup_printf("SENSITIVE:RESTART:%d\n", can_restart ? 1 : 0);
-    g_autofree gchar *sensitive_dashboard = g_strdup_printf("SENSITIVE:OPEN_DASHBOARD:%d\n", can_open_dashboard ? 1 : 0);
+    g_autofree gchar *sensitive_start = g_strdup_printf("SENSITIVE:START:%d\n", tdm.start_sensitive ? 1 : 0);
+    g_autofree gchar *sensitive_stop = g_strdup_printf("SENSITIVE:STOP:%d\n", tdm.stop_sensitive ? 1 : 0);
+    g_autofree gchar *sensitive_restart = g_strdup_printf("SENSITIVE:RESTART:%d\n", tdm.restart_sensitive ? 1 : 0);
+    g_autofree gchar *sensitive_dashboard = g_strdup_printf("SENSITIVE:OPEN_DASHBOARD:%d\n", tdm.open_dashboard_sensitive ? 1 : 0);
     g_autofree gchar *sensitive_chat = g_strdup_printf("SENSITIVE:OPEN_CHAT:%d\n", can_open_chat ? 1 : 0);
 
     /*
@@ -405,10 +373,6 @@ void tray_update_from_state(const AppState state) {
     /* A6: Send runtime mode label if available.
      * tray_helper.c supports RUNTIME:<label> for the runtime menu item.
      */
-    RuntimeMode rm = state_get_runtime_mode();
-    TrayDisplayModel tdm;
-    HealthState *health = state_get_health();
-    tray_display_model_build(state, rm, health, &tdm);
     if (tdm.runtime_label) {
         g_autofree gchar *runtime_line = g_strdup_printf("RUNTIME:%s\n", tdm.runtime_label);
         send_line_to_helper(runtime_line, NULL);

--- a/apps/linux/tests/test_display_model.c
+++ b/apps/linux/tests/test_display_model.c
@@ -262,12 +262,12 @@ static void test_dashboard_null_output(void) {
  * Tray display model tests
  * ══════════════════════════════════════════════════════════════════ */
 
-static void test_tray_running(void) {
+static void test_tray_running_service_controllable(void) {
     HealthState hs = {0};
     hs.config_valid = TRUE;
     hs.has_wizard_onboard_marker = TRUE;
     TrayDisplayModel tm;
-    tray_display_model_build(STATE_RUNNING, RUNTIME_EXPECTED_SERVICE_HEALTHY, &hs, &tm);
+    tray_display_model_build(STATE_RUNNING, RUNTIME_EXPECTED_SERVICE_HEALTHY, &hs, TRUE, &tm);
 
     assert_contains(tm.status_label, "Running", "tray_running.label");
     g_assert_nonnull(tm.runtime_label);
@@ -277,10 +277,23 @@ static void test_tray_running(void) {
     g_assert_true(tm.open_dashboard_sensitive);
 }
 
-static void test_tray_stopped(void) {
+static void test_tray_running_service_not_controllable(void) {
+    HealthState hs = {0};
+    hs.config_valid = TRUE;
+    TrayDisplayModel tm;
+    tray_display_model_build(STATE_RUNNING, RUNTIME_EXPECTED_SERVICE_HEALTHY, &hs, FALSE, &tm);
+
+    assert_contains(tm.status_label, "Running", "tray_running_uncontrollable.label");
+    g_assert_false(tm.start_sensitive);
+    g_assert_false(tm.stop_sensitive);
+    g_assert_false(tm.restart_sensitive);
+    g_assert_true(tm.open_dashboard_sensitive);
+}
+
+static void test_tray_stopped_service_controllable(void) {
     HealthState hs = {0};
     TrayDisplayModel tm;
-    tray_display_model_build(STATE_STOPPED, RUNTIME_NONE, &hs, &tm);
+    tray_display_model_build(STATE_STOPPED, RUNTIME_NONE, &hs, TRUE, &tm);
 
     assert_contains(tm.status_label, "Stopped", "tray_stopped.label");
     g_assert_true(tm.start_sensitive);
@@ -289,29 +302,44 @@ static void test_tray_stopped(void) {
     g_assert_false(tm.open_dashboard_sensitive);
 }
 
-static void test_tray_starting(void) {
+static void test_tray_stopped_service_not_controllable(void) {
     HealthState hs = {0};
     TrayDisplayModel tm;
-    tray_display_model_build(STATE_STARTING, RUNTIME_NONE, &hs, &tm);
+    tray_display_model_build(STATE_STOPPED, RUNTIME_NONE, &hs, FALSE, &tm);
 
-    assert_contains(tm.status_label, "Starting", "tray_starting.label");
-    /* Transition: all service actions disabled */
+    assert_contains(tm.status_label, "Stopped", "tray_stopped_uncontrollable.label");
     g_assert_false(tm.start_sensitive);
     g_assert_false(tm.stop_sensitive);
     g_assert_false(tm.restart_sensitive);
+    g_assert_false(tm.open_dashboard_sensitive);
+}
+
+static void test_tray_starting_service_controllable(void) {
+    HealthState hs = {0};
+    TrayDisplayModel tm;
+    tray_display_model_build(STATE_STARTING, RUNTIME_NONE, &hs, TRUE, &tm);
+
+    assert_contains(tm.status_label, "Starting", "tray_starting.label");
+    g_assert_false(tm.start_sensitive);
+    g_assert_true(tm.stop_sensitive);
+    g_assert_false(tm.restart_sensitive);
+    g_assert_false(tm.open_dashboard_sensitive);
 }
 
 static void test_tray_needs_setup(void) {
     HealthState hs = {0};
     TrayDisplayModel tm;
-    tray_display_model_build(STATE_NEEDS_SETUP, RUNTIME_NONE, &hs, &tm);
+    tray_display_model_build(STATE_NEEDS_SETUP, RUNTIME_NONE, &hs, TRUE, &tm);
 
     assert_contains(tm.status_label, "Setup Required", "tray_setup.label");
     g_assert_false(tm.start_sensitive);
+    g_assert_false(tm.stop_sensitive);
+    g_assert_false(tm.restart_sensitive);
+    g_assert_false(tm.open_dashboard_sensitive);
 }
 
 static void test_tray_null_output(void) {
-    tray_display_model_build(STATE_RUNNING, RUNTIME_NONE, NULL, NULL);
+    tray_display_model_build(STATE_RUNNING, RUNTIME_NONE, NULL, TRUE, NULL);
 }
 
 /* ══════════════════════════════════════════════════════════════════
@@ -835,9 +863,16 @@ int main(int argc, char **argv) {
                     test_dashboard_null_output);
 
     /* Tray display model */
-    g_test_add_func("/display_model/tray/running", test_tray_running);
-    g_test_add_func("/display_model/tray/stopped", test_tray_stopped);
-    g_test_add_func("/display_model/tray/starting", test_tray_starting);
+    g_test_add_func("/display_model/tray/running_service_controllable",
+                    test_tray_running_service_controllable);
+    g_test_add_func("/display_model/tray/running_service_not_controllable",
+                    test_tray_running_service_not_controllable);
+    g_test_add_func("/display_model/tray/stopped_service_controllable",
+                    test_tray_stopped_service_controllable);
+    g_test_add_func("/display_model/tray/stopped_service_not_controllable",
+                    test_tray_stopped_service_not_controllable);
+    g_test_add_func("/display_model/tray/starting_service_controllable",
+                    test_tray_starting_service_controllable);
     g_test_add_func("/display_model/tray/needs_setup", test_tray_needs_setup);
     g_test_add_func("/display_model/tray/null_output", test_tray_null_output);
 


### PR DESCRIPTION
Route the General section through canonical effective-path resolution so displayed config/state paths and reveal actions use the same effective locations already used by Environment and Diagnostics.

Unify tray action sensitivity behind the pure tray display model by adding service_controllable as an explicit input and making tray.c emit helper IPC directly from that model instead of maintaining a parallel sensitivity switch.

Update Linux tray display-model tests to cover controllable and non-controllable service states, and align the Linux README so Diagnostics is described as an integrated main-window section.

Why:
- eliminate cross-surface path drift in the Linux companion
- ensure live tray behavior matches the tested pure contract
- keep Linux operator documentation aligned with the shipped UI