### PR TITLE
feat(linux): add connection mode to product layer (#98)

### DIFF
--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -44,6 +44,7 @@
 #include "ui_model_utils.h"
 #include "runtime_paths.h"
 #include "log.h"
+#include "product_state.h"
 #include "product_coordinator.h"
 
 /* ── Section metadata ── */
@@ -878,6 +879,10 @@ static void refresh_dashboard_content(void) {
 static GtkWidget *gen_status_label = NULL;
 static GtkWidget *gen_runtime_label = NULL;
 static GtkWidget *gen_service_notice_label = NULL;
+static GtkWidget *gen_connection_mode_dropdown = NULL;
+static GtkStringList *gen_connection_mode_dropdown_model = NULL;
+static GtkWidget *gen_connection_mode_detail_label = NULL;
+static gboolean gen_connection_mode_programmatic_change = FALSE;
 
 /* General widget refs — gateway info */
 static GtkWidget *gen_endpoint_label = NULL;
@@ -922,6 +927,65 @@ static void on_gen_quit(GtkButton *b, gpointer d) {
     (void)b; (void)d;
     GApplication *app = g_application_get_default();
     if (app) g_application_quit(app);
+}
+
+static guint gen_connection_mode_selection_for_mode(ProductConnectionMode mode) {
+    return mode == PRODUCT_CONNECTION_MODE_REMOTE ? 1u : 0u;
+}
+
+static ProductConnectionMode gen_connection_mode_for_selection(guint selected) {
+    return selected == 1u ? PRODUCT_CONNECTION_MODE_REMOTE : PRODUCT_CONNECTION_MODE_LOCAL;
+}
+
+static const gchar* gen_connection_mode_detail_text(ProductConnectionMode stored_mode,
+                                                    ProductConnectionMode effective_mode) {
+    if (effective_mode == PRODUCT_CONNECTION_MODE_REMOTE) {
+        return "Remote mode is saved, but Linux remote connection flow is not implemented yet. Open General for guidance or switch back to Local to use onboarding on this machine.";
+    }
+
+    if (stored_mode == PRODUCT_CONNECTION_MODE_UNSPECIFIED) {
+        return "Local is currently the effective default on Linux. Choose a mode here to save it explicitly.";
+    }
+
+    return "Use this Linux machine's local gateway and onboarding flow.";
+}
+
+static void refresh_general_connection_mode_controls(void) {
+    ProductConnectionMode stored_mode = product_state_get_connection_mode();
+    ProductConnectionMode effective_mode = product_state_get_effective_connection_mode();
+    guint selected = gen_connection_mode_selection_for_mode(effective_mode);
+
+    if (gen_connection_mode_dropdown && GTK_IS_DROP_DOWN(gen_connection_mode_dropdown)) {
+        gen_connection_mode_programmatic_change = TRUE;
+        gtk_drop_down_set_selected(GTK_DROP_DOWN(gen_connection_mode_dropdown), selected);
+        gen_connection_mode_programmatic_change = FALSE;
+    }
+
+    if (gen_connection_mode_detail_label) {
+        gtk_label_set_text(GTK_LABEL(gen_connection_mode_detail_label),
+                           gen_connection_mode_detail_text(stored_mode, effective_mode));
+    }
+}
+
+static void on_gen_connection_mode_selected_notify(GObject *object,
+                                                   GParamSpec *pspec,
+                                                   gpointer user_data) {
+    (void)pspec;
+    (void)user_data;
+
+    if (gen_connection_mode_programmatic_change || !GTK_IS_DROP_DOWN(object)) {
+        return;
+    }
+
+    guint selected = gtk_drop_down_get_selected(GTK_DROP_DOWN(object));
+    if (selected == GTK_INVALID_LIST_POSITION) {
+        refresh_general_connection_mode_controls();
+        return;
+    }
+
+    if (!product_coordinator_request_set_connection_mode(gen_connection_mode_for_selection(selected))) {
+        refresh_general_connection_mode_controls();
+    }
 }
 
 static void general_resolve_effective_paths(RuntimeEffectivePaths *out) {
@@ -1015,6 +1079,47 @@ static GtkWidget* build_general_section(void) {
     gtk_label_set_wrap(GTK_LABEL(gen_service_notice_label), TRUE);
     gtk_widget_set_visible(gen_service_notice_label, FALSE);
     gtk_box_append(GTK_BOX(page), gen_service_notice_label);
+
+    GtkWidget *connection_heading = gtk_label_new("Connection");
+    gtk_widget_add_css_class(connection_heading, "heading");
+    gtk_label_set_xalign(GTK_LABEL(connection_heading), 0.0);
+    gtk_widget_set_margin_top(connection_heading, 12);
+    gtk_box_append(GTK_BOX(page), connection_heading);
+
+    GtkWidget *connection_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_margin_top(connection_row, 4);
+
+    GtkWidget *connection_mode_label = gtk_label_new("Connection Mode");
+    gtk_widget_add_css_class(connection_mode_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(connection_mode_label), 0.0);
+    gtk_widget_set_size_request(connection_mode_label, 120, -1);
+    gtk_box_append(GTK_BOX(connection_row), connection_mode_label);
+
+    gen_connection_mode_dropdown = gtk_drop_down_new(NULL, NULL);
+    gtk_widget_set_hexpand(gen_connection_mode_dropdown, TRUE);
+    gtk_box_append(GTK_BOX(connection_row), gen_connection_mode_dropdown);
+    gtk_box_append(GTK_BOX(page), connection_row);
+
+    GtkStringList *connection_mode_model = gtk_string_list_new(NULL);
+    gtk_string_list_append(connection_mode_model, "Local (this machine)");
+    gtk_string_list_append(connection_mode_model, "Remote (coming soon)");
+    ui_dropdown_replace_model(gen_connection_mode_dropdown,
+                              (gpointer *)&gen_connection_mode_dropdown_model,
+                              G_LIST_MODEL(connection_mode_model),
+                              0,
+                              TRUE);
+    g_signal_connect(gen_connection_mode_dropdown,
+                     "notify::selected",
+                     G_CALLBACK(on_gen_connection_mode_selected_notify),
+                     NULL);
+
+    gen_connection_mode_detail_label = gtk_label_new("");
+    gtk_widget_add_css_class(gen_connection_mode_detail_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(gen_connection_mode_detail_label), 0.0);
+    gtk_label_set_wrap(GTK_LABEL(gen_connection_mode_detail_label), TRUE);
+    gtk_widget_set_margin_top(gen_connection_mode_detail_label, 2);
+    gtk_box_append(GTK_BOX(page), gen_connection_mode_detail_label);
+    refresh_general_connection_mode_controls();
 
     /* ── Product actions ── */
     GtkWidget *sep1 = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
@@ -1208,6 +1313,8 @@ static void refresh_general_content(void) {
 
     runtime_path_status_clear(&general_paths);
     runtime_effective_paths_clear(&effective_paths);
+
+    refresh_general_connection_mode_controls();
 
     /* Button sensitivity */
     gtk_widget_set_sensitive(gen_btn_start, dm.can_start);
@@ -2609,6 +2716,10 @@ static void on_window_destroy(GtkWindow *window, gpointer user_data) {
     gen_status_label = NULL;
     gen_runtime_label = NULL;
     gen_service_notice_label = NULL;
+    ui_dropdown_detach_model(gen_connection_mode_dropdown, (gpointer *)&gen_connection_mode_dropdown_model);
+    gen_connection_mode_dropdown = NULL;
+    gen_connection_mode_detail_label = NULL;
+    gen_connection_mode_programmatic_change = FALSE;
     gen_endpoint_label = NULL;
     gen_version_label = NULL;
     gen_auth_mode_label = NULL;

--- a/apps/linux/src/product_coordinator.c
+++ b/apps/linux/src/product_coordinator.c
@@ -24,6 +24,11 @@ typedef struct {
 
 static ProductCoordinatorState g_coordinator = {0};
 
+static void product_coordinator_route_remote_guidance(void) {
+    app_window_show();
+    app_window_navigate_to(SECTION_GENERAL);
+}
+
 static void product_coordinator_boot_runtime_lanes(void) {
     state_init();
     product_state_init();
@@ -37,7 +42,12 @@ static void product_coordinator_boot_runtime_lanes(void) {
 
 static ProductStartupPresentationAction product_coordinator_decide_startup_presentation(
     AppState runtime_state,
+    ProductConnectionMode effective_mode,
     guint onboarding_seen_version) {
+    if (effective_mode == PRODUCT_CONNECTION_MODE_REMOTE) {
+        return PRODUCT_STARTUP_PRESENTATION_NOOP;
+    }
+
     OnboardingRoute route = onboarding_routing_decide(runtime_state,
                                                       (int)onboarding_seen_version,
                                                       ONBOARDING_CURRENT_VERSION);
@@ -68,6 +78,7 @@ void product_coordinator_activate(void) {
 void product_coordinator_reconcile_startup_presentation(void) {
     ProductStartupPresentationAction action = product_coordinator_decide_startup_presentation(
         state_get_current(),
+        product_state_get_effective_connection_mode(),
         product_state_get_onboarding_seen_version());
 
     if (action == PRODUCT_STARTUP_PRESENTATION_SHOW_ONBOARDING) {
@@ -76,21 +87,55 @@ void product_coordinator_reconcile_startup_presentation(void) {
 }
 
 void product_coordinator_request_show_main(void) {
+    if (product_state_get_effective_connection_mode() == PRODUCT_CONNECTION_MODE_REMOTE) {
+        product_coordinator_route_remote_guidance();
+        return;
+    }
+
     app_window_show();
 }
 
 void product_coordinator_request_show_section(AppSection section) {
+    if (product_state_get_effective_connection_mode() == PRODUCT_CONNECTION_MODE_REMOTE) {
+        product_coordinator_route_remote_guidance();
+        return;
+    }
+
     app_window_show();
     app_window_navigate_to(section);
 }
 
 void product_coordinator_request_rerun_onboarding(void) {
+    if (product_state_get_effective_connection_mode() == PRODUCT_CONNECTION_MODE_REMOTE) {
+        product_coordinator_route_remote_guidance();
+        return;
+    }
+
     onboarding_show();
 }
 
 void product_coordinator_notify_onboarding_completed(void) {
     (void)product_state_set_onboarding_seen_version(ONBOARDING_CURRENT_VERSION);
     app_window_show();
+}
+
+gboolean product_coordinator_request_set_connection_mode(ProductConnectionMode mode) {
+    if (!product_state_set_connection_mode(mode)) {
+        return FALSE;
+    }
+
+    if (product_state_get_effective_connection_mode() == PRODUCT_CONNECTION_MODE_REMOTE) {
+        product_coordinator_route_remote_guidance();
+        return TRUE;
+    }
+
+    app_window_refresh_snapshot();
+
+    if (product_state_get_onboarding_seen_version() < ONBOARDING_CURRENT_VERSION) {
+        onboarding_show();
+    }
+
+    return TRUE;
 }
 
 void product_coordinator_test_reset(void) {

--- a/apps/linux/src/product_coordinator.h
+++ b/apps/linux/src/product_coordinator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "app_window.h"
+#include "product_state.h"
 
 void product_coordinator_activate(void);
 void product_coordinator_reconcile_startup_presentation(void);
@@ -8,5 +9,6 @@ void product_coordinator_request_show_main(void);
 void product_coordinator_request_show_section(AppSection section);
 void product_coordinator_request_rerun_onboarding(void);
 void product_coordinator_notify_onboarding_completed(void);
+gboolean product_coordinator_request_set_connection_mode(ProductConnectionMode mode);
 
 void product_coordinator_test_reset(void);

--- a/apps/linux/src/product_state.c
+++ b/apps/linux/src/product_state.c
@@ -34,7 +34,19 @@ static void product_state_apply_defaults(ProductStateSnapshot *state) {
 }
 
 static ProductConnectionMode product_state_normalize_connection_mode(ProductConnectionMode mode) {
-    if (mode == PRODUCT_CONNECTION_MODE_LOCAL) return PRODUCT_CONNECTION_MODE_LOCAL;
+    switch (mode) {
+    case PRODUCT_CONNECTION_MODE_UNSPECIFIED:
+    case PRODUCT_CONNECTION_MODE_LOCAL:
+    case PRODUCT_CONNECTION_MODE_REMOTE:
+        return mode;
+    default:
+        return PRODUCT_CONNECTION_MODE_UNSPECIFIED;
+    }
+}
+
+static ProductConnectionMode product_state_effective_connection_mode(ProductConnectionMode mode) {
+    ProductConnectionMode normalized = product_state_normalize_connection_mode(mode);
+    if (normalized == PRODUCT_CONNECTION_MODE_REMOTE) return PRODUCT_CONNECTION_MODE_REMOTE;
     return PRODUCT_CONNECTION_MODE_LOCAL;
 }
 
@@ -44,12 +56,21 @@ static void product_state_normalize(ProductStateSnapshot *state) {
 }
 
 static const gchar* product_connection_mode_to_string(ProductConnectionMode mode) {
-    if (product_state_normalize_connection_mode(mode) == PRODUCT_CONNECTION_MODE_LOCAL) return "local";
-    return "local";
+    switch (product_state_normalize_connection_mode(mode)) {
+    case PRODUCT_CONNECTION_MODE_REMOTE:
+        return "remote";
+    case PRODUCT_CONNECTION_MODE_LOCAL:
+        return "local";
+    case PRODUCT_CONNECTION_MODE_UNSPECIFIED:
+    default:
+        return "unspecified";
+    }
 }
 
 static ProductConnectionMode product_connection_mode_from_string(const gchar *value) {
+    if (g_strcmp0(value, "unspecified") == 0) return PRODUCT_CONNECTION_MODE_UNSPECIFIED;
     if (g_strcmp0(value, "local") == 0) return PRODUCT_CONNECTION_MODE_LOCAL;
+    if (g_strcmp0(value, "remote") == 0) return PRODUCT_CONNECTION_MODE_REMOTE;
     return PRODUCT_CONNECTION_MODE_UNSPECIFIED;
 }
 
@@ -132,11 +153,11 @@ static gboolean product_state_load_from_disk(ProductStateSnapshot *state,
                                                                      PRODUCT_STATE_KEY_CONNECTION_MODE,
                                                                      NULL);
                 ProductConnectionMode parsed_mode = product_connection_mode_from_string(mode_value);
-                if (parsed_mode == PRODUCT_CONNECTION_MODE_UNSPECIFIED) {
+                if (g_strcmp0(mode_value, "unspecified") != 0 &&
+                    parsed_mode == PRODUCT_CONNECTION_MODE_UNSPECIFIED) {
                     needs_flush = TRUE;
-                } else {
-                    state->connection_mode = parsed_mode;
                 }
+                state->connection_mode = parsed_mode;
             } else {
                 needs_flush = TRUE;
             }
@@ -202,6 +223,11 @@ void product_state_get_snapshot(ProductStateSnapshot *out) {
 ProductConnectionMode product_state_get_connection_mode(void) {
     product_state_ensure_initialized();
     return g_store.snapshot.connection_mode;
+}
+
+ProductConnectionMode product_state_get_effective_connection_mode(void) {
+    product_state_ensure_initialized();
+    return product_state_effective_connection_mode(g_store.snapshot.connection_mode);
 }
 
 gboolean product_state_set_connection_mode(ProductConnectionMode mode) {

--- a/apps/linux/src/product_state.h
+++ b/apps/linux/src/product_state.h
@@ -5,6 +5,7 @@
 typedef enum {
     PRODUCT_CONNECTION_MODE_UNSPECIFIED = 0,
     PRODUCT_CONNECTION_MODE_LOCAL = 1,
+    PRODUCT_CONNECTION_MODE_REMOTE = 2,
 } ProductConnectionMode;
 
 typedef struct {
@@ -15,6 +16,7 @@ typedef struct {
 void product_state_init(void);
 void product_state_get_snapshot(ProductStateSnapshot *out);
 ProductConnectionMode product_state_get_connection_mode(void);
+ProductConnectionMode product_state_get_effective_connection_mode(void);
 gboolean product_state_set_connection_mode(ProductConnectionMode mode);
 guint product_state_get_onboarding_seen_version(void);
 gboolean product_state_set_onboarding_seen_version(guint version);

--- a/apps/linux/tests/test_product_coordinator.c
+++ b/apps/linux/tests/test_product_coordinator.c
@@ -18,11 +18,15 @@ static gint stub_device_pair_prompter_init_calls = 0;
 static gint stub_onboarding_show_calls = 0;
 static gint stub_app_window_show_calls = 0;
 static gint stub_app_window_navigate_calls = 0;
+static gint stub_app_window_refresh_snapshot_calls = 0;
 static gint stub_product_state_set_seen_calls = 0;
+static gint stub_product_state_set_connection_mode_calls = 0;
+static gboolean stub_product_state_set_connection_mode_result = TRUE;
 static AppSection stub_last_navigate_section = SECTION_DASHBOARD;
 static guint stub_onboarding_seen_version = 0;
 static guint stub_last_persisted_onboarding_seen_version = 0;
 static AppState stub_current_state = STATE_NEEDS_SETUP;
+static ProductConnectionMode stub_connection_mode = PRODUCT_CONNECTION_MODE_LOCAL;
 static AppState stub_last_routing_state = STATE_ERROR;
 static gint stub_last_routing_seen_version = -1;
 static gint stub_last_routing_current_version = -1;
@@ -41,11 +45,15 @@ static void stub_reset(void) {
     stub_onboarding_show_calls = 0;
     stub_app_window_show_calls = 0;
     stub_app_window_navigate_calls = 0;
+    stub_app_window_refresh_snapshot_calls = 0;
     stub_product_state_set_seen_calls = 0;
+    stub_product_state_set_connection_mode_calls = 0;
+    stub_product_state_set_connection_mode_result = TRUE;
     stub_last_navigate_section = SECTION_DASHBOARD;
     stub_onboarding_seen_version = 0;
     stub_last_persisted_onboarding_seen_version = 0;
     stub_current_state = STATE_NEEDS_SETUP;
+    stub_connection_mode = PRODUCT_CONNECTION_MODE_LOCAL;
     stub_last_routing_state = STATE_ERROR;
     stub_last_routing_seen_version = -1;
     stub_last_routing_current_version = -1;
@@ -98,8 +106,31 @@ void app_window_navigate_to(AppSection section) {
     stub_last_navigate_section = section;
 }
 
+void app_window_refresh_snapshot(void) {
+    stub_app_window_refresh_snapshot_calls++;
+}
+
 void product_state_init(void) {
     stub_product_state_init_calls++;
+}
+
+ProductConnectionMode product_state_get_connection_mode(void) {
+    return stub_connection_mode;
+}
+
+ProductConnectionMode product_state_get_effective_connection_mode(void) {
+    return stub_connection_mode == PRODUCT_CONNECTION_MODE_REMOTE
+        ? PRODUCT_CONNECTION_MODE_REMOTE
+        : PRODUCT_CONNECTION_MODE_LOCAL;
+}
+
+gboolean product_state_set_connection_mode(ProductConnectionMode mode) {
+    stub_product_state_set_connection_mode_calls++;
+    if (!stub_product_state_set_connection_mode_result) {
+        return FALSE;
+    }
+    stub_connection_mode = mode;
+    return TRUE;
 }
 
 guint product_state_get_onboarding_seen_version(void) {
@@ -144,6 +175,7 @@ static void test_activate_boots_runtime_lanes_once(void) {
 static void test_reconcile_startup_presentation_shows_onboarding(void) {
     stub_reset();
     stub_current_state = STATE_NEEDS_ONBOARDING;
+    stub_connection_mode = PRODUCT_CONNECTION_MODE_LOCAL;
     stub_onboarding_seen_version = 0;
     stub_route = ONBOARDING_SHOW_FULL;
 
@@ -160,6 +192,7 @@ static void test_reconcile_startup_presentation_shows_onboarding(void) {
 static void test_reconcile_startup_presentation_skips_when_completed(void) {
     stub_reset();
     stub_current_state = STATE_RUNNING;
+    stub_connection_mode = PRODUCT_CONNECTION_MODE_LOCAL;
     stub_onboarding_seen_version = ONBOARDING_CURRENT_VERSION;
     stub_route = ONBOARDING_SKIP;
 
@@ -168,6 +201,23 @@ static void test_reconcile_startup_presentation_skips_when_completed(void) {
     g_assert_cmpint(stub_onboarding_show_calls, ==, 0);
     g_assert_cmpint(stub_last_routing_state, ==, STATE_RUNNING);
     g_assert_cmpint(stub_last_routing_seen_version, ==, ONBOARDING_CURRENT_VERSION);
+
+    stub_reset();
+}
+
+static void test_reconcile_startup_presentation_remote_incomplete_is_noop(void) {
+    stub_reset();
+    stub_current_state = STATE_NEEDS_ONBOARDING;
+    stub_connection_mode = PRODUCT_CONNECTION_MODE_REMOTE;
+    stub_onboarding_seen_version = 0;
+    stub_route = ONBOARDING_SHOW_FULL;
+
+    product_coordinator_reconcile_startup_presentation();
+
+    g_assert_cmpint(stub_onboarding_show_calls, ==, 0);
+    g_assert_cmpint(stub_app_window_show_calls, ==, 0);
+    g_assert_cmpint(stub_app_window_navigate_calls, ==, 0);
+    g_assert_cmpint(stub_last_routing_state, ==, STATE_ERROR);
 
     stub_reset();
 }
@@ -197,11 +247,26 @@ static void test_request_show_section_routes_to_main_window(void) {
 
 static void test_request_rerun_onboarding_shows_onboarding(void) {
     stub_reset();
+    stub_connection_mode = PRODUCT_CONNECTION_MODE_LOCAL;
 
     product_coordinator_request_rerun_onboarding();
 
     g_assert_cmpint(stub_onboarding_show_calls, ==, 1);
     g_assert_cmpint(stub_app_window_show_calls, ==, 0);
+
+    stub_reset();
+}
+
+static void test_request_rerun_onboarding_remote_routes_to_general(void) {
+    stub_reset();
+    stub_connection_mode = PRODUCT_CONNECTION_MODE_REMOTE;
+
+    product_coordinator_request_rerun_onboarding();
+
+    g_assert_cmpint(stub_onboarding_show_calls, ==, 0);
+    g_assert_cmpint(stub_app_window_show_calls, ==, 1);
+    g_assert_cmpint(stub_app_window_navigate_calls, ==, 1);
+    g_assert_cmpint(stub_last_navigate_section, ==, SECTION_GENERAL);
 
     stub_reset();
 }
@@ -218,14 +283,68 @@ static void test_notify_onboarding_completed_persists_and_opens_main(void) {
     stub_reset();
 }
 
+static void test_request_set_connection_mode_remote_routes_to_general(void) {
+    stub_reset();
+    stub_connection_mode = PRODUCT_CONNECTION_MODE_LOCAL;
+
+    g_assert_true(product_coordinator_request_set_connection_mode(PRODUCT_CONNECTION_MODE_REMOTE));
+
+    g_assert_cmpint(stub_product_state_set_connection_mode_calls, ==, 1);
+    g_assert_cmpint(stub_connection_mode, ==, PRODUCT_CONNECTION_MODE_REMOTE);
+    g_assert_cmpint(stub_onboarding_show_calls, ==, 0);
+    g_assert_cmpint(stub_app_window_show_calls, ==, 1);
+    g_assert_cmpint(stub_app_window_navigate_calls, ==, 1);
+    g_assert_cmpint(stub_last_navigate_section, ==, SECTION_GENERAL);
+    g_assert_cmpint(stub_app_window_refresh_snapshot_calls, ==, 0);
+
+    stub_reset();
+}
+
+static void test_request_set_connection_mode_local_incomplete_shows_onboarding(void) {
+    stub_reset();
+    stub_connection_mode = PRODUCT_CONNECTION_MODE_REMOTE;
+    stub_onboarding_seen_version = 0;
+
+    g_assert_true(product_coordinator_request_set_connection_mode(PRODUCT_CONNECTION_MODE_LOCAL));
+
+    g_assert_cmpint(stub_product_state_set_connection_mode_calls, ==, 1);
+    g_assert_cmpint(stub_connection_mode, ==, PRODUCT_CONNECTION_MODE_LOCAL);
+    g_assert_cmpint(stub_app_window_refresh_snapshot_calls, ==, 1);
+    g_assert_cmpint(stub_onboarding_show_calls, ==, 1);
+    g_assert_cmpint(stub_app_window_navigate_calls, ==, 0);
+
+    stub_reset();
+}
+
+static void test_request_set_connection_mode_failure_restores_noop(void) {
+    stub_reset();
+    stub_product_state_set_connection_mode_result = FALSE;
+
+    g_assert_false(product_coordinator_request_set_connection_mode(PRODUCT_CONNECTION_MODE_REMOTE));
+
+    g_assert_cmpint(stub_product_state_set_connection_mode_calls, ==, 1);
+    g_assert_cmpint(stub_connection_mode, ==, PRODUCT_CONNECTION_MODE_LOCAL);
+    g_assert_cmpint(stub_onboarding_show_calls, ==, 0);
+    g_assert_cmpint(stub_app_window_show_calls, ==, 0);
+    g_assert_cmpint(stub_app_window_navigate_calls, ==, 0);
+    g_assert_cmpint(stub_app_window_refresh_snapshot_calls, ==, 0);
+
+    stub_reset();
+}
+
 int main(int argc, char **argv) {
     g_test_init(&argc, &argv, NULL);
     g_test_add_func("/product_coordinator/activate_boots_runtime_lanes_once", test_activate_boots_runtime_lanes_once);
     g_test_add_func("/product_coordinator/reconcile_startup_presentation_shows_onboarding", test_reconcile_startup_presentation_shows_onboarding);
     g_test_add_func("/product_coordinator/reconcile_startup_presentation_skips_when_completed", test_reconcile_startup_presentation_skips_when_completed);
+    g_test_add_func("/product_coordinator/reconcile_startup_presentation_remote_incomplete_is_noop", test_reconcile_startup_presentation_remote_incomplete_is_noop);
     g_test_add_func("/product_coordinator/request_show_main_presents_main_window", test_request_show_main_presents_main_window);
     g_test_add_func("/product_coordinator/request_show_section_routes_to_main_window", test_request_show_section_routes_to_main_window);
     g_test_add_func("/product_coordinator/request_rerun_onboarding_shows_onboarding", test_request_rerun_onboarding_shows_onboarding);
+    g_test_add_func("/product_coordinator/request_rerun_onboarding_remote_routes_to_general", test_request_rerun_onboarding_remote_routes_to_general);
     g_test_add_func("/product_coordinator/notify_onboarding_completed_persists_and_opens_main", test_notify_onboarding_completed_persists_and_opens_main);
+    g_test_add_func("/product_coordinator/request_set_connection_mode_remote_routes_to_general", test_request_set_connection_mode_remote_routes_to_general);
+    g_test_add_func("/product_coordinator/request_set_connection_mode_local_incomplete_shows_onboarding", test_request_set_connection_mode_local_incomplete_shows_onboarding);
+    g_test_add_func("/product_coordinator/request_set_connection_mode_failure_restores_noop", test_request_set_connection_mode_failure_restores_noop);
     return g_test_run();
 }

--- a/apps/linux/tests/test_product_state.c
+++ b/apps/linux/tests/test_product_state.c
@@ -82,6 +82,7 @@ static void test_onboarding_seen_version_roundtrip(void) {
 
     g_assert_cmpuint(product_state_get_onboarding_seen_version(), ==, 7);
     g_assert_cmpint(product_state_get_connection_mode(), ==, PRODUCT_CONNECTION_MODE_LOCAL);
+    g_assert_cmpint(product_state_get_effective_connection_mode(), ==, PRODUCT_CONNECTION_MODE_LOCAL);
 
     clear_product_state_test_overrides();
     remove_if_exists(storage_path);
@@ -89,7 +90,57 @@ static void test_onboarding_seen_version_roundtrip(void) {
     cleanup_tmp_dir(dir);
 }
 
-static void test_invalid_mode_falls_back_to_local(void) {
+static void test_remote_mode_roundtrip(void) {
+    g_autofree gchar *dir = make_tmp_dir();
+    g_autofree gchar *storage_path = g_build_filename(dir, "product-state.ini", NULL);
+    g_autofree gchar *legacy_path = g_build_filename(dir, "onboarding_version", NULL);
+
+    reset_product_state_for_paths(storage_path, legacy_path);
+    product_state_init();
+    g_assert_true(product_state_set_connection_mode(PRODUCT_CONNECTION_MODE_REMOTE));
+
+    product_state_test_reset();
+    product_state_init();
+
+    g_assert_cmpint(product_state_get_connection_mode(), ==, PRODUCT_CONNECTION_MODE_REMOTE);
+    g_assert_cmpint(product_state_get_effective_connection_mode(), ==, PRODUCT_CONNECTION_MODE_REMOTE);
+
+    g_autofree gchar *contents = read_file_or_null(storage_path);
+    g_assert_nonnull(contents);
+    g_assert_nonnull(g_strstr_len(contents, -1, "connection_mode=remote"));
+
+    clear_product_state_test_overrides();
+    remove_if_exists(storage_path);
+    remove_if_exists(legacy_path);
+    cleanup_tmp_dir(dir);
+}
+
+static void test_unspecified_mode_resolves_to_effective_local(void) {
+    g_autofree gchar *dir = make_tmp_dir();
+    g_autofree gchar *storage_path = g_build_filename(dir, "product-state.ini", NULL);
+    g_autofree gchar *legacy_path = g_build_filename(dir, "onboarding_version", NULL);
+
+    reset_product_state_for_paths(storage_path, legacy_path);
+    product_state_init();
+    g_assert_true(product_state_set_connection_mode(PRODUCT_CONNECTION_MODE_UNSPECIFIED));
+
+    product_state_test_reset();
+    product_state_init();
+
+    g_assert_cmpint(product_state_get_connection_mode(), ==, PRODUCT_CONNECTION_MODE_UNSPECIFIED);
+    g_assert_cmpint(product_state_get_effective_connection_mode(), ==, PRODUCT_CONNECTION_MODE_LOCAL);
+
+    g_autofree gchar *contents = read_file_or_null(storage_path);
+    g_assert_nonnull(contents);
+    g_assert_nonnull(g_strstr_len(contents, -1, "connection_mode=unspecified"));
+
+    clear_product_state_test_overrides();
+    remove_if_exists(storage_path);
+    remove_if_exists(legacy_path);
+    cleanup_tmp_dir(dir);
+}
+
+static void test_invalid_mode_falls_back_to_unspecified_effective_local(void) {
     g_autofree gchar *dir = make_tmp_dir();
     g_autofree gchar *storage_path = g_build_filename(dir, "product-state.ini", NULL);
     g_autofree gchar *legacy_path = g_build_filename(dir, "onboarding_version", NULL);
@@ -99,12 +150,13 @@ static void test_invalid_mode_falls_back_to_local(void) {
     reset_product_state_for_paths(storage_path, legacy_path);
     product_state_init();
 
-    g_assert_cmpint(product_state_get_connection_mode(), ==, PRODUCT_CONNECTION_MODE_LOCAL);
+    g_assert_cmpint(product_state_get_connection_mode(), ==, PRODUCT_CONNECTION_MODE_UNSPECIFIED);
+    g_assert_cmpint(product_state_get_effective_connection_mode(), ==, PRODUCT_CONNECTION_MODE_LOCAL);
     g_assert_cmpuint(product_state_get_onboarding_seen_version(), ==, 4);
 
     g_autofree gchar *contents = read_file_or_null(storage_path);
     g_assert_nonnull(contents);
-    g_assert_nonnull(g_strstr_len(contents, -1, "connection_mode=local"));
+    g_assert_nonnull(g_strstr_len(contents, -1, "connection_mode=unspecified"));
 
     clear_product_state_test_overrides();
     remove_if_exists(storage_path);
@@ -145,6 +197,7 @@ static void test_legacy_marker_migrates_to_product_state(void) {
 
     g_autofree gchar *contents = read_file_or_null(storage_path);
     g_assert_nonnull(contents);
+    g_assert_nonnull(g_strstr_len(contents, -1, "connection_mode=local"));
     g_assert_nonnull(g_strstr_len(contents, -1, "onboarding_seen_version=3"));
 
     clear_product_state_test_overrides();
@@ -178,7 +231,9 @@ int main(int argc, char **argv) {
     g_test_init(&argc, &argv, NULL);
     g_test_add_func("/product_state/defaults_create_local_state", test_defaults_create_local_state);
     g_test_add_func("/product_state/onboarding_seen_version_roundtrip", test_onboarding_seen_version_roundtrip);
-    g_test_add_func("/product_state/invalid_mode_falls_back_to_local", test_invalid_mode_falls_back_to_local);
+    g_test_add_func("/product_state/remote_mode_roundtrip", test_remote_mode_roundtrip);
+    g_test_add_func("/product_state/unspecified_mode_resolves_to_effective_local", test_unspecified_mode_resolves_to_effective_local);
+    g_test_add_func("/product_state/invalid_mode_falls_back_to_unspecified_effective_local", test_invalid_mode_falls_back_to_unspecified_effective_local);
     g_test_add_func("/product_state/invalid_seen_version_falls_back_to_zero", test_invalid_seen_version_falls_back_to_zero);
     g_test_add_func("/product_state/legacy_marker_migrates", test_legacy_marker_migrates_to_product_state);
     g_test_add_func("/product_state/reset_onboarding_seen_version_persists_zero", test_reset_onboarding_seen_version_persists_zero);


### PR DESCRIPTION
Add Linux product-level connection mode support across `product_state`, `product_coordinator`, the General section, and focused tests.

Persist raw connection modes `unspecified`, `local`, and `remote`, and add effective-mode resolution so `UNSPECIFIED` behaves as local. Make the coordinator mode-aware for startup, rerun-onboarding behavior, and explicit shell routing.

Add a Connection Mode dropdown and guidance text to the General section. `REMOTE` is now selectable and persisted, but remains startup-quiet and routes explicit actions to General for guidance rather than pretending full remote runtime support already exists.

Extend `test_product_state.c` and
`test_product_coordinator.c` to cover raw/effective mode semantics, remote startup no-op behavior, remote routing, and persistence-failure safety.