### PR TITLE
feat(linux): activate config audit warning state (#92)

### DIFF
--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -1644,7 +1644,7 @@ static void on_cfg_reload_models(GtkButton *button, gpointer user_data) {
         return;
     }
 
-    gateway_client_invalidate_dependencies(TRUE, FALSE);
+    gateway_client_invalidate_dependencies(TRUE, FALSE, FALSE);
     gateway_client_request_dependency_refresh();
 }
 
@@ -1843,7 +1843,7 @@ static void on_cfg_save_done(const GatewayRpcResponse *response, gpointer user_d
     if (cfg_setup_status_label) {
         gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Saved provider/model config. Reloading baseline…");
     }
-    gateway_client_invalidate_dependencies(TRUE, TRUE);
+    gateway_client_invalidate_dependencies(TRUE, TRUE, TRUE);
     gateway_client_refresh();
     gateway_client_request_dependency_refresh();
     cfg_request_reload();

--- a/apps/linux/src/gateway_client.c
+++ b/apps/linux/src/gateway_client.c
@@ -18,6 +18,7 @@
 #include "gateway_http.h"
 #include "gateway_rpc.h"
 #include "gateway_ws.h"
+#include "gateway_data.h"
 #include "json_access.h"
 #include "runtime_paths.h"
 #include "device_pair_prompter.h"
@@ -36,6 +37,7 @@ typedef struct {
 typedef enum {
     DEP_REFRESH_MODELS = 1,
     DEP_REFRESH_AGENTS = 2,
+    DEP_REFRESH_CONFIG_AUDIT = 3,
 } DependencyRefreshKind;
 
 typedef struct {
@@ -57,11 +59,14 @@ static guint health_poll_timer_id = 0;
 static guint dependency_generation = 1;
 static gboolean dependency_models_in_flight = FALSE;
 static gboolean dependency_agents_in_flight = FALSE;
+static gboolean dependency_config_audit_in_flight = FALSE;
 static gint64 dependency_last_refresh_us = 0;
 static gboolean dependency_models_fresh = FALSE;
 static gboolean dependency_agents_fresh = FALSE;
+static gboolean dependency_config_audit_fresh = FALSE;
 static gint64 dependency_models_last_success_us = 0;
 static gint64 dependency_agents_last_success_us = 0;
+static gint64 dependency_config_audit_last_success_us = 0;
 #define DEPENDENCY_REFRESH_MIN_INTERVAL_US (2 * G_TIME_SPAN_SECOND)
 #define DEPENDENCY_REFRESH_STALE_AFTER_US (30 * G_TIME_SPAN_SECOND)
 
@@ -79,6 +84,7 @@ static void config_monitor_rearm(void);
 static void dependency_refresh_start(gboolean force);
 static void dependency_invalidate(gboolean invalidate_models,
                                   gboolean invalidate_agents,
+                                  gboolean invalidate_config_audit,
                                   gboolean cancel_in_flight,
                                   const gchar *reason);
 
@@ -113,9 +119,10 @@ static gboolean dependency_fact_is_stale(gboolean fresh,
 
 static void dependency_invalidate(gboolean invalidate_models,
                                   gboolean invalidate_agents,
+                                  gboolean invalidate_config_audit,
                                   gboolean cancel_in_flight,
                                   const gchar *reason) {
-    if (!invalidate_models && !invalidate_agents) {
+    if (!invalidate_models && !invalidate_agents && !invalidate_config_audit) {
         return;
     }
 
@@ -123,6 +130,7 @@ static void dependency_invalidate(gboolean invalidate_models,
         dependency_generation++;
         dependency_models_in_flight = FALSE;
         dependency_agents_in_flight = FALSE;
+        dependency_config_audit_in_flight = FALSE;
     }
 
     if (invalidate_models) {
@@ -135,13 +143,19 @@ static void dependency_invalidate(gboolean invalidate_models,
         dependency_agents_last_success_us = 0;
         state_set_agents_fact(FALSE, 0);
     }
+    if (invalidate_config_audit) {
+        dependency_config_audit_fresh = FALSE;
+        dependency_config_audit_last_success_us = 0;
+        state_set_config_audit_fact(FALSE, 0);
+    }
 
     dependency_last_refresh_us = 0;
 
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
-                 "dependency refresh invalidated models=%d agents=%d cancel_in_flight=%d reason=%s",
+                 "dependency refresh invalidated models=%d agents=%d config_audit=%d cancel_in_flight=%d reason=%s",
                  invalidate_models,
                  invalidate_agents,
+                 invalidate_config_audit,
                  cancel_in_flight,
                  reason ? reason : "(none)");
 }
@@ -238,17 +252,56 @@ static void on_dependency_agents_response(const GatewayRpcResponse *response, gp
     state_set_agents_fact(TRUE, json_array_get_length(arr));
 }
 
+static void on_dependency_config_audit_response(const GatewayRpcResponse *response, gpointer user_data) {
+    DependencyRefreshContext *ctx = (DependencyRefreshContext *)user_data;
+    if (dependency_refresh_context_is_stale(ctx)) {
+        dependency_refresh_context_free(ctx);
+        return;
+    }
+    dependency_refresh_context_free(ctx);
+    dependency_config_audit_in_flight = FALSE;
+
+    if (!response || !response->ok || !response->payload || !JSON_NODE_HOLDS_OBJECT(response->payload)) {
+        dependency_config_audit_fresh = FALSE;
+        dependency_config_audit_last_success_us = 0;
+        state_set_config_audit_fact(FALSE, 0);
+        return;
+    }
+
+    GatewayConfigSnapshot *snapshot = gateway_data_parse_config_get(response->payload);
+    if (!snapshot) {
+        dependency_config_audit_fresh = FALSE;
+        dependency_config_audit_last_success_us = 0;
+        state_set_config_audit_fact(FALSE, 0);
+        return;
+    }
+
+    dependency_config_audit_fresh = TRUE;
+    dependency_config_audit_last_success_us = g_get_real_time();
+    state_set_config_audit_fact(TRUE,
+                                snapshot->n_issues > 0
+                                    ? (guint)snapshot->n_issues
+                                    : 0);
+    gateway_config_snapshot_free(snapshot);
+}
+
 static void dependency_refresh_start(gboolean force) {
     if (!gateway_can_refresh_dependencies()) return;
-    if (dependency_models_in_flight || dependency_agents_in_flight) return;
 
     gint64 now_us = g_get_real_time();
+    gboolean models_stale = dependency_fact_is_stale(
+        dependency_models_fresh, dependency_models_last_success_us, now_us);
+    gboolean agents_stale = dependency_fact_is_stale(
+        dependency_agents_fresh, dependency_agents_last_success_us, now_us);
+    gboolean config_audit_stale = dependency_fact_is_stale(
+        dependency_config_audit_fresh, dependency_config_audit_last_success_us, now_us);
+
+    gboolean need_models = force || models_stale;
+    gboolean need_agents = force || agents_stale;
+    gboolean need_config_audit = force || config_audit_stale;
+
     if (!force) {
-        gboolean models_stale = dependency_fact_is_stale(
-            dependency_models_fresh, dependency_models_last_success_us, now_us);
-        gboolean agents_stale = dependency_fact_is_stale(
-            dependency_agents_fresh, dependency_agents_last_success_us, now_us);
-        gboolean freshness_refresh_needed = models_stale || agents_stale;
+        gboolean freshness_refresh_needed = need_models || need_agents || need_config_audit;
 
         if (!freshness_refresh_needed &&
             dependency_last_refresh_us > 0 &&
@@ -256,31 +309,66 @@ static void dependency_refresh_start(gboolean force) {
             return;
         }
     }
-    dependency_last_refresh_us = now_us;
 
-    dependency_models_in_flight = TRUE;
-    dependency_agents_in_flight = TRUE;
-
-    DependencyRefreshContext *models_ctx = dependency_refresh_context_new(DEP_REFRESH_MODELS);
-    g_autofree gchar *models_rid = gateway_rpc_request("models.list", NULL, 0,
-                                                       on_dependency_models_response, models_ctx);
-    if (!models_rid) {
-        dependency_refresh_context_free(models_ctx);
-        dependency_models_in_flight = FALSE;
-        dependency_models_fresh = FALSE;
-        dependency_models_last_success_us = 0;
-        state_set_model_catalog_fact(FALSE, 0, FALSE);
+    if (dependency_models_in_flight) {
+        need_models = FALSE;
+    }
+    if (dependency_agents_in_flight) {
+        need_agents = FALSE;
+    }
+    if (dependency_config_audit_in_flight) {
+        need_config_audit = FALSE;
     }
 
-    DependencyRefreshContext *agents_ctx = dependency_refresh_context_new(DEP_REFRESH_AGENTS);
-    g_autofree gchar *agents_rid = gateway_rpc_request("agents.list", NULL, 0,
-                                                       on_dependency_agents_response, agents_ctx);
-    if (!agents_rid) {
-        dependency_refresh_context_free(agents_ctx);
-        dependency_agents_in_flight = FALSE;
-        dependency_agents_fresh = FALSE;
-        dependency_agents_last_success_us = 0;
-        state_set_agents_fact(FALSE, 0);
+    if (!need_models && !need_agents && !need_config_audit) {
+        return;
+    }
+
+    dependency_last_refresh_us = now_us;
+
+    if (need_models) {
+        dependency_models_in_flight = TRUE;
+
+        DependencyRefreshContext *models_ctx = dependency_refresh_context_new(DEP_REFRESH_MODELS);
+        g_autofree gchar *models_rid = gateway_rpc_request("models.list", NULL, 0,
+                                                           on_dependency_models_response, models_ctx);
+        if (!models_rid) {
+            dependency_refresh_context_free(models_ctx);
+            dependency_models_in_flight = FALSE;
+            dependency_models_fresh = FALSE;
+            dependency_models_last_success_us = 0;
+            state_set_model_catalog_fact(FALSE, 0, FALSE);
+        }
+    }
+
+    if (need_agents) {
+        dependency_agents_in_flight = TRUE;
+
+        DependencyRefreshContext *agents_ctx = dependency_refresh_context_new(DEP_REFRESH_AGENTS);
+        g_autofree gchar *agents_rid = gateway_rpc_request("agents.list", NULL, 0,
+                                                           on_dependency_agents_response, agents_ctx);
+        if (!agents_rid) {
+            dependency_refresh_context_free(agents_ctx);
+            dependency_agents_in_flight = FALSE;
+            dependency_agents_fresh = FALSE;
+            dependency_agents_last_success_us = 0;
+            state_set_agents_fact(FALSE, 0);
+        }
+    }
+
+    if (need_config_audit) {
+        dependency_config_audit_in_flight = TRUE;
+
+        DependencyRefreshContext *config_ctx = dependency_refresh_context_new(DEP_REFRESH_CONFIG_AUDIT);
+        g_autofree gchar *config_rid = gateway_rpc_request("config.get", NULL, 0,
+                                                           on_dependency_config_audit_response, config_ctx);
+        if (!config_rid) {
+            dependency_refresh_context_free(config_ctx);
+            dependency_config_audit_in_flight = FALSE;
+            dependency_config_audit_fresh = FALSE;
+            dependency_config_audit_last_success_us = 0;
+            state_set_config_audit_fact(FALSE, 0);
+        }
     }
 }
 
@@ -338,12 +426,6 @@ static void publish_health_state(gboolean http_ok, HttpProbeResult http_probe_re
     hs.wizard_last_run_at = current_config ? current_config->wizard_last_run_at : NULL;
     hs.wizard_last_run_mode = current_config ? current_config->wizard_last_run_mode : NULL;
     hs.wizard_marker_fail_reason = current_config ? current_config->wizard_marker_fail_reason : NULL;
-
-    /* TODO(MVP deferral): We do not populate config_audit_ok or config_issues_count 
-     * here because those are not yet extracted or tracked in the Linux MVP.
-     * Do NOT synthesize fake errors into these fields just to activate the
-     * STATE_RUNNING_WITH_WARNING branch.
-     */
 
     if (current_config) {
         hs.endpoint_host = g_strdup(current_config->host);
@@ -537,7 +619,8 @@ static gboolean on_health_poll_timer(gpointer user_data) {
 }
 
 static void teardown_transport(gboolean invalidate_models,
-                              gboolean invalidate_agents) {
+                              gboolean invalidate_agents,
+                              gboolean invalidate_config_audit) {
     if (health_poll_timer_id) {
         g_source_remove(health_poll_timer_id);
         health_poll_timer_id = 0;
@@ -553,6 +636,7 @@ static void teardown_transport(gboolean invalidate_models,
     current_health_generation++;
     dependency_invalidate(invalidate_models,
                           invalidate_agents,
+                          invalidate_config_audit,
                           TRUE,
                           "transport teardown");
     state_reset_resolved_facts();
@@ -920,6 +1004,7 @@ void gateway_client_refresh(void) {
     /* Config changed — always replace stored config */
     gboolean invalidate_models = TRUE;
     gboolean invalidate_agents = TRUE;
+    gboolean invalidate_config_audit = TRUE;
     if (current_config && new_config && current_config->valid && new_config->valid) {
         gboolean model_context_changed =
             current_config->has_provider_config != new_config->has_provider_config ||
@@ -930,7 +1015,9 @@ void gateway_client_refresh(void) {
             invalidate_models = FALSE;
         }
     }
-    teardown_transport(invalidate_models, invalidate_agents);
+    teardown_transport(invalidate_models,
+                       invalidate_agents,
+                       invalidate_config_audit);
     gateway_config_free(current_config);
     current_config = new_config;
 
@@ -951,7 +1038,7 @@ void gateway_client_shutdown(void) {
     /* Stop monitoring config file (Feature A) */
     config_monitor_clear();
 
-    teardown_transport(TRUE, TRUE);
+    teardown_transport(TRUE, TRUE, TRUE);
     gateway_ws_shutdown();
     gateway_http_shutdown();
     gateway_config_free(current_config);
@@ -971,9 +1058,11 @@ void gateway_client_request_dependency_refresh(void) {
 }
 
 void gateway_client_invalidate_dependencies(gboolean invalidate_models,
-                                            gboolean invalidate_agents) {
+                                            gboolean invalidate_agents,
+                                            gboolean invalidate_config_audit) {
     dependency_invalidate(invalidate_models,
                           invalidate_agents,
+                          invalidate_config_audit,
                           FALSE,
                           "explicit request");
 }

--- a/apps/linux/src/gateway_client.h
+++ b/apps/linux/src/gateway_client.h
@@ -23,7 +23,8 @@ void gateway_client_shutdown(void);
 gboolean gateway_client_is_connected(void);
 void gateway_client_request_dependency_refresh(void);
 void gateway_client_invalidate_dependencies(gboolean invalidate_models,
-                                            gboolean invalidate_agents);
+                                            gboolean invalidate_agents,
+                                            gboolean invalidate_config_audit);
 
 #include "gateway_config.h"
 GatewayConfig* gateway_client_get_config(void);

--- a/apps/linux/src/state.c
+++ b/apps/linux/src/state.c
@@ -35,6 +35,8 @@ typedef struct {
     gboolean selected_model_resolved;
     gboolean agents_fetch_succeeded;
     guint agents_count;
+    gboolean config_audit_fetch_succeeded;
+    guint config_issues_count;
 } DesktopResolvedFacts;
 
 static DesktopResolvedFacts current_resolved_facts = {0};
@@ -79,6 +81,14 @@ static void recompute_resolved_health_fields(void) {
     current_health_state.agents_available =
         current_resolved_facts.agents_fetch_succeeded &&
         current_resolved_facts.agents_count > 0;
+
+    current_health_state.config_audit_ok =
+        current_resolved_facts.config_audit_fetch_succeeded &&
+        current_resolved_facts.config_issues_count == 0;
+    current_health_state.config_issues_count =
+        current_resolved_facts.config_audit_fetch_succeeded
+            ? (int)current_resolved_facts.config_issues_count
+            : 0;
 }
 
 static void compute_readiness_snapshot(void) {
@@ -173,12 +183,6 @@ static AppState compute_state(void) {
         if (!current_health_state.rpc_ok || !current_health_state.auth_ok) {
             return STATE_DEGRADED;
         }
-        /* TODO(MVP deferral): STATE_RUNNING_WITH_WARNING is intentionally deferred.
-         * The Linux MVP does not yet populate config-audit inputs (config_audit_ok,
-         * config_issues_count). We explicitly retain this branch to preserve the
-         * intended UX shape, but do NOT synthesize warning-state behavior from
-         * unrelated config errors just to make it live.
-         */
         if (!current_health_state.config_audit_ok && current_health_state.config_issues_count > 0) {
             return STATE_RUNNING_WITH_WARNING;
         }
@@ -472,6 +476,16 @@ void state_set_model_catalog_fact(gboolean fetch_succeeded,
     recompute_resolved_health_fields();
     compute_readiness_snapshot();
     trigger_updates(current_state);
+}
+
+void state_set_config_audit_fact(gboolean fetch_succeeded,
+                                 guint issues_count) {
+    current_resolved_facts.config_audit_fetch_succeeded = fetch_succeeded;
+    current_resolved_facts.config_issues_count = fetch_succeeded ? issues_count : 0;
+
+    recompute_resolved_health_fields();
+    compute_readiness_snapshot();
+    trigger_updates(compute_state());
 }
 
 void state_set_agents_fact(gboolean fetch_succeeded,

--- a/apps/linux/src/state.h
+++ b/apps/linux/src/state.h
@@ -171,6 +171,8 @@ void state_set_model_catalog_fact(gboolean fetch_succeeded,
                                   gboolean selected_model_resolved);
 void state_set_agents_fact(gboolean fetch_succeeded,
                            guint agent_count);
+void state_set_config_audit_fact(gboolean fetch_succeeded,
+                                 guint issues_count);
 void state_reset_resolved_facts(void);
 
 AppState state_get_current(void);

--- a/apps/linux/tests/test_state.c
+++ b/apps/linux/tests/test_state.c
@@ -88,11 +88,8 @@ static void test_warning_health(void) {
     hs.auth_ok = TRUE;
     hs.config_valid = TRUE;
     hs.has_wizard_onboard_marker = TRUE;
-    
-    
-    hs.config_audit_ok = FALSE;
-    hs.config_issues_count = 1;
     state_update_health(&hs);
+    state_set_config_audit_fact(TRUE, 1);
 
     g_assert_cmpint(state_get_current(), ==, STATE_RUNNING_WITH_WARNING);
 }
@@ -237,9 +234,31 @@ static void test_precedence_native_connected_with_warning(void) {
     hs.ws_connected = TRUE;
     hs.rpc_ok = TRUE;
     hs.auth_ok = TRUE;
-    hs.config_audit_ok = FALSE;
-    hs.config_issues_count = 2;
     state_update_health(&hs);
+    state_set_config_audit_fact(TRUE, 2);
+
+    g_assert_cmpint(state_get_current(), ==, STATE_RUNNING_WITH_WARNING);
+}
+
+static void test_native_connected_with_warning_via_facts(void) {
+    state_init();
+
+    SystemdState sys = {0};
+    sys.installed = TRUE;
+    sys.active = TRUE;
+    state_update_systemd(&sys);
+
+    HealthState hs = {0};
+    hs.last_updated = 12345;
+    hs.http_ok = TRUE;
+    hs.ws_connected = TRUE;
+    hs.rpc_ok = TRUE;
+    hs.auth_ok = TRUE;
+    hs.config_valid = TRUE;
+    hs.has_wizard_onboard_marker = TRUE;
+    state_update_health(&hs);
+
+    state_set_config_audit_fact(TRUE, 1);
 
     g_assert_cmpint(state_get_current(), ==, STATE_RUNNING_WITH_WARNING);
 }
@@ -946,6 +965,7 @@ int main(int argc, char **argv) {
     g_test_add_func("/state/precedence/not_installed_native_connected", test_precedence_not_installed_native_connected);
     g_test_add_func("/state/precedence/native_connected_with_warning", test_precedence_native_connected_with_warning);
     g_test_add_func("/state/precedence/native_connected_auth_fail", test_precedence_native_connected_auth_fail);
+    g_test_add_func("/state/precedence/native_connected_with_warning_via_facts", test_native_connected_with_warning_via_facts);
 
     /* Lifecycle and generation tests */
     g_test_add_func("/state/unit_retarget_bumps_generation", test_unit_retarget_bumps_generation);


### PR DESCRIPTION
Add config-audit resolved facts and
`state_set_config_audit_fact()` to the Linux companion state model so backend configuration issues can drive
`STATE_RUNNING_WITH_WARNING` through the existing state machine.

Extend `gateway_client` dependency refresh with a third lane for `config.get`, track config-audit freshness and in-flight state alongside models and agents, and publish parsed audit facts through `gateway_data_parse_config_get()` into `state.c`.

Update dependency invalidation and transport teardown to include config-audit freshness, update `app_window.c` call sites to the expanded invalidation API, and add hermetic state coverage proving that config-audit facts activate `STATE_RUNNING_WITH_WARNING`.
