### PR TITLE
linux: align shell order with macOS settings (#102)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -63,6 +63,7 @@ sources = [
   'src/ui_model_utils.c',
   'src/config_setup_transform.c',
   'src/shell_sections.c',
+  'src/section_about.c',
   'src/section_dashboard.c',
   'src/section_general.c',
   'src/section_config.c',
@@ -159,6 +160,11 @@ test_shell_sections_exe = executable('test_shell_sections',
   ['tests/test_shell_sections.c', 'src/shell_sections.c'],
   dependencies : [glib_dep, gtk4_dep])
 test('shell_sections', test_shell_sections_exe)
+
+test_shell_sections_display_exe = executable('test_shell_sections_display',
+  ['tests/test_shell_sections_display.c', 'src/shell_sections.c'],
+  dependencies : [glib_dep, gtk4_dep])
+test('shell_sections_display', test_shell_sections_display_exe)
 
 test_onboarding_controller_exe = executable('test_onboarding_controller',
   ['tests/test_onboarding_controller.c', 'src/onboarding.c', 'src/test_seams.c'],

--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -74,7 +74,6 @@ static const SectionController *section_controllers[SECTION_COUNT] = {0};
 /* ── Forward declarations ── */
 
 static GtkWidget* build_placeholder_section(AppSection section);
-static GtkWidget* build_about_section(void);
 static void refresh_shell_status_footer(void);
 static void ensure_app_css_loaded(void);
 static void destroy_all_section_controllers(void);
@@ -136,6 +135,22 @@ static GtkWidget* build_sidebar_row(AppSection section) {
     return box;
 }
 
+static GtkWidget* build_sidebar_separator_row(void) {
+    GtkWidget *separator = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
+    gtk_widget_set_margin_start(separator, 12);
+    gtk_widget_set_margin_end(separator, 12);
+    gtk_widget_set_margin_top(separator, 6);
+    gtk_widget_set_margin_bottom(separator, 6);
+
+    GtkWidget *row = gtk_list_box_row_new();
+    gtk_list_box_row_set_selectable(GTK_LIST_BOX_ROW(row), FALSE);
+    gtk_list_box_row_set_activatable(GTK_LIST_BOX_ROW(row), FALSE);
+    gtk_widget_set_focusable(row, FALSE);
+    gtk_list_box_row_set_child(GTK_LIST_BOX_ROW(row), separator);
+
+    return row;
+}
+
 static GtkWidget* build_sidebar(void) {
     GtkWidget *sidebar_shell = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
@@ -149,10 +164,25 @@ static GtkWidget* build_sidebar(void) {
     gtk_list_box_set_selection_mode(GTK_LIST_BOX(sidebar_list), GTK_SELECTION_SINGLE);
     gtk_widget_add_css_class(sidebar_list, "navigation-sidebar");
 
-    for (int i = 0; i < SECTION_COUNT; i++) {
-        if (!section_is_embedded_in_main_window((AppSection)i)) continue;
-        GtkWidget *row_content = build_sidebar_row((AppSection)i);
+    ShellSectionGroup previous_group = SHELL_SECTION_GROUP_PARITY;
+    gboolean have_previous_group = FALSE;
+    for (gsize i = 0; i < shell_sections_display_count(); i++) {
+        const ShellSectionDisplayEntry *entry = shell_sections_display_at(i);
+        if (!entry) continue;
+
+        AppSection section = entry->section;
+        if (!section_is_embedded_in_main_window(section)) continue;
+        if (section == SECTION_DEBUG && !shell_sections_debug_pane_enabled()) continue;
+
+        if (have_previous_group && previous_group != entry->group) {
+            GtkWidget *separator_row = build_sidebar_separator_row();
+            gtk_list_box_append(GTK_LIST_BOX(sidebar_list), separator_row);
+        }
+
+        GtkWidget *row_content = build_sidebar_row(section);
         gtk_list_box_append(GTK_LIST_BOX(sidebar_list), row_content);
+        previous_group = entry->group;
+        have_previous_group = TRUE;
     }
 
     g_signal_connect(sidebar_list, "row-activated",
@@ -367,21 +397,32 @@ static GtkWidget* build_content_stack(void) {
     gtk_stack_set_transition_type(GTK_STACK(content_stack), GTK_STACK_TRANSITION_TYPE_CROSSFADE);
     gtk_stack_set_transition_duration(GTK_STACK(content_stack), 150);
 
-    for (int i = 0; i < SECTION_COUNT; i++) {
-        section_controllers[i] = shell_sections_controller((AppSection)i);
+    for (gsize i = 0; i < shell_sections_display_count(); i++) {
+        const ShellSectionDisplayEntry *entry = shell_sections_display_at(i);
+        if (!entry) continue;
+
+        AppSection section = entry->section;
+        if (!section_is_embedded_in_main_window(section)) continue;
+        if (section == SECTION_DEBUG && !shell_sections_debug_pane_enabled()) continue;
+
+        section_controllers[section] = shell_sections_controller(section);
     }
 
-    for (int i = 0; i < SECTION_COUNT; i++) {
-        if (!section_is_embedded_in_main_window((AppSection)i)) continue;
+    for (gsize i = 0; i < shell_sections_display_count(); i++) {
+        const ShellSectionDisplayEntry *entry = shell_sections_display_at(i);
+        if (!entry) continue;
+
+        AppSection section = entry->section;
+        if (!section_is_embedded_in_main_window(section)) continue;
+        if (section == SECTION_DEBUG && !shell_sections_debug_pane_enabled()) continue;
+
         GtkWidget *page;
-        if (section_controllers[i]) {
-            page = section_controllers[i]->build();
-        } else if (i == SECTION_ABOUT) {
-            page = build_about_section();
+        if (section_controllers[section]) {
+            page = section_controllers[section]->build();
         } else {
-            page = build_placeholder_section((AppSection)i);
+            page = build_placeholder_section(section);
         }
-        gtk_stack_add_named(GTK_STACK(content_stack), page, shell_sections_meta((AppSection)i)->id);
+        gtk_stack_add_named(GTK_STACK(content_stack), page, shell_sections_meta(section)->id);
     }
 
     return content_stack;
@@ -448,58 +489,6 @@ static GtkWidget* build_placeholder_section(AppSection section) {
     gtk_box_append(GTK_BOX(page), subtitle);
 
     return page;
-}
-
-/* ══════════════════════════════════════════════════════════════════
- * About section
- * ══════════════════════════════════════════════════════════════════ */
-
-static GtkWidget* build_about_section(void) {
-    GtkWidget *scrolled = gtk_scrolled_window_new();
-    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
-                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
-
-    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
-    gtk_widget_set_margin_start(page, 24);
-    gtk_widget_set_margin_end(page, 24);
-    gtk_widget_set_margin_top(page, 40);
-    gtk_widget_set_margin_bottom(page, 24);
-    gtk_widget_set_halign(page, GTK_ALIGN_CENTER);
-
-    GtkWidget *title = gtk_label_new("OpenClaw");
-    gtk_widget_add_css_class(title, "title-1");
-    gtk_box_append(GTK_BOX(page), title);
-
-    GtkWidget *subtitle = gtk_label_new("Linux Companion App");
-    gtk_widget_add_css_class(subtitle, "title-3");
-    gtk_box_append(GTK_BOX(page), subtitle);
-
-    HealthState *health = state_get_health();
-    const char *ver = (health && health->gateway_version) ? health->gateway_version : "Unknown";
-    g_autofree gchar *ver_text = g_strdup_printf("Gateway Version: %s", ver);
-    GtkWidget *version = gtk_label_new(ver_text);
-    gtk_widget_add_css_class(version, "dim-label");
-    gtk_widget_set_margin_top(version, 16);
-    gtk_box_append(GTK_BOX(page), version);
-
-    GtkWidget *docs_link = gtk_label_new(NULL);
-    gtk_label_set_markup(GTK_LABEL(docs_link),
-        "<a href=\"https://docs.openclaw.ai\">Documentation</a>");
-    gtk_widget_set_margin_top(docs_link, 12);
-    gtk_box_append(GTK_BOX(page), docs_link);
-
-    GtkWidget *gh_link = gtk_label_new(NULL);
-    gtk_label_set_markup(GTK_LABEL(gh_link),
-        "<a href=\"https://github.com/openclaw/openclaw\">GitHub</a>");
-    gtk_box_append(GTK_BOX(page), gh_link);
-
-    GtkWidget *copyright = gtk_label_new("Copyright \u00A9 2025 OpenClaw Contributors");
-    gtk_widget_add_css_class(copyright, "dim-label");
-    gtk_widget_set_margin_top(copyright, 24);
-    gtk_box_append(GTK_BOX(page), copyright);
-
-    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
-    return scrolled;
 }
 
 /* ── Auto-refresh timer ── */
@@ -663,6 +652,7 @@ void app_window_show(void) {
 
 void app_window_navigate_to(AppSection section) {
     if (section < 0 || section >= SECTION_COUNT) return;
+    if (section == SECTION_DEBUG && !shell_sections_debug_pane_enabled()) return;
 
     /* Sections that live in their own window (Chat) must not drag the
      * main window open; route them to the dedicated surface instead. */

--- a/apps/linux/src/section_about.c
+++ b/apps/linux/src/section_about.c
@@ -1,0 +1,64 @@
+#include "section_about.h"
+
+#include <gtk/gtk.h>
+
+#include "state.h"
+
+static GtkWidget* about_build(void) {
+    GtkWidget *scrolled = gtk_scrolled_window_new();
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
+                                   GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+    gtk_widget_set_margin_start(page, 24);
+    gtk_widget_set_margin_end(page, 24);
+    gtk_widget_set_margin_top(page, 40);
+    gtk_widget_set_margin_bottom(page, 24);
+    gtk_widget_set_halign(page, GTK_ALIGN_CENTER);
+
+    GtkWidget *title = gtk_label_new("OpenClaw");
+    gtk_widget_add_css_class(title, "title-1");
+    gtk_box_append(GTK_BOX(page), title);
+
+    GtkWidget *subtitle = gtk_label_new("Linux Companion App");
+    gtk_widget_add_css_class(subtitle, "title-3");
+    gtk_box_append(GTK_BOX(page), subtitle);
+
+    HealthState *health = state_get_health();
+    const char *ver = (health && health->gateway_version) ? health->gateway_version : "Unknown";
+    g_autofree gchar *ver_text = g_strdup_printf("Gateway Version: %s", ver);
+    GtkWidget *version = gtk_label_new(ver_text);
+    gtk_widget_add_css_class(version, "dim-label");
+    gtk_widget_set_margin_top(version, 16);
+    gtk_box_append(GTK_BOX(page), version);
+
+    GtkWidget *docs_link = gtk_label_new(NULL);
+    gtk_label_set_markup(GTK_LABEL(docs_link),
+        "<a href=\"https://docs.openclaw.ai\">Documentation</a>");
+    gtk_widget_set_margin_top(docs_link, 12);
+    gtk_box_append(GTK_BOX(page), docs_link);
+
+    GtkWidget *gh_link = gtk_label_new(NULL);
+    gtk_label_set_markup(GTK_LABEL(gh_link),
+        "<a href=\"https://github.com/openclaw/openclaw\">GitHub</a>");
+    gtk_box_append(GTK_BOX(page), gh_link);
+
+    GtkWidget *copyright = gtk_label_new("Copyright © 2025 OpenClaw Contributors");
+    gtk_widget_add_css_class(copyright, "dim-label");
+    gtk_widget_set_margin_top(copyright, 24);
+    gtk_box_append(GTK_BOX(page), copyright);
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
+    return scrolled;
+}
+
+static const SectionController about_controller = {
+    .build = about_build,
+    .refresh = NULL,
+    .destroy = NULL,
+    .invalidate = NULL,
+};
+
+const SectionController* section_about_get(void) {
+    return &about_controller;
+}

--- a/apps/linux/src/section_about.h
+++ b/apps/linux/src/section_about.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "section_controller.h"
+
+const SectionController* section_about_get(void);

--- a/apps/linux/src/shell_sections.c
+++ b/apps/linux/src/shell_sections.c
@@ -13,6 +13,7 @@
 #include "shell_sections.h"
 
 #include "section_agents.h"
+#include "section_about.h"
 #include "section_channels.h"
 #include "section_config.h"
 #include "section_control_room.h"
@@ -50,6 +51,26 @@ static const ShellSectionMeta section_meta[SECTION_COUNT] = {
     [SECTION_CRON]         = { "cron",         "Cron",         "alarm-symbolic" },
 };
 
+static const ShellSectionDisplayEntry section_display_order[] = {
+    { SECTION_DASHBOARD,    SHELL_SECTION_GROUP_PARITY },
+    { SECTION_GENERAL,      SHELL_SECTION_GROUP_PARITY },
+    { SECTION_CHANNELS,     SHELL_SECTION_GROUP_PARITY },
+    { SECTION_CONFIG,       SHELL_SECTION_GROUP_PARITY },
+    { SECTION_INSTANCES,    SHELL_SECTION_GROUP_PARITY },
+    { SECTION_SESSIONS,     SHELL_SECTION_GROUP_PARITY },
+    { SECTION_CRON,         SHELL_SECTION_GROUP_PARITY },
+    { SECTION_SKILLS,       SHELL_SECTION_GROUP_PARITY },
+    { SECTION_ABOUT,        SHELL_SECTION_GROUP_PARITY },
+    { SECTION_AGENTS,       SHELL_SECTION_GROUP_EXTRAS },
+    { SECTION_USAGE,        SHELL_SECTION_GROUP_EXTRAS },
+    { SECTION_WORKFLOWS,    SHELL_SECTION_GROUP_EXTRAS },
+    { SECTION_CONTROL_ROOM, SHELL_SECTION_GROUP_EXTRAS },
+    { SECTION_ENVIRONMENT,  SHELL_SECTION_GROUP_EXTRAS },
+    { SECTION_DIAGNOSTICS,  SHELL_SECTION_GROUP_EXTRAS },
+    { SECTION_LOGS,         SHELL_SECTION_GROUP_EXTRAS },
+    { SECTION_DEBUG,        SHELL_SECTION_GROUP_EXTRAS },
+};
+
 gboolean shell_sections_is_embedded(AppSection section) {
     if (section < 0 || section >= SECTION_COUNT) {
         return FALSE;
@@ -64,6 +85,30 @@ const ShellSectionMeta* shell_sections_meta(AppSection section) {
     }
 
     return &section_meta[section];
+}
+
+gsize shell_sections_display_count(void) {
+    return G_N_ELEMENTS(section_display_order);
+}
+
+const ShellSectionDisplayEntry* shell_sections_display_at(gsize index) {
+    if (index >= G_N_ELEMENTS(section_display_order)) {
+        return NULL;
+    }
+
+    return &section_display_order[index];
+}
+
+gboolean shell_sections_debug_pane_enabled(void) {
+    const gchar *value = g_getenv("OPENCLAW_DEBUG_PANE");
+
+    if (!value || value[0] == '\0') {
+        return FALSE;
+    }
+
+    return g_ascii_strcasecmp(value, "1") == 0
+        || g_ascii_strcasecmp(value, "true") == 0
+        || g_ascii_strcasecmp(value, "yes") == 0;
 }
 
 const SectionController* shell_sections_controller(AppSection section) {
@@ -100,8 +145,9 @@ const SectionController* shell_sections_controller(AppSection section) {
         return section_sessions_get();
     case SECTION_CRON:
         return section_cron_get();
-    case SECTION_CHAT:
     case SECTION_ABOUT:
+        return section_about_get();
+    case SECTION_CHAT:
     case SECTION_COUNT:
         return NULL;
     default:

--- a/apps/linux/src/shell_sections.h
+++ b/apps/linux/src/shell_sections.h
@@ -5,12 +5,25 @@
 #include "app_window.h"
 #include "section_controller.h"
 
+typedef enum {
+    SHELL_SECTION_GROUP_PARITY = 0,
+    SHELL_SECTION_GROUP_EXTRAS = 1,
+} ShellSectionGroup;
+
 typedef struct {
     const char *id;
     const char *title;
     const char *icon_name;
 } ShellSectionMeta;
 
+typedef struct {
+    AppSection section;
+    ShellSectionGroup group;
+} ShellSectionDisplayEntry;
+
 gboolean shell_sections_is_embedded(AppSection section);
 const ShellSectionMeta* shell_sections_meta(AppSection section);
 const SectionController* shell_sections_controller(AppSection section);
+gsize shell_sections_display_count(void);
+const ShellSectionDisplayEntry* shell_sections_display_at(gsize index);
+gboolean shell_sections_debug_pane_enabled(void);

--- a/apps/linux/tests/test_shell_sections.c
+++ b/apps/linux/tests/test_shell_sections.c
@@ -22,6 +22,7 @@ static const SectionController dummy_controller = {0};
 
 DEFINE_SECTION_GETTER(section_dashboard_get)
 DEFINE_SECTION_GETTER(section_agents_get)
+DEFINE_SECTION_GETTER(section_about_get)
 DEFINE_SECTION_GETTER(section_usage_get)
 DEFINE_SECTION_GETTER(section_general_get)
 DEFINE_SECTION_GETTER(section_config_get)
@@ -69,8 +70,8 @@ static void test_controller_lookup(void) {
     g_assert_nonnull(shell_sections_controller(SECTION_DEBUG));
     g_assert_nonnull(shell_sections_controller(SECTION_AGENTS));
     g_assert_nonnull(shell_sections_controller(SECTION_INSTANCES));
+    g_assert_nonnull(shell_sections_controller(SECTION_ABOUT));
     g_assert_null(shell_sections_controller(SECTION_CHAT));
-    g_assert_null(shell_sections_controller(SECTION_ABOUT));
 }
 
 int main(int argc, char **argv) {

--- a/apps/linux/tests/test_shell_sections_display.c
+++ b/apps/linux/tests/test_shell_sections_display.c
@@ -1,0 +1,125 @@
+#include <glib.h>
+
+#include "../src/app_window.h"
+#include "../src/section_controller.h"
+#include "../src/shell_sections.h"
+
+static const SectionController dummy_controller = {0};
+
+#define DEFINE_SECTION_GETTER(name) \
+    const SectionController* name(void) { return &dummy_controller; }
+
+DEFINE_SECTION_GETTER(section_dashboard_get)
+DEFINE_SECTION_GETTER(section_agents_get)
+DEFINE_SECTION_GETTER(section_about_get)
+DEFINE_SECTION_GETTER(section_usage_get)
+DEFINE_SECTION_GETTER(section_general_get)
+DEFINE_SECTION_GETTER(section_config_get)
+DEFINE_SECTION_GETTER(section_channels_get)
+DEFINE_SECTION_GETTER(section_skills_get)
+DEFINE_SECTION_GETTER(section_workflows_get)
+DEFINE_SECTION_GETTER(section_control_room_get)
+DEFINE_SECTION_GETTER(section_environment_get)
+DEFINE_SECTION_GETTER(section_diagnostics_get)
+DEFINE_SECTION_GETTER(section_logs_get)
+DEFINE_SECTION_GETTER(section_instances_get)
+DEFINE_SECTION_GETTER(section_debug_get)
+DEFINE_SECTION_GETTER(section_sessions_get)
+DEFINE_SECTION_GETTER(section_cron_get)
+
+static void test_display_order_matches_expected_blocks(void) {
+    const AppSection expected_order[] = {
+        SECTION_DASHBOARD,
+        SECTION_GENERAL,
+        SECTION_CHANNELS,
+        SECTION_CONFIG,
+        SECTION_INSTANCES,
+        SECTION_SESSIONS,
+        SECTION_CRON,
+        SECTION_SKILLS,
+        SECTION_ABOUT,
+        SECTION_AGENTS,
+        SECTION_USAGE,
+        SECTION_WORKFLOWS,
+        SECTION_CONTROL_ROOM,
+        SECTION_ENVIRONMENT,
+        SECTION_DIAGNOSTICS,
+        SECTION_LOGS,
+        SECTION_DEBUG,
+    };
+    g_assert_cmpuint(shell_sections_display_count(), ==, G_N_ELEMENTS(expected_order));
+
+    gboolean seen[SECTION_COUNT] = {FALSE};
+    gboolean extras_started = FALSE;
+    for (gsize i = 0; i < shell_sections_display_count(); i++) {
+        const ShellSectionDisplayEntry *entry = shell_sections_display_at(i);
+        g_assert_nonnull(entry);
+        g_assert_cmpint(entry->section, ==, expected_order[i]);
+        g_assert_true(shell_sections_is_embedded(entry->section));
+        g_assert_false(seen[entry->section]);
+        seen[entry->section] = TRUE;
+
+        if (i < 9) {
+            g_assert_cmpint(entry->group, ==, SHELL_SECTION_GROUP_PARITY);
+        } else {
+            extras_started = TRUE;
+            g_assert_cmpint(entry->group, ==, SHELL_SECTION_GROUP_EXTRAS);
+        }
+    }
+
+    g_assert_true(extras_started);
+    g_assert_false(seen[SECTION_CHAT]);
+    for (int i = 0; i < SECTION_COUNT; i++) {
+        if (i == SECTION_CHAT) continue;
+        g_assert_true(seen[i]);
+    }
+}
+
+static void test_display_order_out_of_range_returns_null(void) {
+    g_assert_null(shell_sections_display_at(shell_sections_display_count()));
+}
+
+static void test_display_entries_have_controllers(void) {
+    for (gsize i = 0; i < shell_sections_display_count(); i++) {
+        const ShellSectionDisplayEntry *entry = shell_sections_display_at(i);
+        g_assert_nonnull(entry);
+        g_assert_nonnull(shell_sections_controller(entry->section));
+    }
+}
+
+static void test_debug_pane_gate(void) {
+    g_unsetenv("OPENCLAW_DEBUG_PANE");
+    g_assert_false(shell_sections_debug_pane_enabled());
+
+    g_setenv("OPENCLAW_DEBUG_PANE", "1", TRUE);
+    g_assert_true(shell_sections_debug_pane_enabled());
+
+    g_setenv("OPENCLAW_DEBUG_PANE", "true", TRUE);
+    g_assert_true(shell_sections_debug_pane_enabled());
+
+    g_setenv("OPENCLAW_DEBUG_PANE", "YES", TRUE);
+    g_assert_true(shell_sections_debug_pane_enabled());
+
+    g_setenv("OPENCLAW_DEBUG_PANE", "0", TRUE);
+    g_assert_false(shell_sections_debug_pane_enabled());
+
+    g_setenv("OPENCLAW_DEBUG_PANE", "banana", TRUE);
+    g_assert_false(shell_sections_debug_pane_enabled());
+
+    g_unsetenv("OPENCLAW_DEBUG_PANE");
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/shell_sections_display/order_matches_expected_blocks",
+                    test_display_order_matches_expected_blocks);
+    g_test_add_func("/shell_sections_display/out_of_range_returns_null",
+                    test_display_order_out_of_range_returns_null);
+    g_test_add_func("/shell_sections_display/entries_have_controllers",
+                    test_display_entries_have_controllers);
+    g_test_add_func("/shell_sections_display/debug_pane_gate",
+                    test_debug_pane_gate);
+
+    return g_test_run();
+}


### PR DESCRIPTION
Introduce an explicit display-order layer for Linux shell sections so the main window no longer depends on raw `AppSection` enum order for sidebar and content-stack presentation.

Reorder embedded sections into a parity-first block followed by Linux-only extras, add a sidebar separator between those groups, and gate the Debug section behind
`OPENCLAW_DEBUG_PANE`.

Move About into a proper `SectionController` so it is owned by the same registry path as other embedded sections.

Add focused display-order tests covering ordering, controller presence, out-of-range access, and debug-pane env-var gating.
