### PR TITLE
fix(linux): reopen pairing bootstrap from prompter after dismiss (#94)

### DIFF
--- a/apps/linux/src/device_pair_prompter.c
+++ b/apps/linux/src/device_pair_prompter.c
@@ -34,6 +34,9 @@ typedef struct {
      * chasing the info pointer (which the hook owns during present).
      */
     gchar             *active_request_id;
+    gchar             *last_pairing_required_request_id;
+    gchar             *last_pairing_required_detail;
+    gboolean           pairing_required_reopen_state_cached;
 
     /* Test seam */
     OcPairPresentHook  present_hook;
@@ -47,6 +50,9 @@ static gboolean queue_contains_request_id(const gchar *request_id);
 static void     remove_request_from_queue(const gchar *request_id);
 
 static void pop_and_present_next(void);
+static void pairing_required_reopen_state_clear(const gchar *reason);
+static void pairing_required_reopen_state_cache(const gchar *request_id,
+                                                const gchar *detail);
 
 /* ──────────────────────────── parent lifetime ──────────────────────────── */
 
@@ -84,6 +90,35 @@ static void parent_assign(GtkWindow *parent) {
         g_state.parent = parent;
         g_object_weak_ref(G_OBJECT(parent), on_parent_destroyed, NULL);
     }
+}
+
+static void pairing_required_reopen_state_clear(const gchar *reason) {
+    if (!g_state.pairing_required_reopen_state_cached &&
+        !g_state.last_pairing_required_request_id &&
+        !g_state.last_pairing_required_detail) {
+        return;
+    }
+
+    g_state.pairing_required_reopen_state_cached = FALSE;
+    g_clear_pointer(&g_state.last_pairing_required_request_id, g_free);
+    g_clear_pointer(&g_state.last_pairing_required_detail, g_free);
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
+                 "device pairing reopen state cleared reason=%s",
+                 reason ? reason : "(none)");
+}
+
+static void pairing_required_reopen_state_cache(const gchar *request_id,
+                                                const gchar *detail) {
+    g_state.pairing_required_reopen_state_cached = TRUE;
+
+    g_clear_pointer(&g_state.last_pairing_required_request_id, g_free);
+    g_state.last_pairing_required_request_id =
+        (request_id && request_id[0]) ? g_strdup(request_id) : NULL;
+
+    g_clear_pointer(&g_state.last_pairing_required_detail, g_free);
+    g_state.last_pairing_required_detail =
+        (detail && detail[0]) ? g_strdup(detail) : NULL;
 }
 
 /* ──────────────────────────── helpers ──────────────────────────── */
@@ -360,6 +395,12 @@ static void handle_device_pair_resolved(JsonNode *payload) {
                 "device.pair.resolved request_id=%s outcome=%s",
                 request_id, outcome ? outcome : "(n/a)");
 
+    if (g_state.pairing_required_reopen_state_cached &&
+        g_state.last_pairing_required_request_id &&
+        g_strcmp0(g_state.last_pairing_required_request_id, request_id) == 0) {
+        pairing_required_reopen_state_clear("pair request resolved");
+    }
+
     /*
      * Three cases:
      *   1. request is currently being presented to the local operator →
@@ -495,6 +536,7 @@ static void handle_pairing_required(JsonNode *payload) {
         detail = oc_json_string_member(obj, "detail");
         if (!detail) detail = oc_json_string_member(obj, "message");
     }
+    pairing_required_reopen_state_cache(request_id, detail);
     /*
      * Ask gateway_ws for the locally-loaded deviceId so the bootstrap
      * window can render the "This machine" fingerprint alongside the
@@ -547,6 +589,7 @@ void device_pair_prompter_shutdown(void) {
     }
     g_state.presenting = FALSE;
     g_clear_pointer(&g_state.active_request_id, g_free);
+    pairing_required_reopen_state_clear("prompter shutdown");
     parent_clear_ref();
 }
 
@@ -592,6 +635,17 @@ void device_pair_prompter_raise(void) {
         pairing_bootstrap_window_raise();
         return;
     }
+    if (gateway_ws_is_pairing_required()) {
+        if (!g_state.pairing_required_reopen_state_cached) {
+            OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                        "pairing required but bootstrap reopen cache missing; reopening with fallback metadata");
+        }
+        pairing_bootstrap_window_show(g_state.parent,
+                                      g_state.last_pairing_required_request_id,
+                                      gateway_ws_get_device_id(),
+                                      g_state.last_pairing_required_detail);
+        return;
+    }
     if (g_state.presenting) {
         device_pair_approval_window_raise_active();
     }
@@ -609,6 +663,7 @@ void device_pair_prompter_notify_transport_authenticated(void) {
      * single module owns the full show → raise → hide lifecycle of the
      * bootstrap surface. No other caller may drive those APIs directly.
      */
+    pairing_required_reopen_state_clear("transport authenticated");
     pairing_bootstrap_window_hide();
 }
 

