### PR TITLE
linux: polish General, Config, and About (#104)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -23,9 +23,19 @@ gio_unix_dep = dependency('gio-unix-2.0')
 glib_dep = dependency('glib-2.0')
 sodium_dep = dependency('libsodium')
 
+app_version = meson.project_version()
+git_commit = run_command('git', 'rev-parse', '--short', 'HEAD', check : false).stdout().strip()
+build_timestamp = run_command('date', '-u', '+%Y-%m-%dT%H:%M:%SZ', check : false).stdout().strip()
+if git_commit == ''
+  git_commit = 'unknown'
+endif
+
 # Define LIBEXEC_PATH for the C compiler so tray.c knows where the installed helper lives
 libexec_path = get_option('prefix') / get_option('libexecdir') / meson.project_name()
 add_project_arguments('-DOPENCLAW_LIBEXEC_DIR="' + libexec_path + '"', language: 'c')
+add_project_arguments('-DOPENCLAW_APP_VERSION="' + app_version + '"', language: 'c')
+add_project_arguments('-DOPENCLAW_GIT_COMMIT="' + git_commit + '"', language: 'c')
+add_project_arguments('-DOPENCLAW_BUILD_TIMESTAMP="' + build_timestamp + '"', language: 'c')
 
 # Main app (GTK4 + Libadwaita + JSON-GLib + libsoup-3.0 + GIO)
 sources = [

--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -431,7 +431,7 @@ static GtkWidget* build_content_stack(void) {
 /* ── Sidebar row activation ── */
 
 static void refresh_active_section(AppSection section) {
-    if (section >= 0 && section < SECTION_COUNT && section_controllers[section]) {
+    if (section >= 0 && section < SECTION_COUNT && section_controllers[section] && section_controllers[section]->refresh) {
         section_controllers[section]->refresh();
     }
 }

--- a/apps/linux/src/section_about.c
+++ b/apps/linux/src/section_about.c
@@ -1,62 +1,206 @@
 #include "section_about.h"
 
-#include <gtk/gtk.h>
+#include <adwaita.h>
 
 #include "state.h"
+
+#ifndef OPENCLAW_APP_VERSION
+#define OPENCLAW_APP_VERSION "dev"
+#endif
+
+#ifndef OPENCLAW_GIT_COMMIT
+#define OPENCLAW_GIT_COMMIT "unknown"
+#endif
+
+#ifndef OPENCLAW_BUILD_TIMESTAMP
+#define OPENCLAW_BUILD_TIMESTAMP ""
+#endif
+
+static void about_open_uri(const gchar *uri) {
+    if (!uri || uri[0] == '\0') {
+        return;
+    }
+
+    g_app_info_launch_default_for_uri(uri, NULL, NULL);
+}
+
+static void on_about_link_row_activated(AdwActionRow *row, gpointer user_data) {
+    (void)user_data;
+    const gchar *uri = (const gchar *)g_object_get_data(G_OBJECT(row), "uri");
+    about_open_uri(uri);
+}
+
+static gchar* about_version_text(void) {
+    if (g_strcmp0(OPENCLAW_GIT_COMMIT, "unknown") == 0 || OPENCLAW_GIT_COMMIT[0] == '\0') {
+        return g_strdup_printf("Version %s", OPENCLAW_APP_VERSION);
+    }
+
+#ifndef NDEBUG
+    return g_strdup_printf("Version %s (%s DEBUG)", OPENCLAW_APP_VERSION, OPENCLAW_GIT_COMMIT);
+#else
+    return g_strdup_printf("Version %s (%s)", OPENCLAW_APP_VERSION, OPENCLAW_GIT_COMMIT);
+#endif
+}
+
+static gchar* about_build_text(void) {
+    if (OPENCLAW_BUILD_TIMESTAMP[0] == '\0') {
+        return NULL;
+    }
+
+    g_autoptr(GDateTime) parsed = g_date_time_new_from_iso8601(OPENCLAW_BUILD_TIMESTAMP, NULL);
+    if (!parsed) {
+        return g_strdup_printf("Built %s", OPENCLAW_BUILD_TIMESTAMP);
+    }
+
+    return g_date_time_format(parsed, "Built %b %-d, %Y %H:%M %Z");
+}
+
+static GtkWidget* about_link_row(const gchar *icon_name,
+                                 const gchar *title,
+                                 const gchar *subtitle,
+                                 const gchar *uri) {
+    GtkWidget *row = adw_action_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(row), title);
+    adw_action_row_set_subtitle(ADW_ACTION_ROW(row), subtitle);
+    gtk_list_box_row_set_activatable(GTK_LIST_BOX_ROW(row), TRUE);
+    gtk_list_box_row_set_selectable(GTK_LIST_BOX_ROW(row), FALSE);
+    g_object_set_data_full(G_OBJECT(row), "uri", g_strdup(uri), g_free);
+    g_signal_connect(row, "activated", G_CALLBACK(on_about_link_row_activated), NULL);
+
+    GtkWidget *icon = gtk_image_new_from_icon_name(icon_name);
+    gtk_widget_set_valign(icon, GTK_ALIGN_CENTER);
+    adw_action_row_add_prefix(ADW_ACTION_ROW(row), icon);
+
+    return row;
+}
 
 static GtkWidget* about_build(void) {
     GtkWidget *scrolled = gtk_scrolled_window_new();
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
                                    GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
 
-    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+    GtkWidget *page = adw_preferences_page_new();
     gtk_widget_set_margin_start(page, 24);
     gtk_widget_set_margin_end(page, 24);
-    gtk_widget_set_margin_top(page, 40);
+    gtk_widget_set_margin_top(page, 24);
     gtk_widget_set_margin_bottom(page, 24);
-    gtk_widget_set_halign(page, GTK_ALIGN_CENTER);
+
+    GtkWidget *identity_group = adw_preferences_group_new();
+    adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(identity_group));
+
+    GtkWidget *identity = gtk_box_new(GTK_ORIENTATION_VERTICAL, 6);
+    gtk_widget_set_halign(identity, GTK_ALIGN_CENTER);
+    gtk_widget_set_margin_top(identity, 8);
+    gtk_widget_set_margin_bottom(identity, 8);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(identity_group), identity);
+
+    GtkIconTheme *theme = gdk_display_get_default()
+        ? gtk_icon_theme_get_for_display(gdk_display_get_default())
+        : NULL;
+    const gchar *app_icon = (theme && gtk_icon_theme_has_icon(theme, "ai.openclaw.Companion"))
+        ? "ai.openclaw.Companion"
+        : "applications-system-symbolic";
+    GtkWidget *icon = gtk_image_new_from_icon_name(app_icon);
+    gtk_image_set_pixel_size(GTK_IMAGE(icon), 96);
+    gtk_widget_set_margin_bottom(icon, 6);
+    gtk_box_append(GTK_BOX(identity), icon);
 
     GtkWidget *title = gtk_label_new("OpenClaw");
     gtk_widget_add_css_class(title, "title-1");
-    gtk_box_append(GTK_BOX(page), title);
+    gtk_box_append(GTK_BOX(identity), title);
 
     GtkWidget *subtitle = gtk_label_new("Linux Companion App");
     gtk_widget_add_css_class(subtitle, "title-3");
-    gtk_box_append(GTK_BOX(page), subtitle);
+    gtk_box_append(GTK_BOX(identity), subtitle);
+
+    g_autofree gchar *version_text = about_version_text();
+    GtkWidget *version = gtk_label_new(version_text);
+    gtk_widget_add_css_class(version, "dim-label");
+    gtk_box_append(GTK_BOX(identity), version);
+
+    g_autofree gchar *build_text = about_build_text();
+    if (build_text) {
+        GtkWidget *build = gtk_label_new(build_text);
+        gtk_widget_add_css_class(build, "dim-label");
+        gtk_box_append(GTK_BOX(identity), build);
+    }
+
+    GtkWidget *summary = gtk_label_new("Companion app for the OpenClaw gateway — runtime status, config, and local service management.");
+    gtk_widget_add_css_class(summary, "dim-label");
+    gtk_label_set_wrap(GTK_LABEL(summary), TRUE);
+    gtk_label_set_justify(GTK_LABEL(summary), GTK_JUSTIFY_CENTER);
+    gtk_label_set_xalign(GTK_LABEL(summary), 0.5);
+    gtk_widget_set_margin_top(summary, 4);
+    gtk_box_append(GTK_BOX(identity), summary);
 
     HealthState *health = state_get_health();
-    const char *ver = (health && health->gateway_version) ? health->gateway_version : "Unknown";
-    g_autofree gchar *ver_text = g_strdup_printf("Gateway Version: %s", ver);
-    GtkWidget *version = gtk_label_new(ver_text);
-    gtk_widget_add_css_class(version, "dim-label");
-    gtk_widget_set_margin_top(version, 16);
-    gtk_box_append(GTK_BOX(page), version);
+    const char *gateway_version = (health && health->gateway_version) ? health->gateway_version : "Unknown";
+    g_autofree gchar *gateway_text = g_strdup_printf("Gateway version: %s", gateway_version);
+    GtkWidget *gateway_label = gtk_label_new(gateway_text);
+    gtk_widget_add_css_class(gateway_label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(gateway_label), 0.5);
+    gtk_widget_set_margin_top(gateway_label, 4);
+    gtk_box_append(GTK_BOX(identity), gateway_label);
 
-    GtkWidget *docs_link = gtk_label_new(NULL);
-    gtk_label_set_markup(GTK_LABEL(docs_link),
-        "<a href=\"https://docs.openclaw.ai\">Documentation</a>");
-    gtk_widget_set_margin_top(docs_link, 12);
-    gtk_box_append(GTK_BOX(page), docs_link);
+    GtkWidget *links_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(links_group), "Links");
+    adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(links_group));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(links_group),
+                              about_link_row("text-x-script-symbolic",
+                                             "GitHub",
+                                             "github.com/openclaw/openclaw",
+                                             "https://github.com/openclaw/openclaw"));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(links_group),
+                              about_link_row("globe-symbolic",
+                                             "Website",
+                                             "openclaw.ai",
+                                             "https://openclaw.ai"));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(links_group),
+                              about_link_row("help-browser-symbolic",
+                                             "Documentation",
+                                             "docs.openclaw.ai",
+                                             "https://docs.openclaw.ai"));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(links_group),
+                              about_link_row("mail-send-symbolic",
+                                             "Email",
+                                             "hello@openclaw.ai",
+                                             "mailto:hello@openclaw.ai"));
 
