### PR TITLE
shell(linux): formalize extras sidebar groups (#106)

### DIFF
--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -151,6 +151,24 @@ static GtkWidget* build_sidebar_separator_row(void) {
     return row;
 }
 
+static GtkWidget* build_sidebar_heading_row(const char *title) {
+    GtkWidget *label = gtk_label_new(title);
+    gtk_widget_add_css_class(label, "dim-label");
+    gtk_label_set_xalign(GTK_LABEL(label), 0.0);
+    gtk_widget_set_margin_start(label, 16);
+    gtk_widget_set_margin_end(label, 8);
+    gtk_widget_set_margin_top(label, 8);
+    gtk_widget_set_margin_bottom(label, 4);
+
+    GtkWidget *row = gtk_list_box_row_new();
+    gtk_list_box_row_set_selectable(GTK_LIST_BOX_ROW(row), FALSE);
+    gtk_list_box_row_set_activatable(GTK_LIST_BOX_ROW(row), FALSE);
+    gtk_widget_set_focusable(row, FALSE);
+    gtk_list_box_row_set_child(GTK_LIST_BOX_ROW(row), label);
+
+    return row;
+}
+
 static GtkWidget* build_sidebar(void) {
     GtkWidget *sidebar_shell = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
@@ -175,8 +193,19 @@ static GtkWidget* build_sidebar(void) {
         if (section == SECTION_DEBUG && !shell_sections_debug_pane_enabled()) continue;
 
         if (have_previous_group && previous_group != entry->group) {
-            GtkWidget *separator_row = build_sidebar_separator_row();
-            gtk_list_box_append(GTK_LIST_BOX(sidebar_list), separator_row);
+            if (previous_group == SHELL_SECTION_GROUP_PARITY) {
+                GtkWidget *separator_row = build_sidebar_separator_row();
+                gtk_list_box_append(GTK_LIST_BOX(sidebar_list), separator_row);
+            }
+        }
+
+        if ((!have_previous_group || previous_group != entry->group)
+            && entry->group != SHELL_SECTION_GROUP_PARITY) {
+            const char *heading = shell_sections_group_heading(entry->group);
+            if (heading && heading[0] != '\0') {
+                GtkWidget *heading_row = build_sidebar_heading_row(heading);
+                gtk_list_box_append(GTK_LIST_BOX(sidebar_list), heading_row);
+            }
         }
 
         GtkWidget *row_content = build_sidebar_row(section);

--- a/apps/linux/src/shell_sections.c
+++ b/apps/linux/src/shell_sections.c
@@ -61,14 +61,14 @@ static const ShellSectionDisplayEntry section_display_order[] = {
     { SECTION_CRON,         SHELL_SECTION_GROUP_PARITY },
     { SECTION_SKILLS,       SHELL_SECTION_GROUP_PARITY },
     { SECTION_ABOUT,        SHELL_SECTION_GROUP_PARITY },
-    { SECTION_AGENTS,       SHELL_SECTION_GROUP_EXTRAS },
-    { SECTION_USAGE,        SHELL_SECTION_GROUP_EXTRAS },
-    { SECTION_WORKFLOWS,    SHELL_SECTION_GROUP_EXTRAS },
-    { SECTION_CONTROL_ROOM, SHELL_SECTION_GROUP_EXTRAS },
-    { SECTION_ENVIRONMENT,  SHELL_SECTION_GROUP_EXTRAS },
-    { SECTION_DIAGNOSTICS,  SHELL_SECTION_GROUP_EXTRAS },
-    { SECTION_LOGS,         SHELL_SECTION_GROUP_EXTRAS },
-    { SECTION_DEBUG,        SHELL_SECTION_GROUP_EXTRAS },
+    { SECTION_AGENTS,       SHELL_SECTION_GROUP_EXTRAS_OPERATIONAL },
+    { SECTION_USAGE,        SHELL_SECTION_GROUP_EXTRAS_OPERATIONAL },
+    { SECTION_WORKFLOWS,    SHELL_SECTION_GROUP_EXTRAS_OPERATIONAL },
+    { SECTION_CONTROL_ROOM, SHELL_SECTION_GROUP_EXTRAS_OPERATIONAL },
+    { SECTION_ENVIRONMENT,  SHELL_SECTION_GROUP_EXTRAS_DIAGNOSTIC },
+    { SECTION_DIAGNOSTICS,  SHELL_SECTION_GROUP_EXTRAS_DIAGNOSTIC },
+    { SECTION_LOGS,         SHELL_SECTION_GROUP_EXTRAS_DIAGNOSTIC },
+    { SECTION_DEBUG,        SHELL_SECTION_GROUP_EXTRAS_DEBUG },
 };
 
 gboolean shell_sections_is_embedded(AppSection section) {
@@ -85,6 +85,21 @@ const ShellSectionMeta* shell_sections_meta(AppSection section) {
     }
 
     return &section_meta[section];
+}
+
+const char* shell_sections_group_heading(ShellSectionGroup group) {
+    switch (group) {
+    case SHELL_SECTION_GROUP_PARITY:
+        return NULL;
+    case SHELL_SECTION_GROUP_EXTRAS_OPERATIONAL:
+        return "Operational";
+    case SHELL_SECTION_GROUP_EXTRAS_DIAGNOSTIC:
+        return "Diagnostics";
+    case SHELL_SECTION_GROUP_EXTRAS_DEBUG:
+        return "Developer";
+    default:
+        return NULL;
+    }
 }
 
 gsize shell_sections_display_count(void) {

--- a/apps/linux/src/shell_sections.h
+++ b/apps/linux/src/shell_sections.h
@@ -7,7 +7,9 @@
 
 typedef enum {
     SHELL_SECTION_GROUP_PARITY = 0,
-    SHELL_SECTION_GROUP_EXTRAS = 1,
+    SHELL_SECTION_GROUP_EXTRAS_OPERATIONAL = 1,
+    SHELL_SECTION_GROUP_EXTRAS_DIAGNOSTIC = 2,
+    SHELL_SECTION_GROUP_EXTRAS_DEBUG = 3,
 } ShellSectionGroup;
 
 typedef struct {
@@ -23,6 +25,7 @@ typedef struct {
 
 gboolean shell_sections_is_embedded(AppSection section);
 const ShellSectionMeta* shell_sections_meta(AppSection section);
+const char* shell_sections_group_heading(ShellSectionGroup group);
 const SectionController* shell_sections_controller(AppSection section);
 gsize shell_sections_display_count(void);
 const ShellSectionDisplayEntry* shell_sections_display_at(gsize index);

--- a/apps/linux/tests/test_shell_sections_display.c
+++ b/apps/linux/tests/test_shell_sections_display.c
@@ -28,6 +28,25 @@ DEFINE_SECTION_GETTER(section_sessions_get)
 DEFINE_SECTION_GETTER(section_cron_get)
 
 static void test_display_order_matches_expected_blocks(void) {
+    const ShellSectionGroup expected_groups[] = {
+        [SECTION_DASHBOARD] = SHELL_SECTION_GROUP_PARITY,
+        [SECTION_AGENTS] = SHELL_SECTION_GROUP_EXTRAS_OPERATIONAL,
+        [SECTION_ABOUT] = SHELL_SECTION_GROUP_PARITY,
+        [SECTION_USAGE] = SHELL_SECTION_GROUP_EXTRAS_OPERATIONAL,
+        [SECTION_GENERAL] = SHELL_SECTION_GROUP_PARITY,
+        [SECTION_CONFIG] = SHELL_SECTION_GROUP_PARITY,
+        [SECTION_CHANNELS] = SHELL_SECTION_GROUP_PARITY,
+        [SECTION_SKILLS] = SHELL_SECTION_GROUP_PARITY,
+        [SECTION_WORKFLOWS] = SHELL_SECTION_GROUP_EXTRAS_OPERATIONAL,
+        [SECTION_CONTROL_ROOM] = SHELL_SECTION_GROUP_EXTRAS_OPERATIONAL,
+        [SECTION_ENVIRONMENT] = SHELL_SECTION_GROUP_EXTRAS_DIAGNOSTIC,
+        [SECTION_DIAGNOSTICS] = SHELL_SECTION_GROUP_EXTRAS_DIAGNOSTIC,
+        [SECTION_LOGS] = SHELL_SECTION_GROUP_EXTRAS_DIAGNOSTIC,
+        [SECTION_INSTANCES] = SHELL_SECTION_GROUP_PARITY,
+        [SECTION_DEBUG] = SHELL_SECTION_GROUP_EXTRAS_DEBUG,
+        [SECTION_SESSIONS] = SHELL_SECTION_GROUP_PARITY,
+        [SECTION_CRON] = SHELL_SECTION_GROUP_PARITY,
+    };
     const AppSection expected_order[] = {
         SECTION_DASHBOARD,
         SECTION_GENERAL,
@@ -50,7 +69,6 @@ static void test_display_order_matches_expected_blocks(void) {
     g_assert_cmpuint(shell_sections_display_count(), ==, G_N_ELEMENTS(expected_order));
 
     gboolean seen[SECTION_COUNT] = {FALSE};
-    gboolean extras_started = FALSE;
     for (gsize i = 0; i < shell_sections_display_count(); i++) {
         const ShellSectionDisplayEntry *entry = shell_sections_display_at(i);
         g_assert_nonnull(entry);
@@ -59,15 +77,9 @@ static void test_display_order_matches_expected_blocks(void) {
         g_assert_false(seen[entry->section]);
         seen[entry->section] = TRUE;
 
-        if (i < 9) {
-            g_assert_cmpint(entry->group, ==, SHELL_SECTION_GROUP_PARITY);
-        } else {
-            extras_started = TRUE;
-            g_assert_cmpint(entry->group, ==, SHELL_SECTION_GROUP_EXTRAS);
-        }
+        g_assert_cmpint(entry->group, ==, expected_groups[entry->section]);
     }
 
-    g_assert_true(extras_started);
     g_assert_false(seen[SECTION_CHAT]);
     for (int i = 0; i < SECTION_COUNT; i++) {
         if (i == SECTION_CHAT) continue;
@@ -85,6 +97,13 @@ static void test_display_entries_have_controllers(void) {
         g_assert_nonnull(entry);
         g_assert_nonnull(shell_sections_controller(entry->section));
     }
+}
+
+static void test_group_heading_contract(void) {
+    g_assert_null(shell_sections_group_heading(SHELL_SECTION_GROUP_PARITY));
+    g_assert_cmpstr(shell_sections_group_heading(SHELL_SECTION_GROUP_EXTRAS_OPERATIONAL), ==, "Operational");
+    g_assert_cmpstr(shell_sections_group_heading(SHELL_SECTION_GROUP_EXTRAS_DIAGNOSTIC), ==, "Diagnostics");
+    g_assert_cmpstr(shell_sections_group_heading(SHELL_SECTION_GROUP_EXTRAS_DEBUG), ==, "Developer");
 }
 
 static void test_debug_pane_gate(void) {
@@ -118,6 +137,8 @@ int main(int argc, char **argv) {
                     test_display_order_out_of_range_returns_null);
     g_test_add_func("/shell_sections_display/entries_have_controllers",
                     test_display_entries_have_controllers);
+    g_test_add_func("/shell_sections_display/group_heading_contract",
+                    test_group_heading_contract);
     g_test_add_func("/shell_sections_display/debug_pane_gate",
                     test_debug_pane_gate);
 


### PR DESCRIPTION
Refine the Linux companion sidebar metadata so Linux-only sections are grouped by purpose instead of sharing a single flat extras bucket.

Expand `ShellSectionGroup` to model operational,
diagnostic, and developer extras explicitly, re-tag the existing extras entries in `section_display_order`, and add a registry-owned `shell_sections_group_heading()` helper so sidebar grouping remains metadata-driven.

Update the sidebar renderer to insert one separator at the parity-to-extras boundary and emit lightweight heading rows for extras sub-groups while preserving the existing `OPENCLAW_DEBUG_PANE` gate for Debug.

Update tests to assert per-section group membership and the heading-label contract instead of relying on positional “first parity, then extras” assumptions.