--- a/apps/linux/tests/test_device_pair_prompter.c
+++ b/apps/linux/tests/test_device_pair_prompter.c
@@ -49,13 +49,22 @@ void gateway_ws_event_unsubscribe(guint listener_id) {
  * the deviceId propagation path set g_ws_device_id to a sentinel value
  * before injecting an event. */
 static const gchar *g_ws_device_id = NULL;
+static gboolean g_ws_pairing_required = FALSE;
 
 const gchar* gateway_ws_get_device_id(void) {
     return g_ws_device_id;
 }
 
+gboolean gateway_ws_is_pairing_required(void) {
+    return g_ws_pairing_required;
+}
+
 G_GNUC_UNUSED static void set_ws_device_id_for_test(const gchar *value) {
     g_ws_device_id = value;
+}
+
+G_GNUC_UNUSED static void set_ws_pairing_required_for_test(gboolean value) {
+    g_ws_pairing_required = value;
 }
 
 static GPtrArray *g_rpc_calls = NULL; /* array of "method|requestId" strings */
@@ -102,6 +111,7 @@ void pairing_bootstrap_window_show(GtkWindow   *parent,
 {
     (void)parent;
     g_bootstrap_shows++;
+    g_bootstrap_visible = TRUE;
     g_clear_pointer(&g_bootstrap_last_request_id, g_free);
     g_clear_pointer(&g_bootstrap_last_device_id, g_free);
     g_clear_pointer(&g_bootstrap_last_detail, g_free);
@@ -216,6 +226,7 @@ static void reset_globals(void) {
     g_clear_pointer(&g_dismiss_last_request_id, g_free);
     g_raise_calls = 0;
     g_ws_device_id = NULL;
+    g_ws_pairing_required = FALSE;
     g_ws_event_cb = NULL;
     g_ws_event_user = NULL;
     g_ws_event_listener_id_counter = 0;
@@ -503,6 +514,46 @@ static void test_resolved_while_active_dismisses_dialog(void) {
     device_pair_prompter_test_set_present_hook(NULL, NULL);
     device_pair_prompter_shutdown();
     g_ptr_array_free(p.seen_request_ids, TRUE);
+}
+
+static void test_raise_reopens_pairing_required_bootstrap_after_dismiss(void) {
+    reset_globals();
+    set_ws_device_id_for_test("dev-reopen");
+    set_ws_pairing_required_for_test(TRUE);
+    device_pair_prompter_init(NULL);
+
+    g_autoptr(JsonBuilder) b = json_builder_new();
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "requestId");
+    json_builder_add_string_value(b, "req-reopen");
+    json_builder_set_member_name(b, "detail");
+    json_builder_add_string_value(b, "approval pending");
+    json_builder_end_object(b);
+    g_autoptr(JsonNode) payload = json_builder_get_root(b);
+
+    g_assert_nonnull(g_ws_event_cb);
+    g_ws_event_cb("device.pairing.required", payload, g_ws_event_user);
+
+    g_assert_cmpint(g_bootstrap_shows, ==, 1);
+    g_assert_true(g_bootstrap_visible);
+    g_assert_cmpstr(g_bootstrap_last_request_id, ==, "req-reopen");
+    g_assert_cmpstr(g_bootstrap_last_device_id, ==, "dev-reopen");
+    g_assert_cmpstr(g_bootstrap_last_detail, ==, "approval pending");
+
+    pairing_bootstrap_window_hide();
+    g_assert_cmpint(g_bootstrap_hides, ==, 1);
+    g_assert_false(g_bootstrap_visible);
+
+    device_pair_prompter_raise();
+
+    g_assert_cmpint(g_bootstrap_shows, ==, 2);
+    g_assert_cmpint(g_bootstrap_raises, ==, 0);
+    g_assert_true(g_bootstrap_visible);
+    g_assert_cmpstr(g_bootstrap_last_request_id, ==, "req-reopen");
+    g_assert_cmpstr(g_bootstrap_last_device_id, ==, "dev-reopen");
+    g_assert_cmpstr(g_bootstrap_last_detail, ==, "approval pending");
+
+    device_pair_prompter_shutdown();
 }
 
 static void test_resolved_while_queued_drops_silently(void) {
@@ -1045,6 +1096,8 @@ int main(int argc, char **argv) {
                     test_raise_with_no_pending_is_noop);
     g_test_add_func("/device_pair_prompter/raise_when_bootstrap_visible_uses_raise_primitive",
                     test_raise_when_bootstrap_visible_uses_raise_primitive);
+    g_test_add_func("/device_pair_prompter/raise_reopens_pairing_required_bootstrap_after_dismiss",
+                    test_raise_reopens_pairing_required_bootstrap_after_dismiss);
     g_test_add_func("/device_pair_prompter/raise_with_active_dialog",
                     test_raise_with_active_dialog_raises_it);
     g_test_add_func("/pairing_bootstrap/cli_command_has_request_id",


### PR DESCRIPTION
Keep the pairing-required reopen contract inside `device_pair_prompter` so the Linux companion footer's actionable pairing state always maps to a working recovery path.

* cache pairing-required bootstrap metadata in `device_pair_prompter.c` when the authoritative pairing-required event is handled
* clear cached reopen state on matching resolve, transport authentication, and prompter shutdown
* update `device_pair_prompter_raise()` to:
  * raise the visible bootstrap window if already shown
  * reopen the bootstrap window when pairing is still required
  * otherwise raise the active approval dialog if present
* add a focused regression test proving the bootstrap can be reopened after dismiss while pairing-required remains true

This fixes the dead-action path where the footer showed `Pairing: required` with an `Open` button, but clicking it did nothing after the bootstrap window had been dismissed.