-    GtkWidget *gh_link = gtk_label_new(NULL);
-    gtk_label_set_markup(GTK_LABEL(gh_link),
-        "<a href=\"https://github.com/openclaw/openclaw\">GitHub</a>");
-    gtk_box_append(GTK_BOX(page), gh_link);
+    GtkWidget *updates_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(updates_group), "Updates");
+    adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(updates_group));
+    GtkWidget *updates_row = adw_action_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(updates_row), "Linux updates");
+    adw_action_row_set_subtitle(ADW_ACTION_ROW(updates_row),
+                                "Automatic updates are not yet available on Linux.");
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(updates_group), updates_row);
 
-    GtkWidget *copyright = gtk_label_new("Copyright © 2025 OpenClaw Contributors");
+    GtkWidget *footer_group = adw_preferences_group_new();
+    adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(footer_group));
+    GtkWidget *copyright = gtk_label_new("© 2025 OpenClaw Contributors — MIT License.");
     gtk_widget_add_css_class(copyright, "dim-label");
-    gtk_widget_set_margin_top(copyright, 24);
-    gtk_box_append(GTK_BOX(page), copyright);
+    gtk_widget_set_margin_top(copyright, 16);
+    gtk_label_set_xalign(GTK_LABEL(copyright), 0.5);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(footer_group), copyright);
 
     gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
     return scrolled;
 }
 
+static void about_refresh(void) {
+}
+
+static void about_destroy(void) {
+}
+
+static void about_invalidate(void) {
+}
+
 static const SectionController about_controller = {
     .build = about_build,
-    .refresh = NULL,
-    .destroy = NULL,
-    .invalidate = NULL,
+    .refresh = about_refresh,
+    .destroy = about_destroy,
+    .invalidate = about_invalidate,
 };
 
 const SectionController* section_about_get(void) {

--- a/apps/linux/src/section_config.c
+++ b/apps/linux/src/section_config.c
@@ -36,7 +36,10 @@ static GtkWidget *cfg_validation_label = NULL;
 static GtkWidget *cfg_copy_btn = NULL;
 static GtkWidget *cfg_reload_btn = NULL;
 static GtkWidget *cfg_save_btn = NULL;
-static GtkWidget *cfg_setup_summary_label = NULL;
+static GtkWidget *cfg_setup_provider_label = NULL;
+static GtkWidget *cfg_setup_default_model_label = NULL;
+static GtkWidget *cfg_setup_catalog_label = NULL;
+static GtkWidget *cfg_setup_readiness_label = NULL;
 static GtkWidget *cfg_setup_status_label = NULL;
 static GtkWidget *cfg_provider_id_entry = NULL;
 static GtkWidget *cfg_provider_base_url_entry = NULL;
@@ -269,6 +272,33 @@ static void cfg_refresh_buttons(void) {
     }
 }
 
