### PR TITLE
fix(linux): dispatch pairing decisions via RPC callback (#88)

### DIFF
--- a/apps/linux/src/device_pair_prompter.c
+++ b/apps/linux/src/device_pair_prompter.c
@@ -147,6 +147,19 @@ static OcPairRequestInfo* build_info_from_payload(JsonNode *payload) {
     return info;
 }
 
+static void on_decision_rpc_response(const GatewayRpcResponse *response,
+                                     gpointer                  user_data)
+{
+    const gchar *method = (const gchar *)user_data;
+    if (!response) return;
+    if (!response->ok) {
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                    "device pair %s RPC failed: %s",
+                    method ? method : "(unknown)",
+                    response->error_msg ? response->error_msg : "(no detail)");
+    }
+}
+
 static void send_decision_rpc(const OcPairRequestInfo *info,
                               OcPairDecision decision)
 {
@@ -168,7 +181,8 @@ static void send_decision_rpc(const OcPairRequestInfo *info,
     json_builder_end_object(b);
     g_autoptr(JsonNode) params = json_builder_get_root(b);
 
-    g_autofree gchar *req_id = gateway_rpc_request(method, params, 0, NULL, NULL);
+    g_autofree gchar *req_id = gateway_rpc_request(
+        method, params, 0, on_decision_rpc_response, (gpointer)method);
     if (!req_id) {
         OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
                     "device pair %s RPC dispatch failed (WS not ready)", method);

--- a/apps/linux/tests/test_gateway_data.c
+++ b/apps/linux/tests/test_gateway_data.c
@@ -12,17 +12,7 @@
 #include <json-glib/json-glib.h>
 #include <string.h>
 
-static int tests_run = 0;
-static int tests_passed = 0;
-
-#define ASSERT(cond, msg) do { \
-    tests_run++; \
-    if (!(cond)) { \
-        g_printerr("FAIL [%s:%d]: %s\n", __FILE__, __LINE__, msg); \
-    } else { \
-        tests_passed++; \
-    } \
-} while(0)
+#define ASSERT(cond, msg) g_assert_true(cond)
 
 static JsonNode* parse_json(const gchar *json_str) {
     JsonParser *parser = json_parser_new();
@@ -1171,98 +1161,83 @@ static void test_config_schema_empty(void) {
 
 /* ── Main ────────────────────────────────────────────────────────── */
 
-int main(void) {
-    /* Channels — happy path */
-    test_channels_parse_basic();
-    test_channels_parse_empty();
-    test_channels_parse_null();
-    /* Channels — negative */
-    test_channels_wrong_type_channel_order();
-    test_channels_mixed_type_channel_order_elements();
-    test_channels_labels_wrong_type();
-    test_channels_accounts_not_array();
-    test_channels_non_object_payload();
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
 
-    /* Skills — happy path */
-    test_skills_parse_basic();
-    test_skills_parse_empty();
-    /* Skills — negative */
-    test_skills_missing_array();
-    test_skills_array_wrong_type();
-    test_skills_mixed_valid_invalid();
-    test_skills_partial_fields();
-    test_skills_wrong_type_booleans();
-    test_skills_null_input();
+    g_test_add_func("/gateway_data/channels/parse_basic", test_channels_parse_basic);
+    g_test_add_func("/gateway_data/channels/parse_empty", test_channels_parse_empty);
+    g_test_add_func("/gateway_data/channels/parse_null", test_channels_parse_null);
+    g_test_add_func("/gateway_data/channels/wrong_type_channel_order", test_channels_wrong_type_channel_order);
+    g_test_add_func("/gateway_data/channels/mixed_type_channel_order_elements", test_channels_mixed_type_channel_order_elements);
+    g_test_add_func("/gateway_data/channels/labels_wrong_type", test_channels_labels_wrong_type);
+    g_test_add_func("/gateway_data/channels/accounts_not_array", test_channels_accounts_not_array);
+    g_test_add_func("/gateway_data/channels/non_object_payload", test_channels_non_object_payload);
 
-    /* Sessions — happy path */
-    test_sessions_parse_basic();
-    /* Sessions — negative */
-    test_sessions_missing_array();
-    test_sessions_array_wrong_type();
-    test_sessions_partial_item();
-    test_sessions_mixed_valid_invalid();
-    test_sessions_wrong_type_fields();
-    test_sessions_null_input();
-    test_sessions_empty();
+    g_test_add_func("/gateway_data/skills/parse_basic", test_skills_parse_basic);
+    g_test_add_func("/gateway_data/skills/parse_empty", test_skills_parse_empty);
+    g_test_add_func("/gateway_data/skills/missing_array", test_skills_missing_array);
+    g_test_add_func("/gateway_data/skills/array_wrong_type", test_skills_array_wrong_type);
+    g_test_add_func("/gateway_data/skills/mixed_valid_invalid", test_skills_mixed_valid_invalid);
+    g_test_add_func("/gateway_data/skills/partial_fields", test_skills_partial_fields);
+    g_test_add_func("/gateway_data/skills/wrong_type_booleans", test_skills_wrong_type_booleans);
+    g_test_add_func("/gateway_data/skills/null_input", test_skills_null_input);
 
-    /* Cron — happy path */
-    test_cron_parse_basic();
-    test_cron_parse_schedule_kind_every();
-    test_cron_parse_schedule_kind_at();
-    test_cron_parse_routing_fields_from_root();
-    /* Cron — negative */
-    test_cron_missing_jobs();
-    test_cron_jobs_wrong_type();
-    test_cron_malformed_state();
-    test_cron_mixed_valid_invalid();
-    test_cron_partial_fields();
-    test_cron_null_input();
-    test_cron_empty();
+    g_test_add_func("/gateway_data/sessions/parse_basic", test_sessions_parse_basic);
+    g_test_add_func("/gateway_data/sessions/missing_array", test_sessions_missing_array);
+    g_test_add_func("/gateway_data/sessions/array_wrong_type", test_sessions_array_wrong_type);
+    g_test_add_func("/gateway_data/sessions/partial_item", test_sessions_partial_item);
+    g_test_add_func("/gateway_data/sessions/mixed_valid_invalid", test_sessions_mixed_valid_invalid);
+    g_test_add_func("/gateway_data/sessions/wrong_type_fields", test_sessions_wrong_type_fields);
+    g_test_add_func("/gateway_data/sessions/null_input", test_sessions_null_input);
+    g_test_add_func("/gateway_data/sessions/empty", test_sessions_empty);
 
-    /* Nodes — happy path */
-    test_nodes_parse_basic();
-    test_nodes_parse_empty();
-    /* Nodes — negative */
-    test_nodes_missing_array();
-    test_nodes_array_wrong_type();
-    test_nodes_partial_fields();
-    test_nodes_mixed_valid_invalid();
-    test_nodes_wrong_type_fields();
-    test_nodes_null_input();
-    test_nodes_non_object_payload();
+    g_test_add_func("/gateway_data/cron/parse_basic", test_cron_parse_basic);
+    g_test_add_func("/gateway_data/cron/parse_schedule_kind_every", test_cron_parse_schedule_kind_every);
+    g_test_add_func("/gateway_data/cron/parse_schedule_kind_at", test_cron_parse_schedule_kind_at);
+    g_test_add_func("/gateway_data/cron/parse_routing_fields_from_root", test_cron_parse_routing_fields_from_root);
+    g_test_add_func("/gateway_data/cron/missing_jobs", test_cron_missing_jobs);
+    g_test_add_func("/gateway_data/cron/jobs_wrong_type", test_cron_jobs_wrong_type);
+    g_test_add_func("/gateway_data/cron/malformed_state", test_cron_malformed_state);
+    g_test_add_func("/gateway_data/cron/mixed_valid_invalid", test_cron_mixed_valid_invalid);
+    g_test_add_func("/gateway_data/cron/partial_fields", test_cron_partial_fields);
+    g_test_add_func("/gateway_data/cron/null_input", test_cron_null_input);
+    g_test_add_func("/gateway_data/cron/empty", test_cron_empty);
 
-    /* Cron Status */
-    test_cron_status_parse_basic();
-    test_cron_status_null();
-    test_cron_status_empty();
+    g_test_add_func("/gateway_data/nodes/parse_basic", test_nodes_parse_basic);
+    g_test_add_func("/gateway_data/nodes/parse_empty", test_nodes_parse_empty);
+    g_test_add_func("/gateway_data/nodes/missing_array", test_nodes_missing_array);
+    g_test_add_func("/gateway_data/nodes/array_wrong_type", test_nodes_array_wrong_type);
+    g_test_add_func("/gateway_data/nodes/partial_fields", test_nodes_partial_fields);
+    g_test_add_func("/gateway_data/nodes/mixed_valid_invalid", test_nodes_mixed_valid_invalid);
+    g_test_add_func("/gateway_data/nodes/wrong_type_fields", test_nodes_wrong_type_fields);
+    g_test_add_func("/gateway_data/nodes/null_input", test_nodes_null_input);
+    g_test_add_func("/gateway_data/nodes/non_object_payload", test_nodes_non_object_payload);
 
-    /* Cron Runs */
-    test_cron_runs_parse_basic();
-    test_cron_runs_null();
+    g_test_add_func("/gateway_data/cron_status/parse_basic", test_cron_status_parse_basic);
+    g_test_add_func("/gateway_data/cron_status/null", test_cron_status_null);
+    g_test_add_func("/gateway_data/cron_status/empty", test_cron_status_empty);
 
-    /* Pairing List */
-    test_pairing_list_parse_basic();
-    test_pairing_list_empty();
-    test_pairing_list_null();
-    test_pairing_list_partial_pending();
-    test_pairing_list_partial_paired();
-    test_pairing_list_wrong_type_arrays();
-    test_pairing_list_non_object_payload();
-    test_pairing_list_repair_flag();
+    g_test_add_func("/gateway_data/cron_runs/parse_basic", test_cron_runs_parse_basic);
+    g_test_add_func("/gateway_data/cron_runs/null", test_cron_runs_null);
 
-    /* Channels — account details */
-    test_channels_with_account_details();
+    g_test_add_func("/gateway_data/pairing_list/parse_basic", test_pairing_list_parse_basic);
+    g_test_add_func("/gateway_data/pairing_list/empty", test_pairing_list_empty);
+    g_test_add_func("/gateway_data/pairing_list/null", test_pairing_list_null);
+    g_test_add_func("/gateway_data/pairing_list/partial_pending", test_pairing_list_partial_pending);
+    g_test_add_func("/gateway_data/pairing_list/partial_paired", test_pairing_list_partial_paired);
+    g_test_add_func("/gateway_data/pairing_list/wrong_type_arrays", test_pairing_list_wrong_type_arrays);
+    g_test_add_func("/gateway_data/pairing_list/non_object_payload", test_pairing_list_non_object_payload);
+    g_test_add_func("/gateway_data/pairing_list/repair_flag", test_pairing_list_repair_flag);
 
-    /* Config Snapshot */
-    test_config_get_parse_basic();
-    test_config_get_null();
-    test_config_get_no_config_obj();
+    g_test_add_func("/gateway_data/channels/with_account_details", test_channels_with_account_details);
 
-    /* Config Schema */
-    test_config_schema_parse_basic();
-    test_config_schema_null();
-    test_config_schema_empty();
+    g_test_add_func("/gateway_data/config_get/parse_basic", test_config_get_parse_basic);
+    g_test_add_func("/gateway_data/config_get/null", test_config_get_null);
+    g_test_add_func("/gateway_data/config_get/no_config_obj", test_config_get_no_config_obj);
 
-    g_print("gateway_data: %d/%d tests passed\n", tests_passed, tests_run);
-    return (tests_passed == tests_run) ? 0 : 1;
+    g_test_add_func("/gateway_data/config_schema/parse_basic", test_config_schema_parse_basic);
+    g_test_add_func("/gateway_data/config_schema/null", test_config_schema_null);
+    g_test_add_func("/gateway_data/config_schema/empty", test_config_schema_empty);
+
+    return g_test_run();
 }

--- a/apps/linux/tests/test_gateway_rpc.c
+++ b/apps/linux/tests/test_gateway_rpc.c
@@ -17,17 +17,7 @@
 #include <json-glib/json-glib.h>
 #include <string.h>
 
-static int tests_run = 0;
-static int tests_passed = 0;
-
-#define ASSERT(cond, msg) do { \
-    tests_run++; \
-    if (!(cond)) { \
-        g_printerr("FAIL [%s:%d]: %s\n", __FILE__, __LINE__, msg); \
-    } else { \
-        tests_passed++; \
-    } \
-} while(0)
+#define ASSERT(cond, msg) g_assert_true(cond)
 
 /* ── Mock gateway_ws ─────────────────────────────────────────────── */
 
@@ -382,8 +372,7 @@ static void test_response_cleanup(void) {
 
     /* NULL response */
     gateway_rpc_response_free_members(NULL);
-    tests_run++;
-    tests_passed++; /* If we got here, no crash */
+    ASSERT(TRUE, "cleanup: null response safe");
 }
 
 /* ══════════════════════════════════════════════════════════════════
@@ -421,19 +410,21 @@ static void test_interleaved_responses(void) {
 
 /* ── Main ────────────────────────────────────────────────────────── */
 
-int main(void) {
-    test_response_correlation();
-    test_unmatched_response();
-    test_error_response();
-    test_request_timeout();
-    test_fail_all_pending();
-    test_request_when_disconnected();
-    test_send_returns_false();
-    test_response_cleanup();
-    test_interleaved_responses();
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    g_log_set_always_fatal((GLogLevelFlags)(G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL));
 
+    g_test_add_func("/gateway_rpc/response_correlation", test_response_correlation);
+    g_test_add_func("/gateway_rpc/unmatched_response", test_unmatched_response);
+    g_test_add_func("/gateway_rpc/error_response", test_error_response);
+    g_test_add_func("/gateway_rpc/request_timeout", test_request_timeout);
+    g_test_add_func("/gateway_rpc/fail_all_pending", test_fail_all_pending);
+    g_test_add_func("/gateway_rpc/request_when_disconnected", test_request_when_disconnected);
+    g_test_add_func("/gateway_rpc/send_returns_false", test_send_returns_false);
+    g_test_add_func("/gateway_rpc/response_cleanup", test_response_cleanup);
+    g_test_add_func("/gateway_rpc/interleaved_responses", test_interleaved_responses);
+
+    int status = g_test_run();
     g_free(mock_last_sent_text);
-
-    g_print("gateway_rpc: %d/%d tests passed\n", tests_passed, tests_run);
-    return (tests_passed == tests_run) ? 0 : 1;
+    return status;
 }

--- a/apps/linux/tests/test_rpc_lifecycle.c
+++ b/apps/linux/tests/test_rpc_lifecycle.c
@@ -23,17 +23,7 @@
 #include <json-glib/json-glib.h>
 #include <string.h>
 
-static int tests_run = 0;
-static int tests_passed = 0;
-
-#define ASSERT(cond, msg) do { \
-    tests_run++; \
-    if (!(cond)) { \
-        g_printerr("FAIL [%s:%d]: %s\n", __FILE__, __LINE__, msg); \
-    } else { \
-        tests_passed++; \
-    } \
-} while(0)
+#define ASSERT(cond, msg) g_assert_true(cond)
 
 /* ── Mock gateway_ws ─────────────────────────────────────────────── */
 
@@ -557,25 +547,25 @@ static void test_ws_rpc_frame_structure(void) {
 
 /* ── Main ────────────────────────────────────────────────────────── */
 
-int main(void) {
-    /* Section lifecycle */
-    test_lifecycle_disconnected();
-    test_lifecycle_error_response();
-    test_lifecycle_timeout_recovery();
-    test_lifecycle_reconnect_after_failure();
-    test_lifecycle_channels_full_pipeline();
-    test_lifecycle_mutation_success();
-    test_lifecycle_mutation_error();
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    g_log_set_always_fatal((GLogLevelFlags)(G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL));
 
-    /* WS↔RPC integration */
-    test_ws_rpc_authenticated_dispatch();
-    test_ws_rpc_unmatched_safety();
-    test_ws_rpc_disconnect_cleanup();
-    test_ws_rpc_send_path_safety();
-    test_ws_rpc_frame_structure();
+    g_test_add_func("/rpc_lifecycle/section/disconnected", test_lifecycle_disconnected);
+    g_test_add_func("/rpc_lifecycle/section/error_response", test_lifecycle_error_response);
+    g_test_add_func("/rpc_lifecycle/section/timeout_recovery", test_lifecycle_timeout_recovery);
+    g_test_add_func("/rpc_lifecycle/section/reconnect_after_failure", test_lifecycle_reconnect_after_failure);
+    g_test_add_func("/rpc_lifecycle/section/channels_full_pipeline", test_lifecycle_channels_full_pipeline);
+    g_test_add_func("/rpc_lifecycle/section/mutation_success", test_lifecycle_mutation_success);
+    g_test_add_func("/rpc_lifecycle/section/mutation_error", test_lifecycle_mutation_error);
 
+    g_test_add_func("/rpc_lifecycle/ws_rpc/authenticated_dispatch", test_ws_rpc_authenticated_dispatch);
+    g_test_add_func("/rpc_lifecycle/ws_rpc/unmatched_safety", test_ws_rpc_unmatched_safety);
+    g_test_add_func("/rpc_lifecycle/ws_rpc/disconnect_cleanup", test_ws_rpc_disconnect_cleanup);
+    g_test_add_func("/rpc_lifecycle/ws_rpc/send_path_safety", test_ws_rpc_send_path_safety);
+    g_test_add_func("/rpc_lifecycle/ws_rpc/frame_structure", test_ws_rpc_frame_structure);
+
+    int status = g_test_run();
     g_free(mock_last_sent_text);
-
-    g_print("rpc_lifecycle: %d/%d tests passed\n", tests_passed, tests_run);
-    return (tests_passed == tests_run) ? 0 : 1;
+    return status;
 }

--- a/apps/linux/tests/test_rpc_mutations.c
+++ b/apps/linux/tests/test_rpc_mutations.c
@@ -17,17 +17,7 @@
 #include <json-glib/json-glib.h>
 #include <string.h>
 
-static int tests_run = 0;
-static int tests_passed = 0;
-
-#define ASSERT(cond, msg) do { \
-    tests_run++; \
-    if (!(cond)) { \
-        g_printerr("FAIL [%s:%d]: %s\n", __FILE__, __LINE__, msg); \
-    } else { \
-        tests_passed++; \
-    } \
-} while(0)
+#define ASSERT(cond, msg) g_assert_true(cond)
 
 /* ── Stub state ──────────────────────────────────────────────────── */
 
@@ -1282,68 +1272,60 @@ static void test_qr_login_start_without_qrdataurl(void) {
     json_node_unref(node5);
 }
 
-int main(void) {
-    /* Skills */
-    test_skills_enable();
-    test_skills_disable();
-    test_skills_install();
-    test_skills_install_no_id();
-    test_skills_update();
-    test_skills_update_env();
-    test_skills_update_api_key();
-    test_skills_api_key_patterns();
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
 
-    /* Sessions */
-    test_sessions_patch();
-    test_sessions_patch_partial();
-    test_sessions_patch_model_only();
-    test_sessions_reset();
-    test_sessions_delete();
-    test_sessions_compact();
+    g_test_add_func("/rpc_mutations/skills/enable", test_skills_enable);
+    g_test_add_func("/rpc_mutations/skills/disable", test_skills_disable);
+    g_test_add_func("/rpc_mutations/skills/install", test_skills_install);
+    g_test_add_func("/rpc_mutations/skills/install_no_id", test_skills_install_no_id);
+    g_test_add_func("/rpc_mutations/skills/update", test_skills_update);
+    g_test_add_func("/rpc_mutations/skills/update_env", test_skills_update_env);
+    g_test_add_func("/rpc_mutations/skills/update_api_key", test_skills_update_api_key);
+    g_test_add_func("/rpc_mutations/skills/api_key_patterns", test_skills_api_key_patterns);
 
-    /* Cron */
-    test_cron_enable();
-    test_cron_remove();
-    test_cron_run();
-    test_cron_add();
-    test_cron_update();
-    test_cron_add_expanded();
-    test_cron_update_expanded();
-    test_cron_update_full_payload();
-    test_cron_edit_patch_builder_helper();
+    g_test_add_func("/rpc_mutations/sessions/patch", test_sessions_patch);
+    g_test_add_func("/rpc_mutations/sessions/patch_partial", test_sessions_patch_partial);
+    g_test_add_func("/rpc_mutations/sessions/patch_model_only", test_sessions_patch_model_only);
+    g_test_add_func("/rpc_mutations/sessions/reset", test_sessions_reset);
+    g_test_add_func("/rpc_mutations/sessions/delete", test_sessions_delete);
+    g_test_add_func("/rpc_mutations/sessions/compact", test_sessions_compact);
 
-    /* Cron regression tests */
-    test_cron_session_target_mapping();
+    g_test_add_func("/rpc_mutations/cron/enable", test_cron_enable);
+    g_test_add_func("/rpc_mutations/cron/remove", test_cron_remove);
+    g_test_add_func("/rpc_mutations/cron/run", test_cron_run);
+    g_test_add_func("/rpc_mutations/cron/add", test_cron_add);
+    g_test_add_func("/rpc_mutations/cron/update", test_cron_update);
+    g_test_add_func("/rpc_mutations/cron/add_expanded", test_cron_add_expanded);
+    g_test_add_func("/rpc_mutations/cron/update_expanded", test_cron_update_expanded);
+    g_test_add_func("/rpc_mutations/cron/update_full_payload", test_cron_update_full_payload);
+    g_test_add_func("/rpc_mutations/cron/edit_patch_builder_helper", test_cron_edit_patch_builder_helper);
+    g_test_add_func("/rpc_mutations/cron/session_target_mapping", test_cron_session_target_mapping);
 
-    /* Channels */
-    test_channels_status_probe();
-    test_channels_status_no_probe();
-    test_channels_logout();
-    test_channels_logout_no_acct();
+    g_test_add_func("/rpc_mutations/channels/status_probe", test_channels_status_probe);
+    g_test_add_func("/rpc_mutations/channels/status_no_probe", test_channels_status_no_probe);
+    g_test_add_func("/rpc_mutations/channels/logout", test_channels_logout);
+    g_test_add_func("/rpc_mutations/channels/logout_no_acct", test_channels_logout_no_acct);
 
-    /* Config */
-    test_config_get();
-    test_config_schema();
-    test_config_set();
-    test_config_set_with_hash();
-    test_config_set_null_hash();
-    test_config_get_no_scope();
-    test_config_save_preserves_unrelated_keys();
+    g_test_add_func("/rpc_mutations/config/get", test_config_get);
+    g_test_add_func("/rpc_mutations/config/schema", test_config_schema);
+    g_test_add_func("/rpc_mutations/config/set", test_config_set);
+    g_test_add_func("/rpc_mutations/config/set_with_hash", test_config_set_with_hash);
+    g_test_add_func("/rpc_mutations/config/set_null_hash", test_config_set_null_hash);
+    g_test_add_func("/rpc_mutations/config/get_no_scope", test_config_get_no_scope);
+    g_test_add_func("/rpc_mutations/config/save_preserves_unrelated_keys", test_config_save_preserves_unrelated_keys);
 
-    /* Nodes */
-    test_node_pair_approve();
-    test_node_pair_reject();
-    test_node_list();
-    test_node_pair_list();
+    g_test_add_func("/rpc_mutations/nodes/pair_approve", test_node_pair_approve);
+    g_test_add_func("/rpc_mutations/nodes/pair_reject", test_node_pair_reject);
+    g_test_add_func("/rpc_mutations/nodes/list", test_node_list);
+    g_test_add_func("/rpc_mutations/nodes/pair_list", test_node_pair_list);
 
-    /* WhatsApp login flow */
-    test_web_login_start();
-    test_web_login_wait();
-    test_web_login_wait_null_account();
-    test_qr_login_start_without_qrdataurl();
+    g_test_add_func("/rpc_mutations/web_login/start", test_web_login_start);
+    g_test_add_func("/rpc_mutations/web_login/wait", test_web_login_wait);
+    g_test_add_func("/rpc_mutations/web_login/wait_null_account", test_web_login_wait_null_account);
+    g_test_add_func("/rpc_mutations/web_login/qr_login_start_without_qrdataurl", test_qr_login_start_without_qrdataurl);
 
+    int status = g_test_run();
     stub_reset();
-
-    g_print("rpc_mutations: %d/%d tests passed\n", tests_passed, tests_run);
-    return (tests_passed == tests_run) ? 0 : 1;
+    return status;
 }


### PR DESCRIPTION
Pairing approve/reject actions in the Linux companion now supply a valid response callback when dispatching through `gateway_rpc_request()`. This fixes a dropped-request path where pairing decisions could fail to send because the RPC layer rejects NULL callbacks. Failed responses are now logged without changing pairing UI behavior.

Also migrate four remaining legacy Linux test binaries to the standard GLib harness. `test_gateway_data.c`,
`test_gateway_rpc.c`, `test_rpc_lifecycle.c`, and
`test_rpc_mutations.c` now register cases with
`g_test_add_func()` and run through `g_test_run()`, bringing them into line with the rest of the Linux suite.
