### PR TITLE
fix(linux): release transient combo model refs in sessions and cron (#90)

### DIFF
--- a/apps/linux/src/section_cron.c
+++ b/apps/linux/src/section_cron.c
@@ -388,6 +388,7 @@ static void on_edit_job(GtkButton *btn, gpointer user_data) {
     GtkWidget *target_combo = adw_combo_row_new();
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(target_combo), "Target Session");
     adw_combo_row_set_model(ADW_COMBO_ROW(target_combo), G_LIST_MODEL(target_model));
+    g_object_unref(target_model);
     /* Select based on current value */
     gint target_idx = session_target_to_index(job_target);
     adw_combo_row_set_selected(ADW_COMBO_ROW(target_combo), target_idx);
@@ -400,6 +401,7 @@ static void on_edit_job(GtkButton *btn, gpointer user_data) {
     GtkWidget *wake_combo = adw_combo_row_new();
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(wake_combo), "Wake Mode");
     adw_combo_row_set_model(ADW_COMBO_ROW(wake_combo), G_LIST_MODEL(wake_model));
+    g_object_unref(wake_model);
     /* Select based on current value */
     gint wake_idx = 0; /* default "next-heartbeat" */
     if (job_wake && g_strcmp0(job_wake, "now") == 0) wake_idx = 1;
@@ -555,6 +557,7 @@ static void on_create_job(GtkButton *btn, gpointer user_data) {
     GtkWidget *target_combo = adw_combo_row_new();
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(target_combo), "Target Session");
     adw_combo_row_set_model(ADW_COMBO_ROW(target_combo), G_LIST_MODEL(target_model));
+    g_object_unref(target_model);
     gtk_box_append(GTK_BOX(vbox), target_combo);
 
     GtkStringList *wake_model = gtk_string_list_new((const char * const[]){
@@ -563,6 +566,7 @@ static void on_create_job(GtkButton *btn, gpointer user_data) {
     GtkWidget *wake_combo = adw_combo_row_new();
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(wake_combo), "Wake Mode");
     adw_combo_row_set_model(ADW_COMBO_ROW(wake_combo), G_LIST_MODEL(wake_model));
+    g_object_unref(wake_model);
     gtk_box_append(GTK_BOX(vbox), wake_combo);
 
     adw_alert_dialog_set_extra_child(dialog, vbox);

--- a/apps/linux/src/section_sessions.c
+++ b/apps/linux/src/section_sessions.c
@@ -455,6 +455,7 @@ static void build_session_card(GatewaySession *s) {
 
     GtkWidget *model_combo = adw_combo_row_new();
     adw_combo_row_set_model(ADW_COMBO_ROW(model_combo), G_LIST_MODEL(model_dropdown));
+    g_object_unref(model_dropdown);
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(model_combo), "Model");
     gtk_widget_add_css_class(model_combo, "flat");
     adw_combo_row_set_selected(ADW_COMBO_ROW(model_combo), selected_model_idx);
@@ -469,6 +470,7 @@ static void build_session_card(GatewaySession *s) {
     });
     GtkWidget *think_combo = adw_combo_row_new();
     adw_combo_row_set_model(ADW_COMBO_ROW(think_combo), G_LIST_MODEL(think_model));
+    g_object_unref(think_model);
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(think_combo), "Thinking");
     gtk_widget_add_css_class(think_combo, "flat");
     
@@ -488,6 +490,7 @@ static void build_session_card(GatewaySession *s) {
     });
     GtkWidget *verb_combo = adw_combo_row_new();
     adw_combo_row_set_model(ADW_COMBO_ROW(verb_combo), G_LIST_MODEL(verb_model));
+    g_object_unref(verb_model);
     adw_preferences_row_set_title(ADW_PREFERENCES_ROW(verb_combo), "Verbose");
     gtk_widget_add_css_class(verb_combo, "flat");
     


### PR DESCRIPTION
Release creator-side GtkStringList references immediately after attaching them to AdwComboRow widgets in the Linux companion.

This fixes the transient model ownership gap in:
- section_sessions.c session cards
- section_cron.c create/edit job dialogs

The change is intentionally narrow: it adds g_object_unref() calls after adw_combo_row_set_model() for locally-created one-shot models and does not introduce any new persistent lifecycle machinery.

Behavior remains unchanged while preventing repeated UI rebuilds and dialog opens from accumulating unnecessary GTK model objects.