+static void cfg_set_validation_message(const gchar *message, gboolean valid) {
+    if (!cfg_validation_label) {
+        return;
+    }
+
+    gtk_label_set_text(GTK_LABEL(cfg_validation_label), message ? message : "Validation unavailable");
+    gtk_widget_remove_css_class(cfg_validation_label, "success");
+    gtk_widget_remove_css_class(cfg_validation_label, "error");
+    gtk_widget_add_css_class(cfg_validation_label, valid ? "success" : "error");
+}
+
+static GtkWidget* cfg_setup_fact_row(const gchar *title, GtkWidget **out_value) {
+    GtkWidget *row = adw_action_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(row), title);
+
+    GtkWidget *value = gtk_label_new("—");
+    gtk_label_set_selectable(GTK_LABEL(value), TRUE);
+    gtk_label_set_wrap(GTK_LABEL(value), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(value), 1.0);
+    gtk_widget_set_hexpand(value, TRUE);
+    gtk_widget_set_halign(value, GTK_ALIGN_END);
+    adw_action_row_add_suffix(ADW_ACTION_ROW(row), value);
+
+    *out_value = value;
+    return row;
+}
+
 static gboolean cfg_validate_and_track(const gchar *text) {
     g_autoptr(JsonParser) parser = json_parser_new();
     g_autoptr(GError) error = NULL;
@@ -278,16 +308,16 @@ static gboolean cfg_validate_and_track(const gchar *text) {
         JsonNode *root = json_parser_get_root(parser);
         valid = root && JSON_NODE_HOLDS_OBJECT(root);
         if (!valid && cfg_validation_label) {
-            gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Validation: root value must be a JSON object");
+            cfg_set_validation_message("Validation: root value must be a JSON object", FALSE);
         }
     } else if (cfg_validation_label) {
         g_autofree gchar *message = g_strdup_printf("Validation: %s",
                                                     error && error->message ? error->message : "invalid JSON");
-        gtk_label_set_text(GTK_LABEL(cfg_validation_label), message);
+        cfg_set_validation_message(message, FALSE);
     }
 
     if (valid && cfg_validation_label) {
-        gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Validation: JSON is valid");
+        cfg_set_validation_message("Validation: JSON is valid", TRUE);
     }
 
     cfg_editor_valid = valid;
@@ -320,7 +350,7 @@ static void cfg_request_save_text(const gchar *text) {
     if (!request_id) {
         cfg_request_in_flight = FALSE;
         if (cfg_validation_label) {
-            gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Failed to request config.set");
+            cfg_set_validation_message("Failed to request config.set", FALSE);
         }
         if (cfg_setup_status_label) {
             gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Provider/model save request failed.");
@@ -396,17 +426,26 @@ static void cfg_refresh_setup_surface(void) {
     const DesktopReadinessSnapshot *snapshot = state_get_readiness_snapshot();
     ChatGateInfo gate = {0};
     readiness_describe_chat_gate(snapshot, &gate);
-    if (cfg_setup_summary_label) {
-        g_autofree gchar *summary = g_strdup_printf(
-            "Provider: %s | Default model: %s | Catalog: %s | Selected: %s | Agents: %s | Chat: %s (%s)",
-            provider_id && provider_id[0] != '\0' ? provider_id : "missing",
-            default_model_id ? default_model_id : "missing",
-            snapshot && snapshot->model_catalog_available ? "ready" : "missing",
-            snapshot && snapshot->selected_model_resolved ? "resolved" : "unresolved",
-            snapshot && snapshot->agents_available ? "ready" : "missing",
-            gate.ready ? "ready" : "blocked",
-            readiness_chat_block_reason_to_string(gate.reason));
-        gtk_label_set_text(GTK_LABEL(cfg_setup_summary_label), summary);
+    if (cfg_setup_provider_label) {
+        gtk_label_set_text(GTK_LABEL(cfg_setup_provider_label),
+                           provider_id && provider_id[0] != '\0' ? provider_id : "missing");
+    }
+    if (cfg_setup_default_model_label) {
+        gtk_label_set_text(GTK_LABEL(cfg_setup_default_model_label),
+                           default_model_id ? default_model_id : "missing");
+    }
+    if (cfg_setup_catalog_label) {
+        g_autofree gchar *catalog_text = g_strdup_printf("%s / %s",
+                                                         snapshot && snapshot->model_catalog_available ? "catalog ready" : "catalog missing",
+                                                         snapshot && snapshot->selected_model_resolved ? "selected resolved" : "selected unresolved");
+        gtk_label_set_text(GTK_LABEL(cfg_setup_catalog_label), catalog_text);
+    }
+    if (cfg_setup_readiness_label) {
+        g_autofree gchar *readiness_text = g_strdup_printf("%s / %s (%s)",
+                                                           snapshot && snapshot->agents_available ? "agents ready" : "agents missing",
+                                                           gate.ready ? "chat ready" : "chat blocked",
+                                                           readiness_chat_block_reason_to_string(gate.reason));
+        gtk_label_set_text(GTK_LABEL(cfg_setup_readiness_label), readiness_text);
     }
 
     if (cfg_setup_status_label) {
@@ -621,7 +660,7 @@ static void on_cfg_get_done(const GatewayRpcResponse *response, gpointer user_da
         if (cfg_validation_label) {
             g_autofree gchar *message = g_strdup_printf("Load failed: %s",
                                                         response && response->error_msg ? response->error_msg : "unknown error");
-            gtk_label_set_text(GTK_LABEL(cfg_validation_label), message);
+            cfg_set_validation_message(message, FALSE);
         }
         cfg_refresh_buttons();
         return;
@@ -630,7 +669,7 @@ static void on_cfg_get_done(const GatewayRpcResponse *response, gpointer user_da
     GatewayConfigSnapshot *snapshot = gateway_data_parse_config_get(response->payload);
     if (!snapshot || !snapshot->config) {
         if (cfg_validation_label) {
-            gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Load failed: invalid config response");
+            cfg_set_validation_message("Load failed: invalid config response", FALSE);
         }
         gateway_config_snapshot_free(snapshot);
         cfg_refresh_buttons();
@@ -673,7 +712,7 @@ static void cfg_request_reload(void) {
     if (!request_id) {
         cfg_request_in_flight = FALSE;
         if (cfg_validation_label) {
-            gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Failed to request config.get");
+            cfg_set_validation_message("Failed to request config.get", FALSE);
         }
         cfg_refresh_buttons();
     }
@@ -696,14 +735,14 @@ static void on_cfg_save_done(const GatewayRpcResponse *response, gpointer user_d
         if (cfg_validation_label) {
             g_autofree gchar *message = g_strdup_printf("Save failed: %s",
                                                         response && response->error_msg ? response->error_msg : "unknown error");
-            gtk_label_set_text(GTK_LABEL(cfg_validation_label), message);
+            cfg_set_validation_message(message, FALSE);
         }
         cfg_refresh_buttons();
         return;
     }
 
     if (cfg_validation_label) {
-        gtk_label_set_text(GTK_LABEL(cfg_validation_label), "Save successful. Reloading baseline…");
+        cfg_set_validation_message("Save successful. Reloading baseline…", TRUE);
     }
     if (cfg_setup_status_label) {
         gtk_label_set_text(GTK_LABEL(cfg_setup_status_label), "Saved provider/model config. Reloading baseline…");
@@ -727,59 +766,75 @@ static void on_cfg_save(GtkButton *button, gpointer user_data) {
 }
 
 static GtkWidget* config_build(void) {
-    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 16);
     gtk_widget_set_margin_start(page, 24);
     gtk_widget_set_margin_end(page, 24);
     gtk_widget_set_margin_top(page, 24);
     gtk_widget_set_margin_bottom(page, 24);
 
     GtkWidget *title = gtk_label_new("Config");
-    gtk_widget_add_css_class(title, "title-1");
+    gtk_widget_add_css_class(title, "title-3");
     gtk_label_set_xalign(GTK_LABEL(title), 0.0);
     gtk_box_append(GTK_BOX(page), title);
+
+    GtkWidget *subtitle = gtk_label_new("Operator-oriented gateway configuration with structured setup controls and raw JSON editing.");
+    gtk_widget_add_css_class(subtitle, "dim-label");
+    gtk_label_set_wrap(GTK_LABEL(subtitle), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(subtitle), 0.0);
+    gtk_box_append(GTK_BOX(page), subtitle);
+
+    GtkWidget *status_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(status_group), "Status");
+    gtk_box_append(GTK_BOX(page), status_group);
+
+    GtkWidget *status_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 6);
+    gtk_widget_set_margin_start(status_box, 12);
+    gtk_widget_set_margin_end(status_box, 12);
+    gtk_widget_set_margin_top(status_box, 6);
+    gtk_widget_set_margin_bottom(status_box, 6);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(status_group), status_box);
 
     cfg_status_label = gtk_label_new("—");
     gtk_widget_add_css_class(cfg_status_label, "title-3");
     gtk_label_set_xalign(GTK_LABEL(cfg_status_label), 0.0);
-    gtk_widget_set_margin_top(cfg_status_label, 4);
-    gtk_box_append(GTK_BOX(page), cfg_status_label);
+    gtk_box_append(GTK_BOX(status_box), cfg_status_label);
 
     cfg_issues_label = gtk_label_new("");
     gtk_widget_add_css_class(cfg_issues_label, "dim-label");
     gtk_label_set_xalign(GTK_LABEL(cfg_issues_label), 0.0);
     gtk_widget_set_visible(cfg_issues_label, FALSE);
-    gtk_box_append(GTK_BOX(page), cfg_issues_label);
+    gtk_box_append(GTK_BOX(status_box), cfg_issues_label);
 
     cfg_warning_label = gtk_label_new("");
     gtk_label_set_wrap(GTK_LABEL(cfg_warning_label), TRUE);
     gtk_label_set_xalign(GTK_LABEL(cfg_warning_label), 0.0);
     gtk_widget_set_visible(cfg_warning_label, FALSE);
-    gtk_box_append(GTK_BOX(page), cfg_warning_label);
+    gtk_box_append(GTK_BOX(status_box), cfg_warning_label);
 
-    GtkWidget *sep1 = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
-    gtk_widget_set_margin_top(sep1, 8);
-    gtk_box_append(GTK_BOX(page), sep1);
+    GtkWidget *file_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(file_group), "File");
+    gtk_box_append(GTK_BOX(page), file_group);
 
-    GtkWidget *path_heading = gtk_label_new("Config File");
-    gtk_widget_add_css_class(path_heading, "heading");
-    gtk_label_set_xalign(GTK_LABEL(path_heading), 0.0);
-    gtk_widget_set_margin_top(path_heading, 8);
-    gtk_box_append(GTK_BOX(page), path_heading);
+    GtkWidget *file_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 6);
+    gtk_widget_set_margin_start(file_box, 12);
+    gtk_widget_set_margin_end(file_box, 12);
+    gtk_widget_set_margin_top(file_box, 6);
+    gtk_widget_set_margin_bottom(file_box, 6);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(file_group), file_box);
 
     cfg_path_label = gtk_label_new("—");
     gtk_label_set_selectable(GTK_LABEL(cfg_path_label), TRUE);
     gtk_label_set_xalign(GTK_LABEL(cfg_path_label), 0.0);
     gtk_label_set_wrap(GTK_LABEL(cfg_path_label), TRUE);
     gtk_widget_add_css_class(cfg_path_label, "monospace");
-    gtk_box_append(GTK_BOX(page), cfg_path_label);
+    gtk_box_append(GTK_BOX(file_box), cfg_path_label);
 
     cfg_modified_label = gtk_label_new("Last modified: —");
     gtk_widget_add_css_class(cfg_modified_label, "dim-label");
     gtk_label_set_xalign(GTK_LABEL(cfg_modified_label), 0.0);
-    gtk_box_append(GTK_BOX(page), cfg_modified_label);
+    gtk_box_append(GTK_BOX(file_box), cfg_modified_label);
 
     GtkWidget *file_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
-    gtk_widget_set_margin_top(file_row, 6);
 
     GtkWidget *open_file_btn = gtk_button_new_with_label("Open Config File");
     g_signal_connect(open_file_btn, "clicked", G_CALLBACK(on_cfg_open_file), NULL);
@@ -789,28 +844,31 @@ static GtkWidget* config_build(void) {
     g_signal_connect(open_folder_btn, "clicked", G_CALLBACK(on_cfg_open_folder), NULL);
     gtk_box_append(GTK_BOX(file_row), open_folder_btn);
 
-    gtk_box_append(GTK_BOX(page), file_row);
+    gtk_box_append(GTK_BOX(file_box), file_row);
 
-    GtkWidget *setup_sep = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
-    gtk_widget_set_margin_top(setup_sep, 8);
-    gtk_box_append(GTK_BOX(page), setup_sep);
+    GtkWidget *setup_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(setup_group), "Provider & Model");
+    gtk_box_append(GTK_BOX(page), setup_group);
 
-    GtkWidget *setup_heading = gtk_label_new("Provider & Model Setup");
-    gtk_widget_add_css_class(setup_heading, "heading");
-    gtk_label_set_xalign(GTK_LABEL(setup_heading), 0.0);
-    gtk_widget_set_margin_top(setup_heading, 8);
-    gtk_box_append(GTK_BOX(page), setup_heading);
+    GtkWidget *setup_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 6);
+    gtk_widget_set_margin_start(setup_box, 12);
+    gtk_widget_set_margin_end(setup_box, 12);
+    gtk_widget_set_margin_top(setup_box, 6);
+    gtk_widget_set_margin_bottom(setup_box, 6);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(setup_group), setup_box);
 
-    cfg_setup_summary_label = gtk_label_new("Provider: missing | Default model: missing");
-    gtk_widget_add_css_class(cfg_setup_summary_label, "dim-label");
-    gtk_label_set_xalign(GTK_LABEL(cfg_setup_summary_label), 0.0);
-    gtk_box_append(GTK_BOX(page), cfg_setup_summary_label);
+    GtkWidget *facts_group = adw_preferences_group_new();
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(facts_group), cfg_setup_fact_row("Provider", &cfg_setup_provider_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(facts_group), cfg_setup_fact_row("Default model", &cfg_setup_default_model_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(facts_group), cfg_setup_fact_row("Catalog / Selected", &cfg_setup_catalog_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(facts_group), cfg_setup_fact_row("Agents / Chat", &cfg_setup_readiness_label));
+    gtk_box_append(GTK_BOX(setup_box), facts_group);
 
     cfg_setup_status_label = gtk_label_new("Use this section to complete provider/model setup for chat readiness.");
     gtk_widget_add_css_class(cfg_setup_status_label, "dim-label");
     gtk_label_set_xalign(GTK_LABEL(cfg_setup_status_label), 0.0);
     gtk_label_set_wrap(GTK_LABEL(cfg_setup_status_label), TRUE);
-    gtk_box_append(GTK_BOX(page), cfg_setup_status_label);
+    gtk_box_append(GTK_BOX(setup_box), cfg_setup_status_label);
 
     GtkWidget *provider_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
     cfg_provider_id_entry = gtk_entry_new();
@@ -826,7 +884,7 @@ static GtkWidget* config_build(void) {
     cfg_apply_provider_btn = gtk_button_new_with_label("Configure Provider");
     g_signal_connect(cfg_apply_provider_btn, "clicked", G_CALLBACK(on_cfg_apply_provider), NULL);
     gtk_box_append(GTK_BOX(provider_row), cfg_apply_provider_btn);
-    gtk_box_append(GTK_BOX(page), provider_row);
+    gtk_box_append(GTK_BOX(setup_box), provider_row);
 
     GtkWidget *model_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
     cfg_reload_models_btn = gtk_button_new_with_label("Reload Models");
@@ -842,15 +900,20 @@ static GtkWidget* config_build(void) {
     gtk_widget_add_css_class(cfg_apply_model_btn, "suggested-action");
     g_signal_connect(cfg_apply_model_btn, "clicked", G_CALLBACK(on_cfg_apply_default_model), NULL);
     gtk_box_append(GTK_BOX(model_row), cfg_apply_model_btn);
-    gtk_box_append(GTK_BOX(page), model_row);
+    gtk_box_append(GTK_BOX(setup_box), model_row);
 
     cfg_set_model_dropdown_placeholder("Load models to pick default", FALSE);
 
-    GtkWidget *json_heading = gtk_label_new("Raw Config");
-    gtk_widget_add_css_class(json_heading, "heading");
-    gtk_label_set_xalign(GTK_LABEL(json_heading), 0.0);
-    gtk_widget_set_margin_top(json_heading, 12);
-    gtk_box_append(GTK_BOX(page), json_heading);
+    GtkWidget *json_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(json_group), "Raw Config (Advanced)");
+    gtk_box_append(GTK_BOX(page), json_group);
+
+    GtkWidget *json_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
+    gtk_widget_set_margin_start(json_box, 12);
+    gtk_widget_set_margin_end(json_box, 12);
+    gtk_widget_set_margin_top(json_box, 6);
+    gtk_widget_set_margin_bottom(json_box, 6);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(json_group), json_box);
 
     GtkTextBuffer *json_buffer = gtk_text_buffer_new(NULL);
     cfg_json_view = gtk_text_view_new_with_buffer(json_buffer);
@@ -865,31 +928,31 @@ static GtkWidget* config_build(void) {
     gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(json_scrolled), cfg_json_view);
     gtk_widget_set_vexpand(json_scrolled, TRUE);
     gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(json_scrolled), 200);
-    gtk_box_append(GTK_BOX(page), json_scrolled);
+    GtkWidget *json_frame = gtk_frame_new(NULL);
+    gtk_frame_set_child(GTK_FRAME(json_frame), json_scrolled);
+    gtk_box_append(GTK_BOX(json_box), json_frame);
 
     cfg_validation_label = gtk_label_new("Validation: loading config…");
-    gtk_widget_add_css_class(cfg_validation_label, "dim-label");
     gtk_label_set_xalign(GTK_LABEL(cfg_validation_label), 0.0);
-    gtk_widget_set_margin_top(cfg_validation_label, 6);
-    gtk_box_append(GTK_BOX(page), cfg_validation_label);
+    gtk_label_set_wrap(GTK_LABEL(cfg_validation_label), TRUE);
+    gtk_box_append(GTK_BOX(json_box), cfg_validation_label);
 
-    GtkWidget *copy_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
-    gtk_widget_set_margin_top(copy_row, 6);
+    GtkWidget *copy_row = gtk_action_bar_new();
 
     cfg_reload_btn = gtk_button_new_with_label("Reload");
     g_signal_connect(cfg_reload_btn, "clicked", G_CALLBACK(on_cfg_reload), NULL);
-    gtk_box_append(GTK_BOX(copy_row), cfg_reload_btn);
+    gtk_action_bar_pack_start(GTK_ACTION_BAR(copy_row), cfg_reload_btn);
+
+    cfg_copy_btn = gtk_button_new_with_label("Copy Config JSON");
+    g_signal_connect(cfg_copy_btn, "clicked", G_CALLBACK(on_cfg_copy_json), NULL);
+    gtk_action_bar_pack_start(GTK_ACTION_BAR(copy_row), cfg_copy_btn);
 
     cfg_save_btn = gtk_button_new_with_label("Save");
     gtk_widget_add_css_class(cfg_save_btn, "suggested-action");
     g_signal_connect(cfg_save_btn, "clicked", G_CALLBACK(on_cfg_save), NULL);
-    gtk_box_append(GTK_BOX(copy_row), cfg_save_btn);
+    gtk_action_bar_pack_end(GTK_ACTION_BAR(copy_row), cfg_save_btn);
 
-    cfg_copy_btn = gtk_button_new_with_label("Copy Config JSON");
-    g_signal_connect(cfg_copy_btn, "clicked", G_CALLBACK(on_cfg_copy_json), NULL);
-    gtk_box_append(GTK_BOX(copy_row), cfg_copy_btn);
-
-    gtk_box_append(GTK_BOX(page), copy_row);
+    gtk_box_append(GTK_BOX(json_box), copy_row);
 
     cfg_refresh_buttons();
     return page;
@@ -958,7 +1021,10 @@ static void config_destroy(void) {
     cfg_issues_label = NULL;
     cfg_json_view = NULL;
     cfg_validation_label = NULL;
-    cfg_setup_summary_label = NULL;
+    cfg_setup_provider_label = NULL;
+    cfg_setup_default_model_label = NULL;
+    cfg_setup_catalog_label = NULL;
+    cfg_setup_readiness_label = NULL;
     cfg_setup_status_label = NULL;
     cfg_provider_id_entry = NULL;
     cfg_provider_base_url_entry = NULL;

--- a/apps/linux/src/section_general.c
+++ b/apps/linux/src/section_general.c
@@ -29,10 +29,10 @@ extern void systemd_restart_gateway(void);
 
 static GtkWidget *gen_status_label = NULL;
 static GtkWidget *gen_runtime_label = NULL;
-static GtkWidget *gen_service_notice_label = NULL;
+static GtkWidget *gen_service_notice_row = NULL;
 static GtkWidget *gen_connection_mode_dropdown = NULL;
 static GtkStringList *gen_connection_mode_dropdown_model = NULL;
-static GtkWidget *gen_connection_mode_detail_label = NULL;
+static GtkWidget *gen_connection_mode_detail_row = NULL;
 static gboolean gen_connection_mode_programmatic_change = FALSE;
 static GtkWidget *gen_endpoint_label = NULL;
 static GtkWidget *gen_version_label = NULL;
@@ -124,15 +124,15 @@ static void refresh_general_connection_mode_controls(void) {
     ProductConnectionMode effective_mode = product_state_get_effective_connection_mode();
     guint selected = gen_connection_mode_selection_for_mode(effective_mode);
 
-    if (gen_connection_mode_dropdown && GTK_IS_DROP_DOWN(gen_connection_mode_dropdown)) {
+    if (gen_connection_mode_dropdown && ADW_IS_COMBO_ROW(gen_connection_mode_dropdown)) {
         gen_connection_mode_programmatic_change = TRUE;
-        gtk_drop_down_set_selected(GTK_DROP_DOWN(gen_connection_mode_dropdown), selected);
+        adw_combo_row_set_selected(ADW_COMBO_ROW(gen_connection_mode_dropdown), selected);
         gen_connection_mode_programmatic_change = FALSE;
     }
 
-    if (gen_connection_mode_detail_label) {
-        gtk_label_set_text(GTK_LABEL(gen_connection_mode_detail_label),
-                           gen_connection_mode_detail_text(stored_mode, effective_mode));
+    if (gen_connection_mode_detail_row && ADW_IS_ACTION_ROW(gen_connection_mode_detail_row)) {
+        adw_action_row_set_subtitle(ADW_ACTION_ROW(gen_connection_mode_detail_row),
+                                    gen_connection_mode_detail_text(stored_mode, effective_mode));
     }
 }
 
@@ -142,11 +142,11 @@ static void on_gen_connection_mode_selected_notify(GObject *object,
     (void)pspec;
     (void)user_data;
 
-    if (gen_connection_mode_programmatic_change || !GTK_IS_DROP_DOWN(object)) {
+    if (gen_connection_mode_programmatic_change || !ADW_IS_COMBO_ROW(object)) {
         return;
     }
 
-    guint selected = gtk_drop_down_get_selected(GTK_DROP_DOWN(object));
+    guint selected = adw_combo_row_get_selected(ADW_COMBO_ROW(object));
     if (selected == GTK_INVALID_LIST_POSITION) {
         refresh_general_connection_mode_controls();
         return;
@@ -203,7 +203,39 @@ static void on_gen_reveal_state_dir(GtkButton *button, gpointer user_data) {
 }
 
 static GtkWidget* general_info_row(const char *heading, GtkWidget **out_value) {
-    return section_info_row(heading, 120, out_value);
+    GtkWidget *row = adw_action_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(row), heading);
+
+    GtkWidget *value = gtk_label_new("—");
+    gtk_label_set_selectable(GTK_LABEL(value), TRUE);
+    gtk_label_set_wrap(GTK_LABEL(value), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(value), 1.0);
+    gtk_widget_set_hexpand(value, TRUE);
+    gtk_widget_set_halign(value, GTK_ALIGN_END);
+    adw_action_row_add_suffix(ADW_ACTION_ROW(row), value);
+
+    *out_value = value;
+    return row;
+}
+
+static GtkWidget* general_action_row(const char *title,
+                                     const char *subtitle,
+                                     GtkWidget *suffix) {
+    GtkWidget *row = adw_action_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(row), title);
+    if (subtitle && subtitle[0] != '\0') {
+        adw_action_row_set_subtitle(ADW_ACTION_ROW(row), subtitle);
+    }
+    if (suffix) {
+        adw_action_row_add_suffix(ADW_ACTION_ROW(row), suffix);
+    }
+    return row;
+}
+
+static GtkWidget* general_note_row(const char *title) {
+    GtkWidget *row = adw_action_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(row), title);
+    return row;
 }
 
 static GtkWidget* general_build(void) {
@@ -211,113 +243,77 @@ static GtkWidget* general_build(void) {
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
                                    GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
 
-    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 4);
+    GtkWidget *page = adw_preferences_page_new();
     gtk_widget_set_margin_start(page, 24);
     gtk_widget_set_margin_end(page, 24);
     gtk_widget_set_margin_top(page, 24);
     gtk_widget_set_margin_bottom(page, 24);
 
-    GtkWidget *title = gtk_label_new("General");
-    gtk_widget_add_css_class(title, "title-1");
-    gtk_label_set_xalign(GTK_LABEL(title), 0.0);
-    gtk_box_append(GTK_BOX(page), title);
+    GtkWidget *status_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(status_group), "Status");
+    adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(status_group));
 
-    gen_status_label = gtk_label_new("—");
+    GtkWidget *status_row = general_info_row("Status", &gen_status_label);
     gtk_widget_add_css_class(gen_status_label, "title-3");
-    gtk_label_set_xalign(GTK_LABEL(gen_status_label), 0.0);
-    gtk_widget_set_margin_top(gen_status_label, 4);
-    gtk_box_append(GTK_BOX(page), gen_status_label);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(status_group), status_row);
 
-    gen_runtime_label = gtk_label_new("—");
+    GtkWidget *runtime_row = general_info_row("Runtime", &gen_runtime_label);
     gtk_widget_add_css_class(gen_runtime_label, "dim-label");
-    gtk_label_set_xalign(GTK_LABEL(gen_runtime_label), 0.0);
-    gtk_box_append(GTK_BOX(page), gen_runtime_label);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(status_group), runtime_row);
 
-    gen_service_notice_label = gtk_label_new("");
-    gtk_widget_add_css_class(gen_service_notice_label, "dim-label");
-    gtk_label_set_xalign(GTK_LABEL(gen_service_notice_label), 0.0);
-    gtk_label_set_wrap(GTK_LABEL(gen_service_notice_label), TRUE);
-    gtk_widget_set_visible(gen_service_notice_label, FALSE);
-    gtk_box_append(GTK_BOX(page), gen_service_notice_label);
+    gen_service_notice_row = general_note_row("Service Notice");
+    gtk_widget_set_visible(gen_service_notice_row, FALSE);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(status_group), gen_service_notice_row);
 
-    GtkWidget *connection_heading = gtk_label_new("Connection");
-    gtk_widget_add_css_class(connection_heading, "heading");
-    gtk_label_set_xalign(GTK_LABEL(connection_heading), 0.0);
-    gtk_widget_set_margin_top(connection_heading, 12);
-    gtk_box_append(GTK_BOX(page), connection_heading);
+    GtkWidget *connection_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(connection_group), "Connection");
+    adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(connection_group));
 
-    GtkWidget *connection_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
-    gtk_widget_set_margin_top(connection_row, 4);
-
-    GtkWidget *connection_mode_label = gtk_label_new("Connection Mode");
-    gtk_widget_add_css_class(connection_mode_label, "dim-label");
-    gtk_label_set_xalign(GTK_LABEL(connection_mode_label), 0.0);
-    gtk_widget_set_size_request(connection_mode_label, 120, -1);
-    gtk_box_append(GTK_BOX(connection_row), connection_mode_label);
-
-    gen_connection_mode_dropdown = gtk_drop_down_new(NULL, NULL);
-    gtk_widget_set_hexpand(gen_connection_mode_dropdown, TRUE);
-    gtk_box_append(GTK_BOX(connection_row), gen_connection_mode_dropdown);
-    gtk_box_append(GTK_BOX(page), connection_row);
+    gen_connection_mode_dropdown = adw_combo_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(gen_connection_mode_dropdown), "Connection Mode");
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(connection_group), gen_connection_mode_dropdown);
 
     GtkStringList *connection_mode_model = gtk_string_list_new(NULL);
     gtk_string_list_append(connection_mode_model, "Local (this machine)");
     gtk_string_list_append(connection_mode_model, "Remote (coming soon)");
