### PR TITLE
fix(linux): plug RPC and config editor leaks (#82)

### DIFF
--- a/apps/linux/src/gateway_rpc.c
+++ b/apps/linux/src/gateway_rpc.c
@@ -77,8 +77,11 @@ gchar* gateway_rpc_request(const gchar *method,
     pending->user_data = user_data;
 
     guint effective_timeout = timeout_ms > 0 ? timeout_ms : GATEWAY_RPC_DEFAULT_TIMEOUT_MS;
-    pending->timeout_id = g_timeout_add(effective_timeout, on_request_timeout,
-                                        g_strdup(request_id));
+    pending->timeout_id = g_timeout_add_full(G_PRIORITY_DEFAULT,
+                                             effective_timeout,
+                                             on_request_timeout,
+                                             g_strdup(request_id),
+                                             g_free);
 
     g_hash_table_insert(pending_requests, pending->request_id, pending);
 
@@ -207,13 +210,11 @@ void gateway_rpc_response_free_members(GatewayRpcResponse *response) {
 static gboolean on_request_timeout(gpointer user_data) {
     gchar *request_id = user_data;
     if (!request_id || !pending_requests) {
-        g_free(request_id);
         return G_SOURCE_REMOVE;
     }
 
     PendingRpcRequest *pending = g_hash_table_lookup(pending_requests, request_id);
     if (!pending) {
-        g_free(request_id);
         return G_SOURCE_REMOVE;
     }
 
@@ -234,7 +235,6 @@ static gboolean on_request_timeout(gpointer user_data) {
     gpointer cb_data = pending->user_data;
 
     g_hash_table_remove(pending_requests, request_id);
-    g_free(request_id);
 
     cb(&response, cb_data);
     gateway_rpc_response_free_members(&response);

--- a/apps/linux/src/section_channels.c
+++ b/apps/linux/src/section_channels.c
@@ -243,12 +243,10 @@ static void on_config_dialog_response(GObject *source, GAsyncResult *result, gpo
     
     /* TRUE deep copy: serialize stored config and re-parse to get isolated mutable tree.
      * session->full_config_obj must remain unchanged in memory during save preparation. */
-    g_autofree gchar *stored_config_json = json_to_string(
-        json_node_new(JSON_NODE_OBJECT), FALSE);
+    g_autofree gchar *stored_config_json = NULL;
     {
         JsonNode *temp_node = json_node_new(JSON_NODE_OBJECT);
         json_node_set_object(temp_node, session->full_config_obj);
-        g_free(stored_config_json);
         stored_config_json = json_to_string(temp_node, FALSE);
         json_node_unref(temp_node);
     }


### PR DESCRIPTION
Use `g_timeout_add_full` in `gateway_rpc.c` so the duplicated `request_id` passed as timeout user data is freed through a `GDestroyNotify` callback when the source is removed.

Remove the manual `g_free(request_id)` calls from
`on_request_timeout`, since GLib now owns cleanup of the timeout user data.

In `section_channels.c`, initialize `stored_config_json` to `NULL` instead of allocating an inline `JsonNode` that becomes unreachable during channel config saves.
