### PR TITLE
refactor(linux): standardise async generation tracking to eliminate duplicated structs (#84)

### DIFF
--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -1265,28 +1265,10 @@ typedef struct {
     gchar *label;
 } ConfigModelChoice;
 
-typedef struct {
-    guint generation;
-} ConfigRequestContext;
-
 static gchar* cfg_editor_get_text(void);
 static void cfg_request_reload(void);
 static void cfg_refresh_setup_surface(void);
 static void on_cfg_save_done(const GatewayRpcResponse *response, gpointer user_data);
-
-static ConfigRequestContext* cfg_request_context_new(void) {
-    ConfigRequestContext *ctx = g_new0(ConfigRequestContext, 1);
-    ctx->generation = cfg_generation;
-    return ctx;
-}
-
-static gboolean cfg_request_context_is_stale(const ConfigRequestContext *ctx) {
-    return !ctx || ctx->generation != cfg_generation;
-}
-
-static void cfg_request_context_free(gpointer data) {
-    g_free(data);
-}
 
 static void cfg_model_choice_free(ConfigModelChoice *choice) {
     if (!choice) return;
@@ -1484,10 +1466,9 @@ static void cfg_request_save_text(const gchar *text) {
 
     cfg_request_in_flight = TRUE;
     cfg_refresh_buttons();
-    ConfigRequestContext *ctx = cfg_request_context_new();
-    g_autofree gchar *rid = mutation_config_set(text, cfg_baseline_hash, on_cfg_save_done, ctx);
+    guint current_gen = cfg_generation;
+    g_autofree gchar *rid = mutation_config_set(text, cfg_baseline_hash, on_cfg_save_done, GUINT_TO_POINTER(current_gen));
     if (!rid) {
-        cfg_request_context_free(ctx);
         cfg_request_in_flight = FALSE;
         if (cfg_validation_label) {
             gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Failed to request config.set");
@@ -1598,12 +1579,10 @@ static void cfg_refresh_setup_surface(void) {
 }
 
 static void on_cfg_models_list_done(const GatewayRpcResponse *response, gpointer user_data) {
-    ConfigRequestContext *ctx = (ConfigRequestContext *)user_data;
-    if (cfg_request_context_is_stale(ctx)) {
-        cfg_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != cfg_generation) {
         return;
     }
-    cfg_request_context_free(ctx);
 
     cfg_models_request_in_flight = FALSE;
     if (cfg_models_cache) g_ptr_array_unref(cfg_models_cache);
@@ -1653,10 +1632,9 @@ static void on_cfg_reload_models(GtkButton *button, gpointer user_data) {
 
     cfg_models_request_in_flight = TRUE;
     cfg_refresh_buttons();
-    ConfigRequestContext *ctx = cfg_request_context_new();
-    g_autofree gchar *rid = gateway_rpc_request("models.list", NULL, 0, on_cfg_models_list_done, ctx);
+    guint current_gen = cfg_generation;
+    g_autofree gchar *rid = gateway_rpc_request("models.list", NULL, 0, on_cfg_models_list_done, GUINT_TO_POINTER(current_gen));
     if (!rid) {
-        cfg_request_context_free(ctx);
         cfg_models_request_in_flight = FALSE;
         if (cfg_setup_status_label) {
             gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Failed to request models.list.");
@@ -1768,12 +1746,10 @@ static void on_cfg_buffer_changed(GtkTextBuffer *buffer, gpointer user_data) {
 }
 
 static void on_cfg_get_done(const GatewayRpcResponse *response, gpointer user_data) {
-    ConfigRequestContext *ctx = (ConfigRequestContext *)user_data;
-    if (cfg_request_context_is_stale(ctx)) {
-        cfg_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != cfg_generation) {
         return;
     }
-    cfg_request_context_free(ctx);
 
     cfg_request_in_flight = FALSE;
 
@@ -1827,10 +1803,9 @@ static void cfg_request_reload(void) {
     if (cfg_request_in_flight) return;
     cfg_request_in_flight = TRUE;
     cfg_refresh_buttons();
-    ConfigRequestContext *ctx = cfg_request_context_new();
-    g_autofree gchar *rid = mutation_config_get(NULL, on_cfg_get_done, ctx);
+    guint current_gen = cfg_generation;
+    g_autofree gchar *rid = mutation_config_get(NULL, on_cfg_get_done, GUINT_TO_POINTER(current_gen));
     if (!rid) {
-        cfg_request_context_free(ctx);
         cfg_request_in_flight = FALSE;
         if (cfg_validation_label) {
             gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Failed to request config.get");
@@ -1846,12 +1821,10 @@ static void on_cfg_reload(GtkButton *b, gpointer d) {
 }
 
 static void on_cfg_save_done(const GatewayRpcResponse *response, gpointer user_data) {
-    ConfigRequestContext *ctx = (ConfigRequestContext *)user_data;
-    if (cfg_request_context_is_stale(ctx)) {
-        cfg_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != cfg_generation) {
         return;
     }
-    cfg_request_context_free(ctx);
 
     cfg_request_in_flight = FALSE;
     if (!response || !response->ok) {

--- a/apps/linux/src/chat_controller.c
+++ b/apps/linux/src/chat_controller.c
@@ -176,24 +176,6 @@ static ChatController *g_ctl = NULL;
 #define chat_generation                (g_ctl->generation)
 #define chat_gate_info                 (g_ctl->gate_info)
 
-typedef struct {
-    guint generation;
-} ChatRequestContext;
-
-static ChatRequestContext* chat_request_context_new(void) {
-    ChatRequestContext *ctx = g_new0(ChatRequestContext, 1);
-    ctx->generation = chat_generation;
-    return ctx;
-}
-
-static gboolean chat_request_context_is_stale(const ChatRequestContext *ctx) {
-    return !ctx || ctx->generation != chat_generation;
-}
-
-static void chat_request_context_free(gpointer data) {
-    g_free(data);
-}
-
 static void chat_agent_choice_free(ChatAgentChoice *a) {
     if (!a) return;
     g_free(a->id);
@@ -751,12 +733,10 @@ static void chat_rebuild_session_dropdown(void) {
 }
 
 static void on_chat_history_response(const GatewayRpcResponse *response, gpointer user_data) {
-    ChatRequestContext *ctx = (ChatRequestContext *)user_data;
-    if (chat_request_context_is_stale(ctx)) {
-        chat_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != chat_generation) {
         return;
     }
-    chat_request_context_free(ctx);
 
     if (!chat_status_label) {
         return;
@@ -812,11 +792,10 @@ static void chat_request_history_for_selected(void) {
     g_object_unref(b);
 
     chat_history_in_flight = TRUE;
-    ChatRequestContext *ctx = chat_request_context_new();
-    g_autofree gchar *rid = gateway_rpc_request("chat.history", params, 0, on_chat_history_response, ctx);
+    guint current_gen = chat_generation;
+    g_autofree gchar *rid = gateway_rpc_request("chat.history", params, 0, on_chat_history_response, GUINT_TO_POINTER(current_gen));
     json_node_unref(params);
     if (!rid) {
-        chat_request_context_free(ctx);
         chat_history_in_flight = FALSE;
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Gateway not connected");
         chat_rebuild_messages_ui();
@@ -824,12 +803,10 @@ static void chat_request_history_for_selected(void) {
 }
 
 static void on_chat_sessions_response(const GatewayRpcResponse *response, gpointer user_data) {
-    ChatRequestContext *ctx = (ChatRequestContext *)user_data;
-    if (chat_request_context_is_stale(ctx)) {
-        chat_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != chat_generation) {
         return;
     }
-    chat_request_context_free(ctx);
 
     if (!chat_status_label) {
         return;
@@ -900,23 +877,20 @@ static void chat_request_sessions_for_selected_agent(void) {
     g_object_unref(b);
 
     chat_sessions_in_flight = TRUE;
-    ChatRequestContext *ctx = chat_request_context_new();
-    g_autofree gchar *rid = gateway_rpc_request("sessions.list", params, 0, on_chat_sessions_response, ctx);
+    guint current_gen = chat_generation;
+    g_autofree gchar *rid = gateway_rpc_request("sessions.list", params, 0, on_chat_sessions_response, GUINT_TO_POINTER(current_gen));
     json_node_unref(params);
     if (!rid) {
-        chat_request_context_free(ctx);
         chat_sessions_in_flight = FALSE;
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Failed to request sessions.list");
     }
 }
 
 static void on_models_response(const GatewayRpcResponse *response, gpointer user_data) {
-    ChatRequestContext *ctx = (ChatRequestContext *)user_data;
-    if (chat_request_context_is_stale(ctx)) {
-        chat_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != chat_generation) {
         return;
     }
-    chat_request_context_free(ctx);
 
     g_autoptr(GPtrArray) parsed_models =
         g_ptr_array_new_with_free_func((GDestroyNotify)chat_model_choice_free);
@@ -1002,12 +976,10 @@ static void on_models_response(const GatewayRpcResponse *response, gpointer user
 }
 
 static void on_agents_response(const GatewayRpcResponse *response, gpointer user_data) {
-    ChatRequestContext *ctx = (ChatRequestContext *)user_data;
-    if (chat_request_context_is_stale(ctx)) {
-        chat_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != chat_generation) {
         return;
     }
-    chat_request_context_free(ctx);
 
     g_autoptr(GPtrArray) parsed_agents =
         g_ptr_array_new_with_free_func((GDestroyNotify)chat_agent_choice_free);
@@ -1082,12 +1054,10 @@ static void on_agents_response(const GatewayRpcResponse *response, gpointer user
 }
 
 static void on_chat_send_response(const GatewayRpcResponse *response, gpointer user_data) {
-    ChatRequestContext *ctx = (ChatRequestContext *)user_data;
-    if (chat_request_context_is_stale(ctx)) {
-        chat_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != chat_generation) {
         return;
     }
-    chat_request_context_free(ctx);
 
     if (!chat_status_label) {
         return;
@@ -1148,11 +1118,10 @@ static void chat_send_current_message(void) {
                 chat_pending_run_id ? chat_pending_run_id : "(none)",
                 strlen(text));
 
-    ChatRequestContext *ctx = chat_request_context_new();
-    g_autofree gchar *rid = gateway_rpc_request("chat.send", params, 0, on_chat_send_response, ctx);
+    guint current_gen = chat_generation;
+    g_autofree gchar *rid = gateway_rpc_request("chat.send", params, 0, on_chat_send_response, GUINT_TO_POINTER(current_gen));
     json_node_unref(params);
     if (!rid) {
-        chat_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Unable to send while disconnected");
         chat_clear_pending_state();
         chat_rebuild_messages_ui();
@@ -1329,12 +1298,10 @@ static void on_chat_session_changed(GtkDropDown *dropdown, GParamSpec *pspec, gp
 }
 
 static void on_chat_model_patch_response(const GatewayRpcResponse *response, gpointer user_data) {
-    ChatRequestContext *ctx = (ChatRequestContext *)user_data;
-    if (chat_request_context_is_stale(ctx)) {
-        chat_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != chat_generation) {
         return;
     }
-    chat_request_context_free(ctx);
 
     if (!chat_status_label) {
         return;
@@ -1373,12 +1340,11 @@ static void on_chat_model_changed(GtkDropDown *dropdown, GParamSpec *pspec, gpoi
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
-    ChatRequestContext *ctx = chat_request_context_new();
+    guint current_gen = chat_generation;
     g_autofree gchar *rid = gateway_rpc_request("sessions.patch", params, 0,
-                                                on_chat_model_patch_response, ctx);
+                                                on_chat_model_patch_response, GUINT_TO_POINTER(current_gen));
     json_node_unref(params);
     if (!rid) {
-        chat_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Failed to send sessions.patch");
     }
 }
@@ -1549,15 +1515,12 @@ static void chat_refresh(void) {
 
     chat_fetch_in_flight = TRUE;
     chat_dependencies_pending = 0;
-    ChatRequestContext *agents_ctx = chat_request_context_new();
-    g_autofree gchar *agents_rid = gateway_rpc_request("agents.list", NULL, 0, on_agents_response, agents_ctx);
+    guint current_gen = chat_generation;
+    g_autofree gchar *agents_rid = gateway_rpc_request("agents.list", NULL, 0, on_agents_response, GUINT_TO_POINTER(current_gen));
     if (agents_rid) chat_dependencies_pending++;
-    else chat_request_context_free(agents_ctx);
 
-    ChatRequestContext *models_ctx = chat_request_context_new();
-    g_autofree gchar *models_rid = gateway_rpc_request("models.list", NULL, 0, on_models_response, models_ctx);
+    g_autofree gchar *models_rid = gateway_rpc_request("models.list", NULL, 0, on_models_response, GUINT_TO_POINTER(current_gen));
     if (models_rid) chat_dependencies_pending++;
-    else chat_request_context_free(models_ctx);
 
     if (!agents_rid || !models_rid) {
         gtk_label_set_text(GTK_LABEL(chat_status_label), "Failed to request chat dependencies");

--- a/apps/linux/src/section_agents.c
+++ b/apps/linux/src/section_agents.c
@@ -79,24 +79,6 @@ static gboolean agents_fetch_in_flight = FALSE;
 static gint64 agents_last_fetch_us = 0;
 static guint agents_generation = 1;
 
-typedef struct {
-    guint generation;
-} AgentsRequestContext;
-
-static AgentsRequestContext* agents_request_context_new(void) {
-    AgentsRequestContext *ctx = g_new0(AgentsRequestContext, 1);
-    ctx->generation = agents_generation;
-    return ctx;
-}
-
-static gboolean agents_request_context_is_stale(const AgentsRequestContext *ctx) {
-    return !ctx || ctx->generation != agents_generation;
-}
-
-static void agents_request_context_free(gpointer data) {
-    g_free(data);
-}
-
 static void agents_attach_dropdown_model(GtkStringList *new_model, guint selected, gboolean sensitive) {
     if (!new_model) return;
     ui_dropdown_replace_model(agents_model_dropdown,
@@ -179,13 +161,11 @@ static void agents_rebuild_files(const GPtrArray *files) {
 }
 
 static void on_agents_files_response(const GatewayRpcResponse *response, gpointer user_data) {
-    AgentsRequestContext *ctx = (AgentsRequestContext *)user_data;
-    if (agents_request_context_is_stale(ctx)) {
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != agents_generation) {
         OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: stale files callback dropped");
-        agents_request_context_free(ctx);
         return;
     }
-    agents_request_context_free(ctx);
 
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: files callback ok=%d", response ? response->ok : 0);
     g_autoptr(GPtrArray) files = g_ptr_array_new_with_free_func((GDestroyNotify)agent_file_row_free);
@@ -251,13 +231,12 @@ static void agents_request_files_for_selected(void) {
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
-    AgentsRequestContext *ctx = agents_request_context_new();
+    guint current_gen = agents_generation;
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: request agents.files.list");
     g_autofree gchar *rid = gateway_rpc_request("agents.files.list", params, 0,
-                                                on_agents_files_response, ctx);
+                                                on_agents_files_response, GUINT_TO_POINTER(current_gen));
     json_node_unref(params);
     if (!rid) {
-        agents_request_context_free(ctx);
         agents_rebuild_files(NULL);
     }
 }
@@ -329,27 +308,17 @@ static void agents_rebuild_list(void) {
 }
 
 static void on_agents_update_response(const GatewayRpcResponse *response, gpointer user_data) {
-    AgentsRequestContext *ctx = (AgentsRequestContext *)user_data;
-    if (agents_request_context_is_stale(ctx)) {
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != agents_generation) {
         OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: stale update callback dropped");
-        agents_request_context_free(ctx);
         return;
     }
-    agents_request_context_free(ctx);
 
     if (!agents_status_label) return;
     if (response->ok) {
         gtk_label_set_text(GTK_LABEL(agents_status_label), "Agent updated");
         section_mark_stale(&agents_last_fetch_us);
     } else {
-        /*
-         * Surface the actual server error so operators can diagnose the
-         * failure without tailing the terminal. A common class of
-         * failure was a torn-down WS after the Logs tab ran into the
-         * oversized-payload ceiling; the fix for that lives in
-         * `gateway_ws.c` / `section_logs.c`, but keeping a useful
-         * error message here is still worthwhile.
-         */
         const gchar *detail = (response->error_msg && response->error_msg[0] != '\0')
             ? response->error_msg
             : (response->error_code && response->error_code[0] != '\0'
@@ -407,14 +376,7 @@ static void on_agents_save_clicked(GtkButton *button, gpointer user_data) {
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
-    AgentsRequestContext *ctx = agents_request_context_new();
-    /*
-     * Structured payload log. The schema for `agents.update` accepts
-     * `agentId` plus any optional subset of `name` / `workspace` /
-     * `model` / `emoji` / `avatar`. We log which fields we chose to
-     * include this invocation so the server-side "agent update failed"
-     * response can be triaged without capturing the WebSocket frame.
-     */
+    guint current_gen = agents_generation;
     OC_LOG_INFO(OPENCLAW_LOG_CAT_STATE,
                 "agents.update agentId=%s name=%s workspace=%s avatar=%s model=%s",
                 a->id,
@@ -423,22 +385,19 @@ static void on_agents_save_clicked(GtkButton *button, gpointer user_data) {
                 (avatar && avatar[0] != '\0') ? avatar : "(unset)",
                 (model && model[0] != '\0') ? model : "(unset)");
     g_autofree gchar *rid = gateway_rpc_request("agents.update", params, 0,
-                                                on_agents_update_response, ctx);
+                                                on_agents_update_response, GUINT_TO_POINTER(current_gen));
     json_node_unref(params);
     if (!rid && agents_status_label) {
-        agents_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(agents_status_label), "Failed to send update");
     }
 }
 
 static void on_agents_list_response(const GatewayRpcResponse *response, gpointer user_data) {
-    AgentsRequestContext *ctx = (AgentsRequestContext *)user_data;
-    if (agents_request_context_is_stale(ctx)) {
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != agents_generation) {
         OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: stale agents.list callback dropped");
-        agents_request_context_free(ctx);
         return;
     }
-    agents_request_context_free(ctx);
 
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: agents.list callback ok=%d", response ? response->ok : 0);
     agents_fetch_in_flight = FALSE;
@@ -532,13 +491,11 @@ static void on_agents_list_response(const GatewayRpcResponse *response, gpointer
 }
 
 static void on_agents_models_response(const GatewayRpcResponse *response, gpointer user_data) {
-    AgentsRequestContext *ctx = (AgentsRequestContext *)user_data;
-    if (agents_request_context_is_stale(ctx)) {
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != agents_generation) {
         OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: stale models.list callback dropped");
-        agents_request_context_free(ctx);
         return;
     }
-    agents_request_context_free(ctx);
 
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: models.list callback ok=%d", response ? response->ok : 0);
     if (agent_models_cache) g_ptr_array_unref(agent_models_cache);
@@ -680,21 +637,18 @@ static void agents_refresh(void) {
     if (!section_is_stale(&agents_last_fetch_us)) return;
 
     agents_fetch_in_flight = TRUE;
-    AgentsRequestContext *list_ctx = agents_request_context_new();
+    guint current_gen = agents_generation;
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: request agents.list");
     g_autofree gchar *rid = gateway_rpc_request("agents.list", NULL, 0,
-                                                on_agents_list_response, list_ctx);
-    AgentsRequestContext *models_ctx = agents_request_context_new();
+                                                on_agents_list_response, GUINT_TO_POINTER(current_gen));
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "agents: request models.list");
     g_autofree gchar *mrid = gateway_rpc_request("models.list", NULL, 0,
-                                                 on_agents_models_response, models_ctx);
+                                                 on_agents_models_response, GUINT_TO_POINTER(current_gen));
     if (!rid) {
-        agents_request_context_free(list_ctx);
         agents_fetch_in_flight = FALSE;
         gtk_label_set_text(GTK_LABEL(agents_status_label), "Failed to request agents");
     }
     if (!mrid) {
-        agents_request_context_free(models_ctx);
         agents_set_model_dropdown_placeholder("Models unavailable", FALSE);
     }
     (void)mrid;

--- a/apps/linux/src/section_channels.c
+++ b/apps/linux/src/section_channels.c
@@ -38,24 +38,6 @@ typedef struct {
     gchar *channel_id;
 } ChannelsIdContext;
 
-typedef struct {
-    guint generation;
-} ChannelsRequestContext;
-
-static ChannelsRequestContext* channels_request_context_new(void) {
-    ChannelsRequestContext *ctx = g_new0(ChannelsRequestContext, 1);
-    ctx->generation = channels_generation;
-    return ctx;
-}
-
-static gboolean channels_request_context_is_stale(const ChannelsRequestContext *ctx) {
-    return !ctx || ctx->generation != channels_generation;
-}
-
-static void channels_request_context_free(gpointer data) {
-    g_free(data);
-}
-
 static ChannelsIdContext* channels_id_context_new(const gchar *channel_id) {
     ChannelsIdContext *ctx = g_new0(ChannelsIdContext, 1);
     ctx->generation = channels_generation;
@@ -81,12 +63,10 @@ static void channels_force_refresh(void);
 /* ── Mutation callbacks ──────────────────────────────────────────── */
 
 static void on_mutation_done(const GatewayRpcResponse *response, gpointer user_data) {
-    ChannelsRequestContext *ctx = (ChannelsRequestContext *)user_data;
-    if (channels_request_context_is_stale(ctx)) {
-        channels_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != channels_generation) {
         return;
     }
-    channels_request_context_free(ctx);
 
     if (!channels_status_label) return;
 
@@ -109,10 +89,9 @@ static void on_refresh_all_channels(GtkButton *btn, gpointer user_data) {
         gtk_label_set_text(GTK_LABEL(channels_status_label), "Refreshing all channels…");
     }
 
-    ChannelsRequestContext *ctx = channels_request_context_new();
-    g_autofree gchar *req = mutation_channels_status(TRUE, on_mutation_done, ctx);
+    guint current_gen = channels_generation;
+    g_autofree gchar *req = mutation_channels_status(TRUE, on_mutation_done, GUINT_TO_POINTER(current_gen));
     if (!req) {
-        channels_request_context_free(ctx);
         gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
         if (channels_status_label)
             gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to send refresh request");
@@ -452,12 +431,10 @@ static void on_edit_config(GtkButton *btn, gpointer user_data) {
 /* ── Web Login / QR Flow ─────────────────────────────────────────── */
 
 static void on_web_login_wait_done(const GatewayRpcResponse *response, gpointer user_data) {
-    ChannelsRequestContext *ctx = (ChannelsRequestContext *)user_data;
-    if (channels_request_context_is_stale(ctx)) {
-        channels_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != channels_generation) {
         return;
     }
-    channels_request_context_free(ctx);
     
     /* STRICT GUARDS: Check response state before any payload access */
     if (!response || !response->ok) {
@@ -599,10 +576,9 @@ static void on_web_login_start_done(const GatewayRpcResponse *response, gpointer
 
     /* Begin waiting for the actual login resolution */
     /* 120s timeout, null account_id since we are linking a primary account */
-    ChannelsRequestContext *wait_ctx = channels_request_context_new();
-    g_autofree gchar *req = mutation_web_login_wait(120000, NULL, on_web_login_wait_done, wait_ctx);
+    guint current_gen = channels_generation;
+    g_autofree gchar *req = mutation_web_login_wait(120000, NULL, on_web_login_wait_done, GUINT_TO_POINTER(current_gen));
     if (!req && channels_status_label) {
-        channels_request_context_free(wait_ctx);
         gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to send wait request");
     }
     
@@ -640,10 +616,9 @@ static void on_logout_dialog_response(GObject *source, GAsyncResult *result, gpo
     if (channels_status_label)
         gtk_label_set_text(GTK_LABEL(channels_status_label), "Logging out\u2026");
 
-    ChannelsRequestContext *ctx = channels_request_context_new();
-    g_autofree gchar *req = mutation_channels_logout(channel_id, account_id, on_mutation_done, ctx);
+    guint current_gen = channels_generation;
+    g_autofree gchar *req = mutation_channels_logout(channel_id, account_id, on_mutation_done, GUINT_TO_POINTER(current_gen));
     if (!req && channels_status_label) {
-        channels_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to send request");
     }
 }
@@ -855,12 +830,10 @@ static void channels_rebuild_list(void) {
 /* ── RPC callback ────────────────────────────────────────────────── */
 
 static void on_channels_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
-    ChannelsRequestContext *ctx = (ChannelsRequestContext *)user_data;
-    if (channels_request_context_is_stale(ctx)) {
-        channels_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != channels_generation) {
         return;
     }
-    channels_request_context_free(ctx);
 
     channels_fetch_in_flight = FALSE;
 
@@ -908,11 +881,10 @@ static void channels_force_refresh(void) {
     if (!gateway_rpc_is_ready()) return;
 
     channels_fetch_in_flight = TRUE;
-    ChannelsRequestContext *ctx = channels_request_context_new();
+    guint current_gen = channels_generation;
     g_autofree gchar *req_id = gateway_rpc_request(
-        "channels.status", NULL, 0, on_channels_rpc_response, ctx);
+        "channels.status", NULL, 0, on_channels_rpc_response, GUINT_TO_POINTER(current_gen));
     if (!req_id) {
-        channels_request_context_free(ctx);
         channels_fetch_in_flight = FALSE;
     }
 }
@@ -985,11 +957,10 @@ static void channels_refresh(void) {
     }
 
     channels_fetch_in_flight = TRUE;
-    ChannelsRequestContext *ctx = channels_request_context_new();
+    guint current_gen = channels_generation;
     g_autofree gchar *req_id = gateway_rpc_request(
-        "channels.status", NULL, 0, on_channels_rpc_response, ctx);
+        "channels.status", NULL, 0, on_channels_rpc_response, GUINT_TO_POINTER(current_gen));
     if (!req_id) {
-        channels_request_context_free(ctx);
         channels_fetch_in_flight = FALSE;
         if (channels_status_label)
             gtk_label_set_text(GTK_LABEL(channels_status_label), "Failed to send request");

--- a/apps/linux/src/section_control_room.c
+++ b/apps/linux/src/section_control_room.c
@@ -33,24 +33,6 @@ static gboolean control_sessions_fetch_in_flight = FALSE;
 static gint64 control_last_fetch_us = 0;
 static guint control_generation = 1;
 
-typedef struct {
-    guint generation;
-} ControlRequestContext;
-
-static ControlRequestContext* control_request_context_new(void) {
-    ControlRequestContext *ctx = g_new0(ControlRequestContext, 1);
-    ctx->generation = control_generation;
-    return ctx;
-}
-
-static gboolean control_request_context_is_stale(const ControlRequestContext *ctx) {
-    return !ctx || ctx->generation != control_generation;
-}
-
-static void control_request_context_free(gpointer data) {
-    g_free(data);
-}
-
 static void control_request_snapshot(void);
 
 static void control_set_count_label(GtkWidget *label, const gchar *prefix, gint count) {
@@ -125,12 +107,10 @@ static void control_nodes_clear(void) {
 }
 
 static void on_control_mutation_done(const GatewayRpcResponse *response, gpointer user_data) {
-    ControlRequestContext *ctx = (ControlRequestContext *)user_data;
-    if (control_request_context_is_stale(ctx)) {
-        control_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != control_generation) {
         return;
     }
-    control_request_context_free(ctx);
 
     if (!control_status_label) return;
     gtk_label_set_text(GTK_LABEL(control_status_label),
@@ -161,12 +141,10 @@ static void on_refresh_snapshot_clicked(GtkButton *button, gpointer user_data) {
 }
 
 static void on_control_agents_response(const GatewayRpcResponse *response, gpointer user_data) {
-    ControlRequestContext *ctx = (ControlRequestContext *)user_data;
-    if (control_request_context_is_stale(ctx)) {
-        control_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != control_generation) {
         return;
     }
-    control_request_context_free(ctx);
 
     control_agents_fetch_in_flight = FALSE;
 
@@ -184,12 +162,10 @@ static void on_control_agents_response(const GatewayRpcResponse *response, gpoin
 }
 
 static void on_control_sessions_response(const GatewayRpcResponse *response, gpointer user_data) {
-    ControlRequestContext *ctx = (ControlRequestContext *)user_data;
-    if (control_request_context_is_stale(ctx)) {
-        control_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != control_generation) {
         return;
     }
-    control_request_context_free(ctx);
 
     control_sessions_fetch_in_flight = FALSE;
 
@@ -227,10 +203,9 @@ static void on_run_cron_clicked(GtkButton *button, gpointer user_data) {
         return;
     }
 
-    ControlRequestContext *ctx = control_request_context_new();
-    g_autofree gchar *rid = mutation_cron_run(job_id, on_control_mutation_done, ctx);
+    guint current_gen = control_generation;
+    g_autofree gchar *rid = mutation_cron_run(job_id, on_control_mutation_done, GUINT_TO_POINTER(current_gen));
     if (!rid && control_status_label) {
-        control_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(control_status_label), "Cron run request failed");
     }
 }
@@ -259,23 +234,20 @@ static void on_abort_session_clicked(GtkButton *button, gpointer user_data) {
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
-    ControlRequestContext *ctx = control_request_context_new();
+    guint current_gen = control_generation;
     g_autofree gchar *rid = gateway_rpc_request("chat.abort", params, 0,
-                                                on_control_mutation_done, ctx);
+                                                on_control_mutation_done, GUINT_TO_POINTER(current_gen));
     json_node_unref(params);
     if (!rid) {
-        control_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(control_status_label), "Abort request failed");
     }
 }
 
 static void on_control_nodes_response(const GatewayRpcResponse *response, gpointer user_data) {
-    ControlRequestContext *ctx = (ControlRequestContext *)user_data;
-    if (control_request_context_is_stale(ctx)) {
-        control_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != control_generation) {
         return;
     }
-    control_request_context_free(ctx);
 
     control_nodes_fetch_in_flight = FALSE;
 
@@ -344,33 +316,30 @@ static void control_request_snapshot(void) {
 
     if (!control_nodes_fetch_in_flight) {
         control_nodes_fetch_in_flight = TRUE;
-        ControlRequestContext *nodes_ctx = control_request_context_new();
+        guint current_gen = control_generation;
         g_autofree gchar *rid_nodes = gateway_rpc_request("node.list", NULL, 0,
-                                                          on_control_nodes_response, nodes_ctx);
+                                                          on_control_nodes_response, GUINT_TO_POINTER(current_gen));
         if (!rid_nodes) {
-            control_request_context_free(nodes_ctx);
             control_nodes_fetch_in_flight = FALSE;
         }
     }
 
     if (!control_agents_fetch_in_flight) {
         control_agents_fetch_in_flight = TRUE;
-        ControlRequestContext *agents_ctx = control_request_context_new();
+        guint current_gen = control_generation;
         g_autofree gchar *rid_agents = gateway_rpc_request("agents.list", NULL, 0,
-                                                           on_control_agents_response, agents_ctx);
+                                                           on_control_agents_response, GUINT_TO_POINTER(current_gen));
         if (!rid_agents) {
-            control_request_context_free(agents_ctx);
             control_agents_fetch_in_flight = FALSE;
         }
     }
 
     if (!control_sessions_fetch_in_flight) {
         control_sessions_fetch_in_flight = TRUE;
-        ControlRequestContext *sessions_ctx = control_request_context_new();
+        guint current_gen = control_generation;
         g_autofree gchar *rid_sessions = gateway_rpc_request("sessions.list", NULL, 0,
-                                                             on_control_sessions_response, sessions_ctx);
+                                                             on_control_sessions_response, GUINT_TO_POINTER(current_gen));
         if (!rid_sessions) {
-            control_request_context_free(sessions_ctx);
             control_sessions_fetch_in_flight = FALSE;
         }
     }

--- a/apps/linux/src/section_logs.c
+++ b/apps/linux/src/section_logs.c
@@ -18,24 +18,6 @@ static gboolean logs_fetch_in_flight = FALSE;
 static gint64 logs_last_fetch_us = 0;
 static guint logs_generation = 1;
 
-typedef struct {
-    guint generation;
-} LogsRequestContext;
-
-static LogsRequestContext* logs_request_context_new(void) {
-    LogsRequestContext *ctx = g_new0(LogsRequestContext, 1);
-    ctx->generation = logs_generation;
-    return ctx;
-}
-
-static gboolean logs_request_context_is_stale(const LogsRequestContext *ctx) {
-    return !ctx || ctx->generation != logs_generation;
-}
-
-static void logs_request_context_free(gpointer data) {
-    g_free(data);
-}
-
 static void logs_trigger_fetch(gboolean force);
 
 static void logs_set_text(const gchar *text) {
@@ -45,12 +27,10 @@ static void logs_set_text(const gchar *text) {
 }
 
 static void on_logs_tail_response(const GatewayRpcResponse *response, gpointer user_data) {
-    LogsRequestContext *ctx = (LogsRequestContext *)user_data;
-    if (logs_request_context_is_stale(ctx)) {
-        logs_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != logs_generation) {
         return;
     }
-    logs_request_context_free(ctx);
 
     logs_fetch_in_flight = FALSE;
 
@@ -222,12 +202,11 @@ static void logs_trigger_fetch(gboolean force) {
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
-    LogsRequestContext *ctx = logs_request_context_new();
+    guint current_gen = logs_generation;
     g_autofree gchar *rid = gateway_rpc_request("logs.tail", params, 0,
-                                                on_logs_tail_response, ctx);
+                                                on_logs_tail_response, GUINT_TO_POINTER(current_gen));
     json_node_unref(params);
     if (!rid) {
-        logs_request_context_free(ctx);
         logs_fetch_in_flight = FALSE;
         gtk_label_set_text(GTK_LABEL(logs_status_label), "Failed to request logs.tail");
     }

--- a/apps/linux/src/section_sessions.c
+++ b/apps/linux/src/section_sessions.c
@@ -35,24 +35,6 @@ typedef struct {
 
 static GPtrArray *session_model_choices = NULL;
 
-typedef struct {
-    guint generation;
-} SessionsRequestContext;
-
-static SessionsRequestContext* sessions_request_context_new(void) {
-    SessionsRequestContext *ctx = g_new0(SessionsRequestContext, 1);
-    ctx->generation = sessions_generation;
-    return ctx;
-}
-
-static gboolean sessions_request_context_is_stale(const SessionsRequestContext *ctx) {
-    return !ctx || ctx->generation != sessions_generation;
-}
-
-static void sessions_request_context_free(gpointer data) {
-    g_free(data);
-}
-
 static void session_model_choice_free(SessionModelChoice *choice) {
     if (!choice) return;
     g_free(choice->id);
@@ -88,12 +70,10 @@ static gchar* sessions_default_model_label(void) {
 /* ── Mutation callbacks ──────────────────────────────────────────── */
 
 static void on_mutation_done(const GatewayRpcResponse *response, gpointer user_data) {
-    SessionsRequestContext *ctx = (SessionsRequestContext *)user_data;
-    if (sessions_request_context_is_stale(ctx)) {
-        sessions_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != sessions_generation) {
         return;
     }
-    sessions_request_context_free(ctx);
 
     if (!sessions_status_label) return;
 
@@ -142,10 +122,9 @@ static void on_session_reset_response(GObject *source, GAsyncResult *result, gpo
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Resetting…");
 
-    SessionsRequestContext *ctx = sessions_request_context_new();
-    g_autofree gchar *req = mutation_sessions_reset(key, on_mutation_done, ctx);
+    guint current_gen = sessions_generation;
+    g_autofree gchar *req = mutation_sessions_reset(key, on_mutation_done, GUINT_TO_POINTER(current_gen));
     if (!req && sessions_status_label) {
-        sessions_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
 }
@@ -159,10 +138,9 @@ static void on_session_compact(GtkButton *btn, gpointer user_data) {
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Compacting\u2026");
 
-    SessionsRequestContext *ctx = sessions_request_context_new();
-    g_autofree gchar *req = mutation_sessions_compact(key, on_mutation_done, ctx);
+    guint current_gen = sessions_generation;
+    g_autofree gchar *req = mutation_sessions_compact(key, on_mutation_done, GUINT_TO_POINTER(current_gen));
     if (!req) {
-        sessions_request_context_free(ctx);
         gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
         if (sessions_status_label)
             gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
@@ -182,10 +160,9 @@ static void on_thinking_changed(GObject *gobject, GParamSpec *pspec, gpointer us
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Updating\u2026");
 
-    SessionsRequestContext *ctx = sessions_request_context_new();
-    g_autofree gchar *req = mutation_sessions_patch(key, level, NULL, NULL, on_mutation_done, ctx);
+    guint current_gen = sessions_generation;
+    g_autofree gchar *req = mutation_sessions_patch(key, level, NULL, NULL, on_mutation_done, GUINT_TO_POINTER(current_gen));
     if (!req && sessions_status_label) {
-        sessions_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
 }
@@ -203,10 +180,9 @@ static void on_verbose_changed(GObject *gobject, GParamSpec *pspec, gpointer use
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Updating\u2026");
 
-    SessionsRequestContext *ctx = sessions_request_context_new();
-    g_autofree gchar *req = mutation_sessions_patch(key, NULL, level, NULL, on_mutation_done, ctx);
+    guint current_gen = sessions_generation;
+    g_autofree gchar *req = mutation_sessions_patch(key, NULL, level, NULL, on_mutation_done, GUINT_TO_POINTER(current_gen));
     if (!req && sessions_status_label) {
-        sessions_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
 }
@@ -226,10 +202,9 @@ static void on_model_changed(GObject *gobject, GParamSpec *pspec, gpointer user_
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Updating…");
 
-    SessionsRequestContext *ctx = sessions_request_context_new();
-    g_autofree gchar *req = mutation_sessions_patch(key, NULL, NULL, model, on_mutation_done, ctx);
+    guint current_gen = sessions_generation;
+    g_autofree gchar *req = mutation_sessions_patch(key, NULL, NULL, model, on_mutation_done, GUINT_TO_POINTER(current_gen));
     if (!req && sessions_status_label) {
-        sessions_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
 }
@@ -248,10 +223,9 @@ static void on_delete_dialog_response(GObject *source, GAsyncResult *result, gpo
     if (sessions_status_label)
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Deleting\u2026");
 
-    SessionsRequestContext *ctx = sessions_request_context_new();
-    g_autofree gchar *req = mutation_sessions_delete(key, TRUE, on_mutation_done, ctx);
+    guint current_gen = sessions_generation;
+    g_autofree gchar *req = mutation_sessions_delete(key, TRUE, on_mutation_done, GUINT_TO_POINTER(current_gen));
     if (!req && sessions_status_label) {
-        sessions_request_context_free(ctx);
         gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
     }
 }
@@ -583,12 +557,10 @@ static void sessions_rebuild_list(void) {
 }
 
 static void on_sessions_models_response(const GatewayRpcResponse *response, gpointer user_data) {
-    SessionsRequestContext *ctx = (SessionsRequestContext *)user_data;
-    if (sessions_request_context_is_stale(ctx)) {
-        sessions_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != sessions_generation) {
         return;
     }
-    sessions_request_context_free(ctx);
 
     if (session_model_choices) g_ptr_array_unref(session_model_choices);
     session_model_choices = g_ptr_array_new_with_free_func((GDestroyNotify)session_model_choice_free);
@@ -636,12 +608,10 @@ static void on_sessions_models_response(const GatewayRpcResponse *response, gpoi
 /* ── RPC callback ────────────────────────────────────────────────── */
 
 static void on_sessions_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
-    SessionsRequestContext *ctx = (SessionsRequestContext *)user_data;
-    if (sessions_request_context_is_stale(ctx)) {
-        sessions_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != sessions_generation) {
         return;
     }
-    sessions_request_context_free(ctx);
 
     sessions_fetch_in_flight = FALSE;
 
@@ -684,18 +654,13 @@ static void sessions_force_refresh(void) {
     if (!gateway_rpc_is_ready()) return;
 
     sessions_fetch_in_flight = TRUE;
-    SessionsRequestContext *sessions_ctx = sessions_request_context_new();
+    guint current_gen = sessions_generation;
     g_autofree gchar *req_id = gateway_rpc_request(
-        "sessions.list", NULL, 0, on_sessions_rpc_response, sessions_ctx);
-    SessionsRequestContext *models_ctx = sessions_request_context_new();
+        "sessions.list", NULL, 0, on_sessions_rpc_response, GUINT_TO_POINTER(current_gen));
     g_autofree gchar *models_req_id = gateway_rpc_request(
-        "models.list", NULL, 0, on_sessions_models_response, models_ctx);
+        "models.list", NULL, 0, on_sessions_models_response, GUINT_TO_POINTER(current_gen));
     if (!req_id) {
-        sessions_request_context_free(sessions_ctx);
         sessions_fetch_in_flight = FALSE;
-    }
-    if (!models_req_id) {
-        sessions_request_context_free(models_ctx);
     }
     (void)models_req_id;
 }
@@ -753,20 +718,15 @@ static void sessions_refresh(void) {
     if (!section_is_stale(&sessions_last_fetch_us)) return;
 
     sessions_fetch_in_flight = TRUE;
-    SessionsRequestContext *sessions_ctx = sessions_request_context_new();
+    guint current_gen = sessions_generation;
     g_autofree gchar *req_id = gateway_rpc_request(
-        "sessions.list", NULL, 0, on_sessions_rpc_response, sessions_ctx);
-    SessionsRequestContext *models_ctx = sessions_request_context_new();
+        "sessions.list", NULL, 0, on_sessions_rpc_response, GUINT_TO_POINTER(current_gen));
     g_autofree gchar *models_req_id = gateway_rpc_request(
-        "models.list", NULL, 0, on_sessions_models_response, models_ctx);
+        "models.list", NULL, 0, on_sessions_models_response, GUINT_TO_POINTER(current_gen));
     if (!req_id) {
-        sessions_request_context_free(sessions_ctx);
         sessions_fetch_in_flight = FALSE;
         if (sessions_status_label)
             gtk_label_set_text(GTK_LABEL(sessions_status_label), "Failed to send request");
-    }
-    if (!models_req_id) {
-        sessions_request_context_free(models_ctx);
     }
     (void)models_req_id;
 }

--- a/apps/linux/src/section_skills.c
+++ b/apps/linux/src/section_skills.c
@@ -30,24 +30,6 @@ static gint64 skills_last_fetch_us = 0;
 static gint current_filter = 0; /* 0: All, 1: Ready, 2: Needs Setup, 3: Disabled */
 static guint skills_generation = 1;
 
-typedef struct {
-    guint generation;
-} SkillsRequestContext;
-
-static SkillsRequestContext* skills_request_context_new(void) {
-    SkillsRequestContext *ctx = g_new0(SkillsRequestContext, 1);
-    ctx->generation = skills_generation;
-    return ctx;
-}
-
-static gboolean skills_request_context_is_stale(const SkillsRequestContext *ctx) {
-    return !ctx || ctx->generation != skills_generation;
-}
-
-static void skills_request_context_free(gpointer data) {
-    g_free(data);
-}
-
 /* Forward declarations */
 static void skills_rebuild_list(void);
 static void skills_force_refresh(void);
@@ -55,12 +37,10 @@ static void skills_force_refresh(void);
 /* ── Mutation callbacks ──────────────────────────────────────────── */
 
 static void on_mutation_done(const GatewayRpcResponse *response, gpointer user_data) {
-    SkillsRequestContext *ctx = (SkillsRequestContext *)user_data;
-    if (skills_request_context_is_stale(ctx)) {
-        skills_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != skills_generation) {
         return;
     }
-    skills_request_context_free(ctx);
 
     if (!skills_status_label) return;
 
@@ -84,10 +64,9 @@ static void on_toggle_enable(GtkButton *btn, gpointer user_data) {
     if (!key) return;
 
     gtk_widget_set_sensitive(GTK_WIDGET(btn), FALSE);
-    SkillsRequestContext *ctx = skills_request_context_new();
-    g_autofree gchar *req = mutation_skills_enable(key, !currently_enabled, on_mutation_done, ctx);
+    guint current_gen = skills_generation;
+    g_autofree gchar *req = mutation_skills_enable(key, !currently_enabled, on_mutation_done, GUINT_TO_POINTER(current_gen));
     if (!req) {
-        skills_request_context_free(ctx);
         gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
         if (skills_status_label)
             gtk_label_set_text(GTK_LABEL(skills_status_label), "Failed to send request");
@@ -105,10 +84,9 @@ static void on_install(GtkButton *btn, gpointer user_data) {
     if (skills_status_label)
         gtk_label_set_text(GTK_LABEL(skills_status_label), "Installing\u2026");
 
-    SkillsRequestContext *ctx = skills_request_context_new();
-    g_autofree gchar *req = mutation_skills_install(name, install_id, on_mutation_done, ctx);
+    guint current_gen = skills_generation;
+    g_autofree gchar *req = mutation_skills_install(name, install_id, on_mutation_done, GUINT_TO_POINTER(current_gen));
     if (!req) {
-        skills_request_context_free(ctx);
         gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
         if (skills_status_label)
             gtk_label_set_text(GTK_LABEL(skills_status_label), "Failed to send install request");
@@ -124,10 +102,9 @@ static void on_update(GtkButton *btn, gpointer user_data) {
     if (skills_status_label)
         gtk_label_set_text(GTK_LABEL(skills_status_label), "Updating\u2026");
 
-    SkillsRequestContext *ctx = skills_request_context_new();
-    g_autofree gchar *req = mutation_skills_update(key, on_mutation_done, ctx);
+    guint current_gen = skills_generation;
+    g_autofree gchar *req = mutation_skills_update(key, on_mutation_done, GUINT_TO_POINTER(current_gen));
     if (!req) {
-        skills_request_context_free(ctx);
         gtk_widget_set_sensitive(GTK_WIDGET(btn), TRUE);
         if (skills_status_label)
             gtk_label_set_text(GTK_LABEL(skills_status_label), "Failed to send update request");
@@ -160,14 +137,11 @@ static void on_env_dialog_response(GObject *source, GAsyncResult *result, gpoint
         gtk_label_set_text(GTK_LABEL(skills_status_label), is_api_key ? "Setting API key\u2026" : "Setting environment\u2026");
 
     g_autofree gchar *req = NULL;
+    guint current_gen = skills_generation;
     if (is_api_key) {
-        SkillsRequestContext *ctx = skills_request_context_new();
-        req = mutation_skills_update_api_key(key, value, on_mutation_done, ctx);
-        if (!req) skills_request_context_free(ctx);
+        req = mutation_skills_update_api_key(key, value, on_mutation_done, GUINT_TO_POINTER(current_gen));
     } else {
-        SkillsRequestContext *ctx = skills_request_context_new();
-        req = mutation_skills_update_env(key, env_name, value, on_mutation_done, ctx);
-        if (!req) skills_request_context_free(ctx);
+        req = mutation_skills_update_env(key, env_name, value, on_mutation_done, GUINT_TO_POINTER(current_gen));
     }
     
     if (!req && skills_status_label) {
@@ -470,12 +444,10 @@ static void skills_rebuild_list(void) {
 /* ── RPC callback ────────────────────────────────────────────────── */
 
 static void on_skills_rpc_response(const GatewayRpcResponse *response, gpointer user_data) {
-    SkillsRequestContext *ctx = (SkillsRequestContext *)user_data;
-    if (skills_request_context_is_stale(ctx)) {
-        skills_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != skills_generation) {
         return;
     }
-    skills_request_context_free(ctx);
 
     skills_fetch_in_flight = FALSE;
 
@@ -524,11 +496,10 @@ static void skills_force_refresh(void) {
     if (!gateway_rpc_is_ready()) return;
 
     skills_fetch_in_flight = TRUE;
-    SkillsRequestContext *ctx = skills_request_context_new();
+    guint current_gen = skills_generation;
     g_autofree gchar *req_id = gateway_rpc_request(
-        "skills.status", NULL, 0, on_skills_rpc_response, ctx);
+        "skills.status", NULL, 0, on_skills_rpc_response, GUINT_TO_POINTER(current_gen));
     if (!req_id) {
-        skills_request_context_free(ctx);
         skills_fetch_in_flight = FALSE;
     }
 }
@@ -602,11 +573,10 @@ static void skills_refresh(void) {
     if (!section_is_stale(&skills_last_fetch_us)) return;
 
     skills_fetch_in_flight = TRUE;
-    SkillsRequestContext *ctx = skills_request_context_new();
+    guint current_gen = skills_generation;
     g_autofree gchar *req_id = gateway_rpc_request(
-        "skills.status", NULL, 0, on_skills_rpc_response, ctx);
+        "skills.status", NULL, 0, on_skills_rpc_response, GUINT_TO_POINTER(current_gen));
     if (!req_id) {
-        skills_request_context_free(ctx);
         skills_fetch_in_flight = FALSE;
         if (skills_status_label)
             gtk_label_set_text(GTK_LABEL(skills_status_label), "Failed to send request");

--- a/apps/linux/src/section_usage.c
+++ b/apps/linux/src/section_usage.c
@@ -26,24 +26,6 @@ static guint usage_generation = 1;
 
 static gint usage_selected_days = 30;
 
-typedef struct {
-    guint generation;
-} UsageRequestContext;
-
-static UsageRequestContext* usage_request_context_new(void) {
-    UsageRequestContext *ctx = g_new0(UsageRequestContext, 1);
-    ctx->generation = usage_generation;
-    return ctx;
-}
-
-static gboolean usage_request_context_is_stale(const UsageRequestContext *ctx) {
-    return !ctx || ctx->generation != usage_generation;
-}
-
-static void usage_request_context_free(gpointer data) {
-    g_free(data);
-}
-
 static void usage_clear_retros(void) {
     if (!usage_retros_box) return;
     section_box_clear(usage_retros_box);
@@ -60,12 +42,10 @@ static void usage_add_retros_line(const gchar *text) {
 static void usage_request_sessions_usage(void);
 
 static void on_usage_sessions_response(const GatewayRpcResponse *response, gpointer user_data) {
-    UsageRequestContext *ctx = (UsageRequestContext *)user_data;
-    if (usage_request_context_is_stale(ctx)) {
-        usage_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != usage_generation) {
         return;
     }
-    usage_request_context_free(ctx);
 
     usage_clear_retros();
 
@@ -134,23 +114,20 @@ static void usage_request_sessions_usage(void) {
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
-    UsageRequestContext *ctx = usage_request_context_new();
+    guint current_gen = usage_generation;
     g_autofree gchar *rid = gateway_rpc_request("sessions.usage", params, 0,
-                                                on_usage_sessions_response, ctx);
+                                                on_usage_sessions_response, GUINT_TO_POINTER(current_gen));
     json_node_unref(params);
     if (!rid) {
-        usage_request_context_free(ctx);
         usage_add_retros_line("Failed to request sessions.usage.");
     }
 }
 
 static void on_usage_cost_response(const GatewayRpcResponse *response, gpointer user_data) {
-    UsageRequestContext *ctx = (UsageRequestContext *)user_data;
-    if (usage_request_context_is_stale(ctx)) {
-        usage_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != usage_generation) {
         return;
     }
-    usage_request_context_free(ctx);
 
     if (!usage_cost_label) return;
 
@@ -187,12 +164,10 @@ static void on_usage_cost_response(const GatewayRpcResponse *response, gpointer 
 }
 
 static void on_usage_status_response(const GatewayRpcResponse *response, gpointer user_data) {
-    UsageRequestContext *ctx = (UsageRequestContext *)user_data;
-    if (usage_request_context_is_stale(ctx)) {
-        usage_request_context_free(ctx);
+    guint generation = GPOINTER_TO_UINT(user_data);
+    if (generation != usage_generation) {
         return;
     }
-    usage_request_context_free(ctx);
 
     usage_fetch_in_flight = FALSE;
 
@@ -261,12 +236,11 @@ static void on_usage_status_response(const GatewayRpcResponse *response, gpointe
     JsonNode *params = json_builder_get_root(b);
     g_object_unref(b);
 
-    UsageRequestContext *cost_ctx = usage_request_context_new();
+    guint current_gen = usage_generation;
     g_autofree gchar *rid = gateway_rpc_request("usage.cost", params, 0,
-                                                on_usage_cost_response, cost_ctx);
+                                                on_usage_cost_response, GUINT_TO_POINTER(current_gen));
     json_node_unref(params);
     if (!rid) {
-        usage_request_context_free(cost_ctx);
         gtk_label_set_text(GTK_LABEL(usage_cost_label), "Cost: unavailable");
         usage_request_sessions_usage();
     }
@@ -340,11 +314,10 @@ static void usage_refresh(void) {
     if (!section_is_stale(&usage_last_fetch_us)) return;
 
     usage_fetch_in_flight = TRUE;
-    UsageRequestContext *ctx = usage_request_context_new();
+    guint current_gen = usage_generation;
     g_autofree gchar *rid = gateway_rpc_request("usage.status", NULL, 0,
-                                                on_usage_status_response, ctx);
+                                                on_usage_status_response, GUINT_TO_POINTER(current_gen));
     if (!rid) {
-        usage_request_context_free(ctx);
         usage_fetch_in_flight = FALSE;
         gtk_label_set_text(GTK_LABEL(usage_status_label), "Failed to request usage.status");
     }


### PR DESCRIPTION
This commit removes the duplicated `*RequestContext` structs previously used across 9 UI controller modules (`section_agents.c`, `section_channels.c`, `section_control_room.c`, `section_logs.c`, `section_sessions.c`, `section_skills.c`, `section_usage.c`, `app_window.c`, and `chat_controller.c`) to track async callback staleness.

Instead of allocating a struct wrapper on the heap simply to pass a single 32-bit `guint generation` token, the architecture has been standardized on the zero-allocation `GUINT_TO_POINTER()` macro. The token is cast directly into the `user_data` pointer when making `gateway_rpc_request()` calls, and cast back via `GPOINTER_TO_UINT()` inside the callback.

This change brings all controllers in line with the efficient pattern previously proven in `section_cron.c`. It completely eliminates over 200 lines of redundant struct declarations, allocators (`*_request_context_new`), and teardown boilerplate (`*_request_context_free`), improving code maintainability and reducing memory fragmentation while perfectly preserving the application's async lifecycle safety.