-    ui_dropdown_replace_model(gen_connection_mode_dropdown,
-                              (gpointer *)&gen_connection_mode_dropdown_model,
-                              G_LIST_MODEL(connection_mode_model),
-                              0,
-                              TRUE);
+    ui_combo_row_replace_model(gen_connection_mode_dropdown,
+                               (gpointer *)&gen_connection_mode_dropdown_model,
+                               G_LIST_MODEL(connection_mode_model),
+                               0);
     g_signal_connect(gen_connection_mode_dropdown,
                      "notify::selected",
                      G_CALLBACK(on_gen_connection_mode_selected_notify),
                      NULL);
 
-    gen_connection_mode_detail_label = gtk_label_new("");
-    gtk_widget_add_css_class(gen_connection_mode_detail_label, "dim-label");
-    gtk_label_set_xalign(GTK_LABEL(gen_connection_mode_detail_label), 0.0);
-    gtk_label_set_wrap(GTK_LABEL(gen_connection_mode_detail_label), TRUE);
-    gtk_widget_set_margin_top(gen_connection_mode_detail_label, 2);
-    gtk_box_append(GTK_BOX(page), gen_connection_mode_detail_label);
+    gen_connection_mode_detail_row = general_note_row("Availability");
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(connection_group), gen_connection_mode_detail_row);
     refresh_general_connection_mode_controls();
 
