### PR TITLE
feat(linux): add product state and coordinator (#96)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -47,6 +47,8 @@ sources = [
   'src/gateway_data.c',
   'src/gateway_mutations.c',
   'src/gateway_client.c',
+  'src/product_state.c',
+  'src/product_coordinator.c',
   'src/state.c',
   'src/runtime_mode.c',
   'src/readiness.c',
@@ -129,6 +131,16 @@ test_config_exe = executable('test_config',
   ['tests/test_config.c', 'src/gateway_config.c', 'src/config_setup_transform.c', 'src/log.c'],
   dependencies : [glib_dep, gio_dep, json_glib_dep])
 test('config', test_config_exe)
+
+test_product_state_exe = executable('test_product_state',
+  ['tests/test_product_state.c', 'src/product_state.c'],
+  dependencies : [glib_dep])
+test('product_state', test_product_state_exe)
+
+test_product_coordinator_exe = executable('test_product_coordinator',
+  ['tests/test_product_coordinator.c', 'src/product_coordinator.c'],
+  dependencies : [glib_dep, gtk4_dep, json_glib_dep])
+test('product_coordinator', test_product_coordinator_exe)
 
 test_seams_exe = executable('test_seams',
   ['tests/test_seams.c', 'src/test_seams.c'],

--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -23,7 +23,6 @@
 #include "gateway_config.h"
 #include "gateway_client.h"
 #include "diagnostics.h"
-#include "onboarding.h"
 #include "device_pair_prompter.h"
 #include "gateway_ws.h"
 #include "chat_window.h"
@@ -45,6 +44,7 @@
 #include "ui_model_utils.h"
 #include "runtime_paths.h"
 #include "log.h"
+#include "product_coordinator.h"
 
 /* ── Section metadata ── */
 
@@ -915,7 +915,7 @@ static void on_gen_open_dashboard(GtkButton *b, gpointer d) {
 
 static void on_gen_rerun_onboarding(GtkButton *b, gpointer d) {
     (void)b; (void)d;
-    onboarding_show();
+    product_coordinator_request_rerun_onboarding();
 }
 
 static void on_gen_quit(GtkButton *b, gpointer d) {
@@ -2383,7 +2383,7 @@ static void on_dbg_restart_gw(GtkButton *b, gpointer d) {
 
 static void on_dbg_rerun_onboarding(GtkButton *b, gpointer d) {
     (void)b; (void)d;
-    onboarding_show();
+    product_coordinator_request_rerun_onboarding();
 }
 
 static void on_dbg_reveal_config(GtkButton *b, gpointer d) {

--- a/apps/linux/src/main.c
+++ b/apps/linux/src/main.c
@@ -18,23 +18,10 @@
 
 #include "log.h"
 #include "gateway_client.h"
-#include "onboarding.h"
-#include "device_pair_prompter.h"
-
-extern void tray_init(void);
-extern void systemd_init(void);
-extern void systemd_refresh(void);
-extern void state_init(void);
-extern void notify_init(void);
+#include "product_coordinator.h"
 
 void state_on_gateway_refresh_requested(void) {
     gateway_client_refresh();
-}
-
-static gboolean onboarding_check_timeout_cb(gpointer user_data) {
-    (void)user_data;
-    onboarding_check_and_show();
-    return G_SOURCE_REMOVE;
 }
 
 static void on_activate(GtkApplication *app, gpointer user_data) {
@@ -49,37 +36,8 @@ static void on_activate(GtkApplication *app, gpointer user_data) {
     // The app has 2 distinct asynchronous runtime lanes:
     // Lane 1: Real-time systemd D-Bus event subscription (service lifecycle context)
     // Lane 2: Native gateway client (HTTP health polling + persistent WebSocket)
-
-    // Startup Sequence:
-    // 1. Initialize app state and notifications
-    state_init();
-    notify_init();
-    
-    // 2. Initialize tray first so the UI helper exists to receive early state broadcasts
-    tray_init();
-    
-    // 3. Initialize systemd D-Bus lane (which may immediately publish 'User Systemd Unavailable')
-    systemd_init();
-    
-    // 4. Perform the initial systemd state fetch so we don't start with a blank UI
-    systemd_refresh();
-
-    // 5. Initialize native gateway client (HTTP health polling + WebSocket)
-    // The gateway client manages its own internal timers for health polling
-    // and WebSocket reconnection with exponential backoff.
-    gateway_client_init();
-
-    // 5b. Initialize the pairing-approval prompter so pairing events that
-    // arrive on the very first WS handshake are captured. Parent remains
-    // NULL here; app_window wires the real parent when the main window
-    // exists.
-    device_pair_prompter_init(NULL);
-
-    // 6. Schedule onboarding check after a short delay so the initial
-    // health probe has time to complete and state is meaningful.
-    // Tray-first: after onboarding is completed, steady-state launches
-    // do NOT auto-open the main window.
-    g_timeout_add_seconds(2, onboarding_check_timeout_cb, NULL);
+ 
+    product_coordinator_activate();
 }
 
 int main(int argc, char **argv) {

--- a/apps/linux/src/onboarding.c
+++ b/apps/linux/src/onboarding.c
@@ -15,57 +15,27 @@
 #include <gtk/gtk.h>
 #include <adwaita.h>
 #include <stdio.h>
-#include <sys/stat.h>
-#include <errno.h>
 #include <string.h>
-#include <glib/gstdio.h>
 
 #include "onboarding.h"
 #include "display_model.h"
 #include "gateway_config.h"
 #include "gateway_client.h"
+#include "product_coordinator.h"
+#include "product_state.h"
 #include "state.h"
 #include "readiness.h"
-#include "app_window.h"
 #include "runtime_paths.h"
 #include "test_seams.h"
-#include "log.h"
 
 /* ── Version marker persistence ── */
 
-static gchar* get_marker_path(void) {
-    const gchar *state_dir = g_get_user_state_dir(); /* XDG_STATE_HOME or ~/.local/state */
-    return g_build_filename(state_dir, "openclaw-companion", "onboarding_version", NULL);
-}
-
 int onboarding_get_seen_version(void) {
-    g_autofree gchar *path = get_marker_path();
-    g_autofree gchar *contents = NULL;
-    if (!g_file_get_contents(path, &contents, NULL, NULL)) {
-        return 0;
-    }
-    g_strstrip(contents);
-    gint64 v = g_ascii_strtoll(contents, NULL, 10);
-    return (int)v;
-}
-
-static void write_seen_version(int version) {
-    g_autofree gchar *path = get_marker_path();
-    g_autofree gchar *dir = g_path_get_dirname(path);
-
-    g_mkdir_with_parents(dir, 0755);
-
-    g_autofree gchar *text = g_strdup_printf("%d\n", version);
-    g_autoptr(GError) err = NULL;
-    if (!g_file_set_contents(path, text, -1, &err)) {
-        OC_LOG_WARN(OPENCLAW_LOG_CAT_STATE, "Failed to write onboarding marker: %s",
-                    err->message);
-    }
+    return (int)product_state_get_onboarding_seen_version();
 }
 
 void onboarding_reset(void) {
-    g_autofree gchar *path = get_marker_path();
-    g_unlink(path);
+    (void)product_state_reset_onboarding_seen_version();
 }
 
 /* ── Onboarding window ── */
@@ -84,10 +54,13 @@ static GtkWidget *onboard_gateway_stage_connection_icon = NULL;
 static GtkWidget *onboard_gateway_stage_connection_detail = NULL;
 static GtkWidget *onboard_gateway_next_action_box = NULL;
 static GtkWidget *onboard_gateway_next_action_value = NULL;
-
 static GtkWidget *onboard_whats_next_guidance_label = NULL;
 static GtkWidget *onboard_whats_next_dashboard_button = NULL;
 static GtkWidget *onboard_environment_checks_box = NULL;
+
+static GtkWidget* build_gateway_page(GtkWidget *carousel);
+static GtkWidget* build_environment_page(GtkWidget *carousel);
+static GtkWidget* build_whats_next_page(GtkWidget *carousel);
 
 typedef struct {
     AppState state;
@@ -107,11 +80,6 @@ typedef struct {
 
 static gboolean onboard_has_render_snapshot = FALSE;
 static OnboardingRenderSnapshot onboard_last_snapshot = {0};
-
-static void onboarding_refresh_live_content(void);
-static GtkWidget* build_gateway_page(GtkWidget *carousel);
-static GtkWidget* build_environment_page(GtkWidget *carousel);
-static GtkWidget* build_whats_next_page(GtkWidget *carousel);
 
 static void onboarding_snapshot_to_input(const OnboardingRenderSnapshot *snap,
                                          OnboardingRefreshSnapshotInput *out) {
@@ -213,11 +181,10 @@ static void on_onboard_destroy(GtkWindow *window, gpointer user_data) {
 
 static void on_finish_clicked(GtkButton *btn, gpointer data) {
     (void)btn; (void)data;
-    write_seen_version(ONBOARDING_CURRENT_VERSION);
     if (onboard_window) {
         gtk_window_destroy(GTK_WINDOW(onboard_window));
     }
-    app_window_show();
+    product_coordinator_notify_onboarding_completed();
 }
 
 static void on_open_dashboard_clicked(GtkButton *btn, gpointer data) {
@@ -809,19 +776,7 @@ void onboarding_show(void) {
 }
 
 void onboarding_check_and_show(void) {
-    AppState current = state_get_current();
-    OnboardingRoute route = onboarding_routing_decide(
-        current, onboarding_get_seen_version(), ONBOARDING_CURRENT_VERSION);
-
-    if (route == ONBOARDING_SKIP) {
-        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "onboarding: skip (seen=%d current=%d)",
-                     onboarding_get_seen_version(), ONBOARDING_CURRENT_VERSION);
-        return;
-    }
-
-    OC_LOG_INFO(OPENCLAW_LOG_CAT_STATE, "onboarding: showing %s flow",
-                route == ONBOARDING_SHOW_FULL ? "full" : "shortened");
-    onboarding_show();
+    product_coordinator_reconcile_startup_presentation();
 }
 
 gboolean onboarding_is_visible(void) {
@@ -862,11 +817,10 @@ void onboarding_refresh(void) {
     readiness_build_onboarding_progress(current, health, sys, &progress);
 
     if (progress.operational_ready) {
-        write_seen_version(ONBOARDING_CURRENT_VERSION);
         if (onboard_window) {
             gtk_window_destroy(GTK_WINDOW(onboard_window));
         }
-        app_window_show();
+        product_coordinator_notify_onboarding_completed();
         g_free(profile);
         g_free(state_dir);
         g_free(config_path);

--- a/apps/linux/src/product_coordinator.c
+++ b/apps/linux/src/product_coordinator.c
@@ -1,0 +1,102 @@
+#include "product_coordinator.h"
+
+#include "device_pair_prompter.h"
+#include "display_model.h"
+#include "gateway_client.h"
+#include "onboarding.h"
+#include "product_state.h"
+#include "state.h"
+
+extern void tray_init(void);
+extern void systemd_init(void);
+extern void systemd_refresh(void);
+extern void notify_init(void);
+
+typedef enum {
+    PRODUCT_STARTUP_PRESENTATION_NOOP = 0,
+    PRODUCT_STARTUP_PRESENTATION_SHOW_ONBOARDING = 1,
+} ProductStartupPresentationAction;
+
+typedef struct {
+    gboolean activated;
+    guint startup_timer_id;
+} ProductCoordinatorState;
+
+static ProductCoordinatorState g_coordinator = {0};
+
+static void product_coordinator_boot_runtime_lanes(void) {
+    state_init();
+    product_state_init();
+    notify_init();
+    tray_init();
+    systemd_init();
+    systemd_refresh();
+    gateway_client_init();
+    device_pair_prompter_init(NULL);
+}
+
+static ProductStartupPresentationAction product_coordinator_decide_startup_presentation(
+    AppState runtime_state,
+    guint onboarding_seen_version) {
+    OnboardingRoute route = onboarding_routing_decide(runtime_state,
+                                                      (int)onboarding_seen_version,
+                                                      ONBOARDING_CURRENT_VERSION);
+    if (route == ONBOARDING_SKIP) return PRODUCT_STARTUP_PRESENTATION_NOOP;
+    return PRODUCT_STARTUP_PRESENTATION_SHOW_ONBOARDING;
+}
+
+static gboolean product_coordinator_startup_timeout_cb(gpointer user_data) {
+    (void)user_data;
+    g_coordinator.startup_timer_id = 0;
+    product_coordinator_reconcile_startup_presentation();
+    return G_SOURCE_REMOVE;
+}
+
+void product_coordinator_activate(void) {
+    if (g_coordinator.activated) return;
+
+    g_coordinator.activated = TRUE;
+    product_coordinator_boot_runtime_lanes();
+
+    if (g_coordinator.startup_timer_id == 0) {
+        g_coordinator.startup_timer_id = g_timeout_add_seconds(2,
+                                                               product_coordinator_startup_timeout_cb,
+                                                               NULL);
+    }
+}
+
+void product_coordinator_reconcile_startup_presentation(void) {
+    ProductStartupPresentationAction action = product_coordinator_decide_startup_presentation(
+        state_get_current(),
+        product_state_get_onboarding_seen_version());
+
+    if (action == PRODUCT_STARTUP_PRESENTATION_SHOW_ONBOARDING) {
+        onboarding_show();
+    }
+}
+
+void product_coordinator_request_show_main(void) {
+    app_window_show();
+}
+
+void product_coordinator_request_show_section(AppSection section) {
+    app_window_show();
+    app_window_navigate_to(section);
+}
+
+void product_coordinator_request_rerun_onboarding(void) {
+    onboarding_show();
+}
+
+void product_coordinator_notify_onboarding_completed(void) {
+    (void)product_state_set_onboarding_seen_version(ONBOARDING_CURRENT_VERSION);
+    app_window_show();
+}
+
+void product_coordinator_test_reset(void) {
+    if (g_coordinator.startup_timer_id != 0) {
+        g_source_remove(g_coordinator.startup_timer_id);
+        g_coordinator.startup_timer_id = 0;
+    }
+    g_coordinator.activated = FALSE;
+}

--- a/apps/linux/src/product_coordinator.h
+++ b/apps/linux/src/product_coordinator.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "app_window.h"
+
+void product_coordinator_activate(void);
+void product_coordinator_reconcile_startup_presentation(void);
+void product_coordinator_request_show_main(void);
+void product_coordinator_request_show_section(AppSection section);
+void product_coordinator_request_rerun_onboarding(void);
+void product_coordinator_notify_onboarding_completed(void);
+
+void product_coordinator_test_reset(void);

--- a/apps/linux/src/product_state.c
+++ b/apps/linux/src/product_state.c
@@ -1,0 +1,256 @@
+#include "product_state.h"
+
+#include <errno.h>
+#include <glib/gstdio.h>
+#include <string.h>
+
+#define PRODUCT_STATE_GROUP "product"
+#define PRODUCT_STATE_KEY_CONNECTION_MODE "connection_mode"
+#define PRODUCT_STATE_KEY_ONBOARDING_SEEN_VERSION "onboarding_seen_version"
+
+typedef struct {
+    ProductStateSnapshot snapshot;
+    gboolean initialized;
+    gchar *storage_path_override;
+    gchar *legacy_marker_path_override;
+} ProductStateStore;
+
+static ProductStateStore g_store = {0};
+
+static gchar* product_state_storage_path(void) {
+    if (g_store.storage_path_override) return g_strdup(g_store.storage_path_override);
+    return g_build_filename(g_get_user_state_dir(), "openclaw-companion", "product-state.ini", NULL);
+}
+
+static gchar* product_state_legacy_marker_path(void) {
+    if (g_store.legacy_marker_path_override) return g_strdup(g_store.legacy_marker_path_override);
+    return g_build_filename(g_get_user_state_dir(), "openclaw-companion", "onboarding_version", NULL);
+}
+
+static void product_state_apply_defaults(ProductStateSnapshot *state) {
+    if (!state) return;
+    state->connection_mode = PRODUCT_CONNECTION_MODE_LOCAL;
+    state->onboarding_seen_version = 0;
+}
+
+static ProductConnectionMode product_state_normalize_connection_mode(ProductConnectionMode mode) {
+    if (mode == PRODUCT_CONNECTION_MODE_LOCAL) return PRODUCT_CONNECTION_MODE_LOCAL;
+    return PRODUCT_CONNECTION_MODE_LOCAL;
+}
+
+static void product_state_normalize(ProductStateSnapshot *state) {
+    if (!state) return;
+    state->connection_mode = product_state_normalize_connection_mode(state->connection_mode);
+}
+
+static const gchar* product_connection_mode_to_string(ProductConnectionMode mode) {
+    if (product_state_normalize_connection_mode(mode) == PRODUCT_CONNECTION_MODE_LOCAL) return "local";
+    return "local";
+}
+
+static ProductConnectionMode product_connection_mode_from_string(const gchar *value) {
+    if (g_strcmp0(value, "local") == 0) return PRODUCT_CONNECTION_MODE_LOCAL;
+    return PRODUCT_CONNECTION_MODE_UNSPECIFIED;
+}
+
+static gboolean product_state_load_legacy_onboarding_version(guint *out_version) {
+    g_autofree gchar *path = product_state_legacy_marker_path();
+    g_autofree gchar *contents = NULL;
+    gint64 parsed = 0;
+
+    if (!out_version || !path) return FALSE;
+    if (!g_file_get_contents(path, &contents, NULL, NULL)) return FALSE;
+
+    g_strstrip(contents);
+    if (contents[0] == '\0') return FALSE;
+
+    parsed = g_ascii_strtoll(contents, NULL, 10);
+    if (parsed < 0 || parsed > G_MAXUINT) return FALSE;
+
+    *out_version = (guint)parsed;
+    return TRUE;
+}
+
+static gboolean product_state_flush_to_disk(const ProductStateSnapshot *state) {
+    g_autofree gchar *path = NULL;
+    g_autofree gchar *dir = NULL;
+    g_autofree gchar *data = NULL;
+    gsize data_len = 0;
+    g_autoptr(GError) error = NULL;
+    g_autoptr(GKeyFile) key_file = NULL;
+
+    if (!state) return FALSE;
+
+    path = product_state_storage_path();
+    if (!path) return FALSE;
+
+    dir = g_path_get_dirname(path);
+    if (!dir) return FALSE;
+
+    if (g_mkdir_with_parents(dir, 0700) != 0 && errno != EEXIST) {
+        return FALSE;
+    }
+
+    key_file = g_key_file_new();
+    g_key_file_set_string(key_file,
+                          PRODUCT_STATE_GROUP,
+                          PRODUCT_STATE_KEY_CONNECTION_MODE,
+                          product_connection_mode_to_string(state->connection_mode));
+    g_key_file_set_uint64(key_file,
+                          PRODUCT_STATE_GROUP,
+                          PRODUCT_STATE_KEY_ONBOARDING_SEEN_VERSION,
+                          state->onboarding_seen_version);
+
+    data = g_key_file_to_data(key_file, &data_len, NULL);
+    if (!data) return FALSE;
+
+    return g_file_set_contents(path, data, (gssize)data_len, &error);
+}
+
+static gboolean product_state_load_from_disk(ProductStateSnapshot *state,
+                                             gboolean *out_loaded_any,
+                                             gboolean *out_needs_flush) {
+    g_autofree gchar *path = NULL;
+    g_autoptr(GKeyFile) key_file = NULL;
+    g_autoptr(GError) error = NULL;
+    gboolean loaded_any = FALSE;
+    gboolean needs_flush = FALSE;
+
+    if (!state) return FALSE;
+
+    path = product_state_storage_path();
+    if (!path) return FALSE;
+
+    key_file = g_key_file_new();
+    if (g_file_test(path, G_FILE_TEST_EXISTS)) {
+        if (g_key_file_load_from_file(key_file, path, G_KEY_FILE_NONE, &error)) {
+            loaded_any = TRUE;
+
+            if (g_key_file_has_key(key_file, PRODUCT_STATE_GROUP, PRODUCT_STATE_KEY_CONNECTION_MODE, NULL)) {
+                g_autofree gchar *mode_value = g_key_file_get_string(key_file,
+                                                                     PRODUCT_STATE_GROUP,
+                                                                     PRODUCT_STATE_KEY_CONNECTION_MODE,
+                                                                     NULL);
+                ProductConnectionMode parsed_mode = product_connection_mode_from_string(mode_value);
+                if (parsed_mode == PRODUCT_CONNECTION_MODE_UNSPECIFIED) {
+                    needs_flush = TRUE;
+                } else {
+                    state->connection_mode = parsed_mode;
+                }
+            } else {
+                needs_flush = TRUE;
+            }
+
+            if (g_key_file_has_key(key_file, PRODUCT_STATE_GROUP, PRODUCT_STATE_KEY_ONBOARDING_SEEN_VERSION, NULL)) {
+                guint64 version = g_key_file_get_uint64(key_file,
+                                                       PRODUCT_STATE_GROUP,
+                                                       PRODUCT_STATE_KEY_ONBOARDING_SEEN_VERSION,
+                                                       &error);
+                if (!error && version <= G_MAXUINT) {
+                    state->onboarding_seen_version = (guint)version;
+                } else {
+                    g_clear_error(&error);
+                    needs_flush = TRUE;
+                }
+            }
+        }
+    }
+
+    if (!loaded_any) {
+        guint legacy_version = 0;
+        if (product_state_load_legacy_onboarding_version(&legacy_version)) {
+            state->onboarding_seen_version = legacy_version;
+            loaded_any = TRUE;
+            needs_flush = TRUE;
+        }
+    }
+
+    product_state_normalize(state);
+
+    if (out_loaded_any) *out_loaded_any = loaded_any;
+    if (out_needs_flush) *out_needs_flush = needs_flush;
+    return TRUE;
+}
+
+static void product_state_ensure_initialized(void) {
+    ProductStateSnapshot snapshot = {0};
+    gboolean loaded_any = FALSE;
+    gboolean needs_flush = FALSE;
+
+    if (g_store.initialized) return;
+
+    product_state_apply_defaults(&snapshot);
+    product_state_load_from_disk(&snapshot, &loaded_any, &needs_flush);
+    g_store.snapshot = snapshot;
+    g_store.initialized = TRUE;
+
+    if (!loaded_any || needs_flush) {
+        (void)product_state_flush_to_disk(&g_store.snapshot);
+    }
+}
+
+void product_state_init(void) {
+    product_state_ensure_initialized();
+}
+
+void product_state_get_snapshot(ProductStateSnapshot *out) {
+    product_state_ensure_initialized();
+    if (!out) return;
+    *out = g_store.snapshot;
+}
+
+ProductConnectionMode product_state_get_connection_mode(void) {
+    product_state_ensure_initialized();
+    return g_store.snapshot.connection_mode;
+}
+
+gboolean product_state_set_connection_mode(ProductConnectionMode mode) {
+    ProductConnectionMode normalized = product_state_normalize_connection_mode(mode);
+
+    product_state_ensure_initialized();
+    if (g_store.snapshot.connection_mode == normalized) return TRUE;
+
+    g_store.snapshot.connection_mode = normalized;
+    return product_state_flush_to_disk(&g_store.snapshot);
+}
+
+guint product_state_get_onboarding_seen_version(void) {
+    product_state_ensure_initialized();
+    return g_store.snapshot.onboarding_seen_version;
+}
+
+gboolean product_state_set_onboarding_seen_version(guint version) {
+    product_state_ensure_initialized();
+    if (g_store.snapshot.onboarding_seen_version == version) return TRUE;
+
+    g_store.snapshot.onboarding_seen_version = version;
+    return product_state_flush_to_disk(&g_store.snapshot);
+}
+
+gboolean product_state_reset_onboarding_seen_version(void) {
+    g_autofree gchar *legacy_path = NULL;
+
+    product_state_ensure_initialized();
+    g_store.snapshot.onboarding_seen_version = 0;
+
+    legacy_path = product_state_legacy_marker_path();
+    if (legacy_path) (void)g_unlink(legacy_path);
+
+    return product_state_flush_to_disk(&g_store.snapshot);
+}
+
+void product_state_test_set_storage_path(const gchar *path) {
+    g_free(g_store.storage_path_override);
+    g_store.storage_path_override = g_strdup(path);
+}
+
+void product_state_test_set_legacy_marker_path(const gchar *path) {
+    g_free(g_store.legacy_marker_path_override);
+    g_store.legacy_marker_path_override = g_strdup(path);
+}
+
+void product_state_test_reset(void) {
+    g_store.snapshot.connection_mode = PRODUCT_CONNECTION_MODE_UNSPECIFIED;
+    g_store.snapshot.onboarding_seen_version = 0;
+    g_store.initialized = FALSE;
+}

--- a/apps/linux/src/product_state.h
+++ b/apps/linux/src/product_state.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <glib.h>
+
+typedef enum {
+    PRODUCT_CONNECTION_MODE_UNSPECIFIED = 0,
+    PRODUCT_CONNECTION_MODE_LOCAL = 1,
+} ProductConnectionMode;
+
+typedef struct {
+    ProductConnectionMode connection_mode;
+    guint onboarding_seen_version;
+} ProductStateSnapshot;
+
+void product_state_init(void);
+void product_state_get_snapshot(ProductStateSnapshot *out);
+ProductConnectionMode product_state_get_connection_mode(void);
+gboolean product_state_set_connection_mode(ProductConnectionMode mode);
+guint product_state_get_onboarding_seen_version(void);
+gboolean product_state_set_onboarding_seen_version(guint version);
+gboolean product_state_reset_onboarding_seen_version(void);
+
+void product_state_test_set_storage_path(const gchar *path);
+void product_state_test_set_legacy_marker_path(const gchar *path);
+void product_state_test_reset(void);

--- a/apps/linux/src/tray.c
+++ b/apps/linux/src/tray.c
@@ -17,12 +17,12 @@
 #include <string.h>
 #include "state.h"
 #include "log.h"
-#include "app_window.h"
 #include "chat_window.h"
 #include "gateway_client.h"
 #include "gateway_config.h"
 #include "display_model.h"
 #include "onboarding.h"
+#include "product_coordinator.h"
 #include "test_seams.h"
 
 static GSubprocess *helper_process = NULL;
@@ -60,16 +60,14 @@ static void handle_helper_action(const gchar *action);
 static void handle_open_settings_request(void) {
     TrayUiAction action = tray_ui_dispatch_decide(TRAY_UI_REQUEST_SETTINGS, onboarding_is_visible());
     if (action == TRAY_UI_ACTION_SHOW_SETTINGS) {
-        app_window_show();
-        app_window_navigate_to(SECTION_GENERAL);
+        product_coordinator_request_show_section(SECTION_GENERAL);
     }
 }
 
 static void handle_open_diagnostics_request(void) {
     TrayUiAction action = tray_ui_dispatch_decide(TRAY_UI_REQUEST_DIAGNOSTICS, onboarding_is_visible());
     if (action == TRAY_UI_ACTION_SHOW_DIAGNOSTICS) {
-        app_window_show();
-        app_window_navigate_to(SECTION_DIAGNOSTICS);
+        product_coordinator_request_show_section(SECTION_DIAGNOSTICS);
     }
 }
 
@@ -95,7 +93,7 @@ static void handle_helper_action(const gchar *action) {
         // Trigger an immediate gateway client health check
         gateway_client_refresh();
     } else if (g_strcmp0(action, "OPEN_MAIN") == 0) {
-        app_window_show();
+        product_coordinator_request_show_main();
     } else if (g_strcmp0(action, "OPEN_CHAT") == 0) {
         /* Standalone chat window — lives independently of the main
          * settings / diagnostics window (see chat_window.{c,h}). */

--- a/apps/linux/tests/test_product_coordinator.c
+++ b/apps/linux/tests/test_product_coordinator.c
@@ -1,0 +1,231 @@
+#include "../src/product_coordinator.h"
+
+#include "../src/display_model.h"
+#include "../src/onboarding.h"
+#include "../src/product_state.h"
+#include "../src/state.h"
+
+#include <glib.h>
+
+static gint stub_state_init_calls = 0;
+static gint stub_product_state_init_calls = 0;
+static gint stub_notify_init_calls = 0;
+static gint stub_tray_init_calls = 0;
+static gint stub_systemd_init_calls = 0;
+static gint stub_systemd_refresh_calls = 0;
+static gint stub_gateway_client_init_calls = 0;
+static gint stub_device_pair_prompter_init_calls = 0;
+static gint stub_onboarding_show_calls = 0;
+static gint stub_app_window_show_calls = 0;
+static gint stub_app_window_navigate_calls = 0;
+static gint stub_product_state_set_seen_calls = 0;
+static AppSection stub_last_navigate_section = SECTION_DASHBOARD;
+static guint stub_onboarding_seen_version = 0;
+static guint stub_last_persisted_onboarding_seen_version = 0;
+static AppState stub_current_state = STATE_NEEDS_SETUP;
+static AppState stub_last_routing_state = STATE_ERROR;
+static gint stub_last_routing_seen_version = -1;
+static gint stub_last_routing_current_version = -1;
+static OnboardingRoute stub_route = ONBOARDING_SKIP;
+
+static void stub_reset(void) {
+    product_coordinator_test_reset();
+    stub_state_init_calls = 0;
+    stub_product_state_init_calls = 0;
+    stub_notify_init_calls = 0;
+    stub_tray_init_calls = 0;
+    stub_systemd_init_calls = 0;
+    stub_systemd_refresh_calls = 0;
+    stub_gateway_client_init_calls = 0;
+    stub_device_pair_prompter_init_calls = 0;
+    stub_onboarding_show_calls = 0;
+    stub_app_window_show_calls = 0;
+    stub_app_window_navigate_calls = 0;
+    stub_product_state_set_seen_calls = 0;
+    stub_last_navigate_section = SECTION_DASHBOARD;
+    stub_onboarding_seen_version = 0;
+    stub_last_persisted_onboarding_seen_version = 0;
+    stub_current_state = STATE_NEEDS_SETUP;
+    stub_last_routing_state = STATE_ERROR;
+    stub_last_routing_seen_version = -1;
+    stub_last_routing_current_version = -1;
+    stub_route = ONBOARDING_SKIP;
+}
+
+void state_init(void) {
+    stub_state_init_calls++;
+}
+
+AppState state_get_current(void) {
+    return stub_current_state;
+}
+
+void notify_init(void) {
+    stub_notify_init_calls++;
+}
+
+void tray_init(void) {
+    stub_tray_init_calls++;
+}
+
+void systemd_init(void) {
+    stub_systemd_init_calls++;
+}
+
+void systemd_refresh(void) {
+    stub_systemd_refresh_calls++;
+}
+
+void gateway_client_init(void) {
+    stub_gateway_client_init_calls++;
+}
+
+void device_pair_prompter_init(GtkWindow *parent) {
+    (void)parent;
+    stub_device_pair_prompter_init_calls++;
+}
+
+void onboarding_show(void) {
+    stub_onboarding_show_calls++;
+}
+
+void app_window_show(void) {
+    stub_app_window_show_calls++;
+}
+
+void app_window_navigate_to(AppSection section) {
+    stub_app_window_navigate_calls++;
+    stub_last_navigate_section = section;
+}
+
+void product_state_init(void) {
+    stub_product_state_init_calls++;
+}
+
+guint product_state_get_onboarding_seen_version(void) {
+    return stub_onboarding_seen_version;
+}
+
+gboolean product_state_set_onboarding_seen_version(guint version) {
+    stub_product_state_set_seen_calls++;
+    stub_last_persisted_onboarding_seen_version = version;
+    stub_onboarding_seen_version = version;
+    return TRUE;
+}
+
+OnboardingRoute onboarding_routing_decide(AppState state,
+                                          int seen_version,
+                                          int current_version) {
+    stub_last_routing_state = state;
+    stub_last_routing_seen_version = seen_version;
+    stub_last_routing_current_version = current_version;
+    return stub_route;
+}
+
+static void test_activate_boots_runtime_lanes_once(void) {
+    stub_reset();
+
+    product_coordinator_activate();
+    product_coordinator_activate();
+
+    g_assert_cmpint(stub_state_init_calls, ==, 1);
+    g_assert_cmpint(stub_product_state_init_calls, ==, 1);
+    g_assert_cmpint(stub_notify_init_calls, ==, 1);
+    g_assert_cmpint(stub_tray_init_calls, ==, 1);
+    g_assert_cmpint(stub_systemd_init_calls, ==, 1);
+    g_assert_cmpint(stub_systemd_refresh_calls, ==, 1);
+    g_assert_cmpint(stub_gateway_client_init_calls, ==, 1);
+    g_assert_cmpint(stub_device_pair_prompter_init_calls, ==, 1);
+    g_assert_cmpint(stub_onboarding_show_calls, ==, 0);
+
+    stub_reset();
+}
+
+static void test_reconcile_startup_presentation_shows_onboarding(void) {
+    stub_reset();
+    stub_current_state = STATE_NEEDS_ONBOARDING;
+    stub_onboarding_seen_version = 0;
+    stub_route = ONBOARDING_SHOW_FULL;
+
+    product_coordinator_reconcile_startup_presentation();
+
+    g_assert_cmpint(stub_onboarding_show_calls, ==, 1);
+    g_assert_cmpint(stub_last_routing_state, ==, STATE_NEEDS_ONBOARDING);
+    g_assert_cmpint(stub_last_routing_seen_version, ==, 0);
+    g_assert_cmpint(stub_last_routing_current_version, ==, ONBOARDING_CURRENT_VERSION);
+
+    stub_reset();
+}
+
+static void test_reconcile_startup_presentation_skips_when_completed(void) {
+    stub_reset();
+    stub_current_state = STATE_RUNNING;
+    stub_onboarding_seen_version = ONBOARDING_CURRENT_VERSION;
+    stub_route = ONBOARDING_SKIP;
+
+    product_coordinator_reconcile_startup_presentation();
+
+    g_assert_cmpint(stub_onboarding_show_calls, ==, 0);
+    g_assert_cmpint(stub_last_routing_state, ==, STATE_RUNNING);
+    g_assert_cmpint(stub_last_routing_seen_version, ==, ONBOARDING_CURRENT_VERSION);
+
+    stub_reset();
+}
+
+static void test_request_show_main_presents_main_window(void) {
+    stub_reset();
+
+    product_coordinator_request_show_main();
+
+    g_assert_cmpint(stub_app_window_show_calls, ==, 1);
+    g_assert_cmpint(stub_app_window_navigate_calls, ==, 0);
+
+    stub_reset();
+}
+
+static void test_request_show_section_routes_to_main_window(void) {
+    stub_reset();
+
+    product_coordinator_request_show_section(SECTION_DIAGNOSTICS);
+
+    g_assert_cmpint(stub_app_window_show_calls, ==, 1);
+    g_assert_cmpint(stub_app_window_navigate_calls, ==, 1);
+    g_assert_cmpint(stub_last_navigate_section, ==, SECTION_DIAGNOSTICS);
+
+    stub_reset();
+}
+
+static void test_request_rerun_onboarding_shows_onboarding(void) {
+    stub_reset();
+
+    product_coordinator_request_rerun_onboarding();
+
+    g_assert_cmpint(stub_onboarding_show_calls, ==, 1);
+    g_assert_cmpint(stub_app_window_show_calls, ==, 0);
+
+    stub_reset();
+}
+
+static void test_notify_onboarding_completed_persists_and_opens_main(void) {
+    stub_reset();
+
+    product_coordinator_notify_onboarding_completed();
+
+    g_assert_cmpint(stub_product_state_set_seen_calls, ==, 1);
+    g_assert_cmpuint(stub_last_persisted_onboarding_seen_version, ==, ONBOARDING_CURRENT_VERSION);
+    g_assert_cmpint(stub_app_window_show_calls, ==, 1);
+
+    stub_reset();
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/product_coordinator/activate_boots_runtime_lanes_once", test_activate_boots_runtime_lanes_once);
+    g_test_add_func("/product_coordinator/reconcile_startup_presentation_shows_onboarding", test_reconcile_startup_presentation_shows_onboarding);
+    g_test_add_func("/product_coordinator/reconcile_startup_presentation_skips_when_completed", test_reconcile_startup_presentation_skips_when_completed);
+    g_test_add_func("/product_coordinator/request_show_main_presents_main_window", test_request_show_main_presents_main_window);
+    g_test_add_func("/product_coordinator/request_show_section_routes_to_main_window", test_request_show_section_routes_to_main_window);
+    g_test_add_func("/product_coordinator/request_rerun_onboarding_shows_onboarding", test_request_rerun_onboarding_shows_onboarding);
+    g_test_add_func("/product_coordinator/notify_onboarding_completed_persists_and_opens_main", test_notify_onboarding_completed_persists_and_opens_main);
+    return g_test_run();
+}

--- a/apps/linux/tests/test_product_state.c
+++ b/apps/linux/tests/test_product_state.c
@@ -1,0 +1,186 @@
+#include "../src/product_state.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+
+static gchar *make_tmp_dir(void) {
+    gchar *tmpl = g_build_filename(g_get_tmp_dir(), "openclaw-product-state-XXXXXX", NULL);
+    gchar *dir = g_mkdtemp(tmpl);
+    g_assert_nonnull(dir);
+    return dir;
+}
+
+static void remove_if_exists(const gchar *path) {
+    if (!path) return;
+    if (g_file_test(path, G_FILE_TEST_EXISTS)) {
+        g_remove(path);
+    }
+}
+
+static void cleanup_tmp_dir(const gchar *dir) {
+    if (!dir) return;
+    if (g_file_test(dir, G_FILE_TEST_IS_DIR)) {
+        g_rmdir(dir);
+    }
+}
+
+static void reset_product_state_for_paths(const gchar *storage_path,
+                                          const gchar *legacy_path) {
+    product_state_test_set_storage_path(storage_path);
+    product_state_test_set_legacy_marker_path(legacy_path);
+    product_state_test_reset();
+}
+
+static void clear_product_state_test_overrides(void) {
+    product_state_test_reset();
+    product_state_test_set_storage_path(NULL);
+    product_state_test_set_legacy_marker_path(NULL);
+}
+
+static gchar* read_file_or_null(const gchar *path) {
+    gchar *contents = NULL;
+    if (!g_file_get_contents(path, &contents, NULL, NULL)) return NULL;
+    return contents;
+}
+
+static void test_defaults_create_local_state(void) {
+    g_autofree gchar *dir = make_tmp_dir();
+    g_autofree gchar *storage_path = g_build_filename(dir, "product-state.ini", NULL);
+    g_autofree gchar *legacy_path = g_build_filename(dir, "onboarding_version", NULL);
+    ProductStateSnapshot snapshot = {0};
+
+    reset_product_state_for_paths(storage_path, legacy_path);
+    product_state_init();
+    product_state_get_snapshot(&snapshot);
+
+    g_assert_cmpint(snapshot.connection_mode, ==, PRODUCT_CONNECTION_MODE_LOCAL);
+    g_assert_cmpuint(snapshot.onboarding_seen_version, ==, 0);
+    g_assert_true(g_file_test(storage_path, G_FILE_TEST_EXISTS));
+
+    g_autofree gchar *contents = read_file_or_null(storage_path);
+    g_assert_nonnull(contents);
+    g_assert_nonnull(g_strstr_len(contents, -1, "connection_mode=local"));
+    g_assert_nonnull(g_strstr_len(contents, -1, "onboarding_seen_version=0"));
+
+    clear_product_state_test_overrides();
+    remove_if_exists(storage_path);
+    remove_if_exists(legacy_path);
+    cleanup_tmp_dir(dir);
+}
+
+static void test_onboarding_seen_version_roundtrip(void) {
+    g_autofree gchar *dir = make_tmp_dir();
+    g_autofree gchar *storage_path = g_build_filename(dir, "product-state.ini", NULL);
+    g_autofree gchar *legacy_path = g_build_filename(dir, "onboarding_version", NULL);
+
+    reset_product_state_for_paths(storage_path, legacy_path);
+    product_state_init();
+    g_assert_true(product_state_set_onboarding_seen_version(7));
+
+    product_state_test_reset();
+    product_state_init();
+
+    g_assert_cmpuint(product_state_get_onboarding_seen_version(), ==, 7);
+    g_assert_cmpint(product_state_get_connection_mode(), ==, PRODUCT_CONNECTION_MODE_LOCAL);
+
+    clear_product_state_test_overrides();
+    remove_if_exists(storage_path);
+    remove_if_exists(legacy_path);
+    cleanup_tmp_dir(dir);
+}
+
+static void test_invalid_mode_falls_back_to_local(void) {
+    g_autofree gchar *dir = make_tmp_dir();
+    g_autofree gchar *storage_path = g_build_filename(dir, "product-state.ini", NULL);
+    g_autofree gchar *legacy_path = g_build_filename(dir, "onboarding_version", NULL);
+    const gchar *bad_data = "[product]\nconnection_mode=bogus\nonboarding_seen_version=4\n";
+
+    g_assert_true(g_file_set_contents(storage_path, bad_data, -1, NULL));
+    reset_product_state_for_paths(storage_path, legacy_path);
+    product_state_init();
+
+    g_assert_cmpint(product_state_get_connection_mode(), ==, PRODUCT_CONNECTION_MODE_LOCAL);
+    g_assert_cmpuint(product_state_get_onboarding_seen_version(), ==, 4);
+
+    g_autofree gchar *contents = read_file_or_null(storage_path);
+    g_assert_nonnull(contents);
+    g_assert_nonnull(g_strstr_len(contents, -1, "connection_mode=local"));
+
+    clear_product_state_test_overrides();
+    remove_if_exists(storage_path);
+    remove_if_exists(legacy_path);
+    cleanup_tmp_dir(dir);
+}
+
+static void test_invalid_seen_version_falls_back_to_zero(void) {
+    g_autofree gchar *dir = make_tmp_dir();
+    g_autofree gchar *storage_path = g_build_filename(dir, "product-state.ini", NULL);
+    g_autofree gchar *legacy_path = g_build_filename(dir, "onboarding_version", NULL);
+    const gchar *bad_data = "[product]\nconnection_mode=local\nonboarding_seen_version=oops\n";
+
+    g_assert_true(g_file_set_contents(storage_path, bad_data, -1, NULL));
+    reset_product_state_for_paths(storage_path, legacy_path);
+    product_state_init();
+
+    g_assert_cmpint(product_state_get_connection_mode(), ==, PRODUCT_CONNECTION_MODE_LOCAL);
+    g_assert_cmpuint(product_state_get_onboarding_seen_version(), ==, 0);
+
+    clear_product_state_test_overrides();
+    remove_if_exists(storage_path);
+    remove_if_exists(legacy_path);
+    cleanup_tmp_dir(dir);
+}
+
+static void test_legacy_marker_migrates_to_product_state(void) {
+    g_autofree gchar *dir = make_tmp_dir();
+    g_autofree gchar *storage_path = g_build_filename(dir, "product-state.ini", NULL);
+    g_autofree gchar *legacy_path = g_build_filename(dir, "onboarding_version", NULL);
+
+    g_assert_true(g_file_set_contents(legacy_path, "3\n", -1, NULL));
+    reset_product_state_for_paths(storage_path, legacy_path);
+    product_state_init();
+
+    g_assert_cmpuint(product_state_get_onboarding_seen_version(), ==, 3);
+    g_assert_true(g_file_test(storage_path, G_FILE_TEST_EXISTS));
+
+    g_autofree gchar *contents = read_file_or_null(storage_path);
+    g_assert_nonnull(contents);
+    g_assert_nonnull(g_strstr_len(contents, -1, "onboarding_seen_version=3"));
+
+    clear_product_state_test_overrides();
+    remove_if_exists(storage_path);
+    remove_if_exists(legacy_path);
+    cleanup_tmp_dir(dir);
+}
+
+static void test_reset_onboarding_seen_version_persists_zero(void) {
+    g_autofree gchar *dir = make_tmp_dir();
+    g_autofree gchar *storage_path = g_build_filename(dir, "product-state.ini", NULL);
+    g_autofree gchar *legacy_path = g_build_filename(dir, "onboarding_version", NULL);
+
+    reset_product_state_for_paths(storage_path, legacy_path);
+    product_state_init();
+    g_assert_true(product_state_set_onboarding_seen_version(9));
+    g_assert_true(product_state_reset_onboarding_seen_version());
+
+    product_state_test_reset();
+    product_state_init();
+
+    g_assert_cmpuint(product_state_get_onboarding_seen_version(), ==, 0);
+
+    clear_product_state_test_overrides();
+    remove_if_exists(storage_path);
+    remove_if_exists(legacy_path);
+    cleanup_tmp_dir(dir);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/product_state/defaults_create_local_state", test_defaults_create_local_state);
+    g_test_add_func("/product_state/onboarding_seen_version_roundtrip", test_onboarding_seen_version_roundtrip);
+    g_test_add_func("/product_state/invalid_mode_falls_back_to_local", test_invalid_mode_falls_back_to_local);
+    g_test_add_func("/product_state/invalid_seen_version_falls_back_to_zero", test_invalid_seen_version_falls_back_to_zero);
+    g_test_add_func("/product_state/legacy_marker_migrates", test_legacy_marker_migrates_to_product_state);
+    g_test_add_func("/product_state/reset_onboarding_seen_version_persists_zero", test_reset_onboarding_seen_version_persists_zero);
+    return g_test_run();
+}


### PR DESCRIPTION
Add `product_state` and `product_coordinator` to the Linux companion to separate persisted product intent and startup / shell orchestration from the runtime readiness state machine.

Persist `connection_mode` and `onboarding_seen_version`, including migration from the legacy onboarding marker file. Move Linux startup activation, delayed onboarding
presentation, main-window routing, section routing, rerun onboarding, and onboarding completion follow-through into the coordinator.

Update `main.c`, `onboarding.c`, `app_window.c`, and `tray.c` to route through the new product-layer seams. Wire the new modules into Meson and add focused tests for product-state persistence, migration, activation idempotence, startup presentation, and shell-routing behavior.

This preserves the existing Linux tray-first behavior while establishing cleaner ownership boundaries for future product-shell work.