-    GtkWidget *sep1 = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
-    gtk_widget_set_margin_top(sep1, 8);
-    gtk_box_append(GTK_BOX(page), sep1);
-
-    GtkWidget *nav_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
-    gtk_widget_set_margin_top(nav_row, 8);
+    GtkWidget *gateway_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(gateway_group), "Gateway");
+    adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(gateway_group));
 
     gen_btn_open_dashboard = gtk_button_new_with_label("Open Dashboard");
     gtk_widget_add_css_class(gen_btn_open_dashboard, "suggested-action");
     g_signal_connect(gen_btn_open_dashboard, "clicked", G_CALLBACK(on_gen_open_dashboard), NULL);
-    gtk_box_append(GTK_BOX(nav_row), gen_btn_open_dashboard);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group), general_info_row("Endpoint", &gen_endpoint_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group), general_info_row("Version", &gen_version_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group), general_info_row("Auth Mode", &gen_auth_mode_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group), general_info_row("Auth Source", &gen_auth_source_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group),
+                              general_action_row("Open Dashboard",
+                                                 "Open the local gateway dashboard in your browser.",
+                                                 gen_btn_open_dashboard));
 
-    gtk_box_append(GTK_BOX(page), nav_row);
+    GtkWidget *service_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(service_group), "Expected Service");
+    adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(service_group));
 
-    GtkWidget *gw_heading = gtk_label_new("Gateway");
-    gtk_widget_add_css_class(gw_heading, "heading");
-    gtk_label_set_xalign(GTK_LABEL(gw_heading), 0.0);
-    gtk_widget_set_margin_top(gw_heading, 12);
-    gtk_box_append(GTK_BOX(page), gw_heading);
-
-    gtk_box_append(GTK_BOX(page), general_info_row("Endpoint", &gen_endpoint_label));
-    gtk_box_append(GTK_BOX(page), general_info_row("Version", &gen_version_label));
-    gtk_box_append(GTK_BOX(page), general_info_row("Auth Mode", &gen_auth_mode_label));
-    gtk_box_append(GTK_BOX(page), general_info_row("Auth Source", &gen_auth_source_label));
-
-    GtkWidget *svc_heading = gtk_label_new("Expected Service");
-    gtk_widget_add_css_class(svc_heading, "heading");
-    gtk_label_set_xalign(GTK_LABEL(svc_heading), 0.0);
-    gtk_widget_set_margin_top(svc_heading, 12);
-    gtk_box_append(GTK_BOX(page), svc_heading);
-
-    gtk_box_append(GTK_BOX(page), general_info_row("Unit", &gen_unit_label));
-    gtk_box_append(GTK_BOX(page), general_info_row("Active State", &gen_active_state_label));
-    gtk_box_append(GTK_BOX(page), general_info_row("Sub State", &gen_sub_state_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(service_group), general_info_row("Unit", &gen_unit_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(service_group), general_info_row("Active State", &gen_active_state_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(service_group), general_info_row("Sub State", &gen_sub_state_label));
 
     GtkWidget *svc_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
-    gtk_widget_set_margin_top(svc_row, 6);
 
     gen_btn_start = gtk_button_new_with_label("Start");
     g_signal_connect(gen_btn_start, "clicked", G_CALLBACK(on_gen_start), NULL);
@@ -331,56 +327,55 @@ static GtkWidget* general_build(void) {
     g_signal_connect(gen_btn_restart, "clicked", G_CALLBACK(on_gen_restart), NULL);
     gtk_box_append(GTK_BOX(svc_row), gen_btn_restart);
 
-    gtk_box_append(GTK_BOX(page), svc_row);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(service_group),
+                              general_action_row("Service Controls",
+                                                 "Manage the local gateway service expected on this machine.",
+                                                 svc_row));
 
-    GtkWidget *paths_heading = gtk_label_new("Paths");
-    gtk_widget_add_css_class(paths_heading, "heading");
-    gtk_label_set_xalign(GTK_LABEL(paths_heading), 0.0);
-    gtk_widget_set_margin_top(paths_heading, 12);
-    gtk_box_append(GTK_BOX(page), paths_heading);
+    GtkWidget *paths_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(paths_group), "Paths");
+    adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(paths_group));
 
-    gtk_box_append(GTK_BOX(page), general_info_row("Config File", &gen_config_path_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(paths_group), general_info_row("Config File", &gen_config_path_label));
     gtk_widget_add_css_class(gen_config_path_label, "monospace");
 
     GtkWidget *reveal_config_btn = gtk_button_new_with_label("Reveal Config Folder");
-    gtk_widget_set_halign(reveal_config_btn, GTK_ALIGN_START);
-    gtk_widget_set_margin_top(reveal_config_btn, 2);
     g_signal_connect(reveal_config_btn, "clicked", G_CALLBACK(on_gen_reveal_config), NULL);
-    gtk_box_append(GTK_BOX(page), reveal_config_btn);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(paths_group),
+                              general_action_row("Config Folder",
+                                                 "Open the folder containing the effective config file.",
+                                                 reveal_config_btn));
 
-    gtk_box_append(GTK_BOX(page), general_info_row("State Dir", &gen_state_dir_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(paths_group), general_info_row("State Dir", &gen_state_dir_label));
     gtk_widget_add_css_class(gen_state_dir_label, "monospace");
 
     GtkWidget *reveal_state_btn = gtk_button_new_with_label("Reveal State Folder");
-    gtk_widget_set_halign(reveal_state_btn, GTK_ALIGN_START);
-    gtk_widget_set_margin_top(reveal_state_btn, 2);
     g_signal_connect(reveal_state_btn, "clicked", G_CALLBACK(on_gen_reveal_state_dir), NULL);
-    gtk_box_append(GTK_BOX(page), reveal_state_btn);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(paths_group),
+                              general_action_row("State Folder",
+                                                 "Open the local state directory used by the companion.",
+                                                 reveal_state_btn));
 
-    gtk_box_append(GTK_BOX(page), general_info_row("Profile", &gen_profile_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(paths_group), general_info_row("Profile", &gen_profile_label));
 
-    GtkWidget *sep2 = gtk_separator_new(GTK_ORIENTATION_HORIZONTAL);
-    gtk_widget_set_margin_top(sep2, 12);
-    gtk_box_append(GTK_BOX(page), sep2);
-
-    GtkWidget *companion_label = gtk_label_new("Companion");
-    gtk_widget_add_css_class(companion_label, "heading");
-    gtk_label_set_xalign(GTK_LABEL(companion_label), 0.0);
-    gtk_widget_set_margin_top(companion_label, 8);
-    gtk_box_append(GTK_BOX(page), companion_label);
+    GtkWidget *companion_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(companion_group), "Companion");
+    adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(companion_group));
 
     GtkWidget *onboard_btn = gtk_button_new_with_label("Re-run Onboarding");
-    gtk_widget_set_halign(onboard_btn, GTK_ALIGN_START);
-    gtk_widget_set_margin_top(onboard_btn, 4);
     g_signal_connect(onboard_btn, "clicked", G_CALLBACK(on_gen_rerun_onboarding), NULL);
-    gtk_box_append(GTK_BOX(page), onboard_btn);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(companion_group),
+                              general_action_row("Onboarding",
+                                                 "Run the local onboarding flow again for this machine.",
+                                                 onboard_btn));
 
     GtkWidget *quit_btn = gtk_button_new_with_label("Quit OpenClaw Companion");
     gtk_widget_add_css_class(quit_btn, "destructive-action");
-    gtk_widget_set_halign(quit_btn, GTK_ALIGN_START);
-    gtk_widget_set_margin_top(quit_btn, 8);
     g_signal_connect(quit_btn, "clicked", G_CALLBACK(on_gen_quit), NULL);
-    gtk_box_append(GTK_BOX(page), quit_btn);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(companion_group),
+                              general_action_row("Quit",
+                                                 "Close the Linux companion app.",
+                                                 quit_btn));
 
     gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
     return scrolled;
@@ -405,11 +400,11 @@ static void general_refresh(void) {
     gtk_label_set_text(GTK_LABEL(gen_status_label), dm.headline ? dm.headline : "—");
     gtk_label_set_text(GTK_LABEL(gen_runtime_label), dm.runtime_label ? dm.runtime_label : "—");
 
-    if (dm.service_context_notice) {
-        gtk_label_set_text(GTK_LABEL(gen_service_notice_label), dm.service_context_notice);
-        gtk_widget_set_visible(gen_service_notice_label, TRUE);
+    if (dm.service_context_notice && gen_service_notice_row && ADW_IS_ACTION_ROW(gen_service_notice_row)) {
+        adw_action_row_set_subtitle(ADW_ACTION_ROW(gen_service_notice_row), dm.service_context_notice);
+        gtk_widget_set_visible(gen_service_notice_row, TRUE);
     } else {
-        gtk_widget_set_visible(gen_service_notice_label, FALSE);
+        gtk_widget_set_visible(gen_service_notice_row, FALSE);
     }
 
     GatewayConfig *cfg = gateway_client_get_config();
@@ -469,11 +464,11 @@ static void general_refresh(void) {
 static void general_destroy(void) {
     gen_status_label = NULL;
     gen_runtime_label = NULL;
-    gen_service_notice_label = NULL;
-    ui_dropdown_detach_model(gen_connection_mode_dropdown, (gpointer *)&gen_connection_mode_dropdown_model);
+    gen_service_notice_row = NULL;
+    ui_combo_row_detach_model(gen_connection_mode_dropdown, (gpointer *)&gen_connection_mode_dropdown_model);
     gen_connection_mode_dropdown = NULL;
     gen_connection_mode_dropdown_model = NULL;
-    gen_connection_mode_detail_label = NULL;
+    gen_connection_mode_detail_row = NULL;
     gen_connection_mode_programmatic_change = FALSE;
     gen_endpoint_label = NULL;
     gen_version_label = NULL;


### PR DESCRIPTION
Refine the Linux companion settings experience to better match the structure and product quality of the macOS app while preserving Linux-specific operator workflows.

Update About to present real product identity with app version, git/build metadata, structured links, a Linux updates note, and gateway version context.

Migrate General to a grouped preferences-style layout using AdwPreferencesPage, AdwPreferencesGroup, and AdwComboRow while preserving existing behavior for connection mode, dashboard launch, service control, path reveal, onboarding rerun, and quit.

Reorganize Config into clearer Status, File, Provider & Model, and Raw Config (Advanced) sections. Split
provider/model readiness into structured fact rows, improve validation feedback, and keep advanced JSON editing intact.

Guard optional section refresh callbacks before invoking them so sections without a refresh hook can be activated safely.