### PR TITLE
linux: consolidate shell visibility and controller contracts (#108)

### DIFF
--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -83,23 +83,6 @@ static void on_shell_pairing_button_clicked(GtkButton *button, gpointer user_dat
 
 /* ── Sidebar construction ── */
 
-/*
- * Returns TRUE when a given AppSection should appear in the main settings
- * window. Sections whose UX lives in their own dedicated window (like
- * Chat, which ships as a standalone AdwApplicationWindow) are filtered
- * out here so the main window stays focused on management / diagnostics.
- */
-static gboolean section_is_embedded_in_main_window(AppSection section) {
-    return shell_sections_is_embedded(section);
-}
-
-/*
- * Pure section-tag encode/decode helpers live in
- * `app_window_section_tag.c` so a headless test can link them without
- * dragging the full GTK/Adwaita main-window TU. See that file for the
- * NULL-collision rationale (SECTION_DASHBOARD == 0).
- */
-
 static GtkWidget* build_sidebar_row(AppSection section) {
     const ShellSectionMeta *meta = shell_sections_meta(section);
 
@@ -189,8 +172,7 @@ static GtkWidget* build_sidebar(void) {
         if (!entry) continue;
 
         AppSection section = entry->section;
-        if (!section_is_embedded_in_main_window(section)) continue;
-        if (section == SECTION_DEBUG && !shell_sections_debug_pane_enabled()) continue;
+        if (!shell_sections_is_visible(section)) continue;
 
         if (have_previous_group && previous_group != entry->group) {
             if (previous_group == SHELL_SECTION_GROUP_PARITY) {
@@ -431,24 +413,13 @@ static GtkWidget* build_content_stack(void) {
         if (!entry) continue;
 
         AppSection section = entry->section;
-        if (!section_is_embedded_in_main_window(section)) continue;
-        if (section == SECTION_DEBUG && !shell_sections_debug_pane_enabled()) continue;
+        if (!shell_sections_is_visible(section)) continue;
 
-        section_controllers[section] = shell_sections_controller(section);
-    }
+        const SectionController *controller = shell_sections_controller(section);
+        section_controllers[section] = controller;
 
-    for (gsize i = 0; i < shell_sections_display_count(); i++) {
-        const ShellSectionDisplayEntry *entry = shell_sections_display_at(i);
-        if (!entry) continue;
-
-        AppSection section = entry->section;
-        if (!section_is_embedded_in_main_window(section)) continue;
-        if (section == SECTION_DEBUG && !shell_sections_debug_pane_enabled()) continue;
-
-        GtkWidget *page;
-        if (section_controllers[section]) {
-            page = section_controllers[section]->build();
-        } else {
+        GtkWidget *page = section_controller_build_safe(controller);
+        if (!page) {
             page = build_placeholder_section(section);
         }
         gtk_stack_add_named(GTK_STACK(content_stack), page, shell_sections_meta(section)->id);
@@ -460,16 +431,14 @@ static GtkWidget* build_content_stack(void) {
 /* ── Sidebar row activation ── */
 
 static void refresh_active_section(AppSection section) {
-    if (section >= 0 && section < SECTION_COUNT && section_controllers[section] && section_controllers[section]->refresh) {
-        section_controllers[section]->refresh();
+    if (section >= 0 && section < SECTION_COUNT) {
+        section_controller_refresh_safe(section_controllers[section]);
     }
 }
 
 static void invalidate_all_rpc_sections(void) {
     for (int i = 0; i < SECTION_COUNT; i++) {
-        if (section_controllers[i] && section_controllers[i]->invalidate) {
-            section_controllers[i]->invalidate();
-        }
+        section_controller_invalidate_safe(section_controllers[i]);
     }
 }
 
@@ -553,9 +522,7 @@ static gboolean on_refresh_tick(gpointer user_data) {
 
 static void destroy_all_section_controllers(void) {
     for (int i = 0; i < SECTION_COUNT; i++) {
-        if (section_controllers[i] && section_controllers[i]->destroy) {
-            section_controllers[i]->destroy();
-        }
+        section_controller_destroy_safe(section_controllers[i]);
     }
 }
 
@@ -681,17 +648,18 @@ void app_window_show(void) {
 
 void app_window_navigate_to(AppSection section) {
     if (section < 0 || section >= SECTION_COUNT) return;
-    if (section == SECTION_DEBUG && !shell_sections_debug_pane_enabled()) return;
 
     /* Sections that live in their own window (Chat) must not drag the
      * main window open; route them to the dedicated surface instead. */
-    if (!section_is_embedded_in_main_window(section)) {
+    if (!shell_sections_is_embedded(section)) {
         if (section == SECTION_CHAT) {
             chat_window_show();
         }
         return;
     }
 
+    if (!shell_sections_is_visible(section)) return;
+ 
     app_window_show();
 
     active_section = section;

--- a/apps/linux/src/section_controller.h
+++ b/apps/linux/src/section_controller.h
@@ -34,6 +34,36 @@ typedef struct {
     void (*invalidate)(void);
 } SectionController;
 
+static inline gboolean section_controller_has_required_callbacks(const SectionController *controller) {
+    return controller
+        && controller->build
+        && controller->refresh
+        && controller->destroy
+        && controller->invalidate;
+}
+
+static inline GtkWidget* section_controller_build_safe(const SectionController *controller) {
+    return (controller && controller->build) ? controller->build() : NULL;
+}
+
+static inline void section_controller_refresh_safe(const SectionController *controller) {
+    if (controller && controller->refresh) {
+        controller->refresh();
+    }
+}
+
+static inline void section_controller_destroy_safe(const SectionController *controller) {
+    if (controller && controller->destroy) {
+        controller->destroy();
+    }
+}
+
+static inline void section_controller_invalidate_safe(const SectionController *controller) {
+    if (controller && controller->invalidate) {
+        controller->invalidate();
+    }
+}
+
 /* ── Shared freshness helpers ────────────────────────────────────── */
 
 static inline gboolean section_is_stale(gint64 *last_fetch_us) {

--- a/apps/linux/src/shell_sections.c
+++ b/apps/linux/src/shell_sections.c
@@ -79,6 +79,18 @@ gboolean shell_sections_is_embedded(AppSection section) {
     return section != SECTION_CHAT;
 }
 
+gboolean shell_sections_is_visible(AppSection section) {
+    if (!shell_sections_is_embedded(section)) {
+        return FALSE;
+    }
+
+    if (section == SECTION_DEBUG && !shell_sections_debug_pane_enabled()) {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
 const ShellSectionMeta* shell_sections_meta(AppSection section) {
     if (section < 0 || section >= SECTION_COUNT) {
         return NULL;

--- a/apps/linux/src/shell_sections.h
+++ b/apps/linux/src/shell_sections.h
@@ -24,6 +24,7 @@ typedef struct {
 } ShellSectionDisplayEntry;
 
 gboolean shell_sections_is_embedded(AppSection section);
+gboolean shell_sections_is_visible(AppSection section);
 const ShellSectionMeta* shell_sections_meta(AppSection section);
 const char* shell_sections_group_heading(ShellSectionGroup group);
 const SectionController* shell_sections_controller(AppSection section);

--- a/apps/linux/tests/test_shell_sections.c
+++ b/apps/linux/tests/test_shell_sections.c
@@ -15,7 +15,25 @@
 #include "../src/section_controller.h"
 #include "../src/shell_sections.h"
 
-static const SectionController dummy_controller = {0};
+static GtkWidget* dummy_build(void) {
+    return NULL;
+}
+
+static void dummy_refresh(void) {
+}
+
+static void dummy_destroy(void) {
+}
+
+static void dummy_invalidate(void) {
+}
+
+static const SectionController dummy_controller = {
+    .build = dummy_build,
+    .refresh = dummy_refresh,
+    .destroy = dummy_destroy,
+    .invalidate = dummy_invalidate,
+};
 
 #define DEFINE_SECTION_GETTER(name) \
     const SectionController* name(void) { return &dummy_controller; }
@@ -42,36 +60,100 @@ static void test_embedded_mapping(void) {
     g_assert_true(shell_sections_is_embedded(SECTION_DASHBOARD));
     g_assert_false(shell_sections_is_embedded(SECTION_CHAT));
     g_assert_true(shell_sections_is_embedded(SECTION_ABOUT));
+    g_assert_false(shell_sections_is_embedded((AppSection)-1));
+    g_assert_false(shell_sections_is_embedded(SECTION_COUNT));
 }
 
 static void test_metadata_contract(void) {
-    const ShellSectionMeta *dashboard = shell_sections_meta(SECTION_DASHBOARD);
-    const ShellSectionMeta *diagnostics = shell_sections_meta(SECTION_DIAGNOSTICS);
-    const ShellSectionMeta *about = shell_sections_meta(SECTION_ABOUT);
+    for (int i = 0; i < SECTION_COUNT; i++) {
+        const ShellSectionMeta *meta = shell_sections_meta((AppSection)i);
+        g_assert_nonnull(meta);
+        g_assert_nonnull(meta->id);
+        g_assert_true(meta->id[0] != '\0');
+        g_assert_nonnull(meta->title);
+        g_assert_true(meta->title[0] != '\0');
+        g_assert_nonnull(meta->icon_name);
+        g_assert_true(meta->icon_name[0] != '\0');
+    }
 
-    g_assert_nonnull(dashboard);
-    g_assert_cmpstr(dashboard->id, ==, "dashboard");
-    g_assert_cmpstr(dashboard->title, ==, "Dashboard");
-
-    g_assert_nonnull(diagnostics);
-    g_assert_cmpstr(diagnostics->id, ==, "diagnostics");
-    g_assert_cmpstr(diagnostics->icon_name, ==, "utilities-system-monitor-symbolic");
-
-    g_assert_nonnull(about);
-    g_assert_cmpstr(about->id, ==, "about");
+    g_assert_null(shell_sections_meta((AppSection)-1));
+    g_assert_null(shell_sections_meta(SECTION_COUNT));
 }
 
 static void test_controller_lookup(void) {
-    g_assert_nonnull(shell_sections_controller(SECTION_DASHBOARD));
-    g_assert_nonnull(shell_sections_controller(SECTION_GENERAL));
-    g_assert_nonnull(shell_sections_controller(SECTION_CONFIG));
-    g_assert_nonnull(shell_sections_controller(SECTION_DIAGNOSTICS));
-    g_assert_nonnull(shell_sections_controller(SECTION_ENVIRONMENT));
-    g_assert_nonnull(shell_sections_controller(SECTION_DEBUG));
-    g_assert_nonnull(shell_sections_controller(SECTION_AGENTS));
-    g_assert_nonnull(shell_sections_controller(SECTION_INSTANCES));
-    g_assert_nonnull(shell_sections_controller(SECTION_ABOUT));
-    g_assert_null(shell_sections_controller(SECTION_CHAT));
+    for (int i = 0; i < SECTION_COUNT; i++) {
+        AppSection section = (AppSection)i;
+        const SectionController *controller = shell_sections_controller(section);
+
+        if (section == SECTION_CHAT) {
+            g_assert_null(controller);
+            continue;
+        }
+
+        g_assert_nonnull(controller);
+        g_assert_true(section_controller_has_required_callbacks(controller));
+    }
+
+    g_assert_null(shell_sections_controller((AppSection)-1));
+    g_assert_null(shell_sections_controller(SECTION_COUNT));
+}
+
+static void test_display_registry_is_complete_and_unique(void) {
+    gboolean seen[SECTION_COUNT] = {FALSE};
+
+    for (gsize i = 0; i < shell_sections_display_count(); i++) {
+        const ShellSectionDisplayEntry *entry = shell_sections_display_at(i);
+        g_assert_nonnull(entry);
+        g_assert_true(shell_sections_is_embedded(entry->section));
+        g_assert_false(seen[entry->section]);
+        seen[entry->section] = TRUE;
+
+        const ShellSectionMeta *meta = shell_sections_meta(entry->section);
+        const SectionController *controller = shell_sections_controller(entry->section);
+
+        g_assert_nonnull(meta);
+        g_assert_nonnull(meta->id);
+        g_assert_true(meta->id[0] != '\0');
+        g_assert_nonnull(meta->title);
+        g_assert_true(meta->title[0] != '\0');
+        g_assert_nonnull(meta->icon_name);
+        g_assert_true(meta->icon_name[0] != '\0');
+        g_assert_nonnull(controller);
+        g_assert_true(section_controller_has_required_callbacks(controller));
+    }
+
+    g_assert_false(seen[SECTION_CHAT]);
+    for (int i = 0; i < SECTION_COUNT; i++) {
+        if (i == SECTION_CHAT) continue;
+        g_assert_true(seen[i]);
+    }
+}
+
+static void test_visibility_contract(void) {
+    g_unsetenv("OPENCLAW_DEBUG_PANE");
+
+    for (int i = 0; i < SECTION_COUNT; i++) {
+        AppSection section = (AppSection)i;
+        if (section == SECTION_CHAT || section == SECTION_DEBUG) {
+            g_assert_false(shell_sections_is_visible(section));
+        } else {
+            g_assert_true(shell_sections_is_visible(section));
+        }
+    }
+
+    g_setenv("OPENCLAW_DEBUG_PANE", "1", TRUE);
+    for (int i = 0; i < SECTION_COUNT; i++) {
+        AppSection section = (AppSection)i;
+        if (section == SECTION_CHAT) {
+            g_assert_false(shell_sections_is_visible(section));
+        } else {
+            g_assert_true(shell_sections_is_visible(section));
+        }
+    }
+
+    g_unsetenv("OPENCLAW_DEBUG_PANE");
+    g_assert_false(shell_sections_is_visible((AppSection)-1));
+    g_assert_false(shell_sections_is_visible(SECTION_COUNT));
 }
 
 int main(int argc, char **argv) {
@@ -80,6 +162,9 @@ int main(int argc, char **argv) {
     g_test_add_func("/shell_sections/embedded_mapping", test_embedded_mapping);
     g_test_add_func("/shell_sections/metadata_contract", test_metadata_contract);
     g_test_add_func("/shell_sections/controller_lookup", test_controller_lookup);
+    g_test_add_func("/shell_sections/display_registry_is_complete_and_unique",
+                    test_display_registry_is_complete_and_unique);
+    g_test_add_func("/shell_sections/visibility_contract", test_visibility_contract);
 
     return g_test_run();
 }

--- a/apps/linux/tests/test_shell_sections_display.c
+++ b/apps/linux/tests/test_shell_sections_display.c
@@ -4,7 +4,25 @@
 #include "../src/section_controller.h"
 #include "../src/shell_sections.h"
 
-static const SectionController dummy_controller = {0};
+static GtkWidget* dummy_build(void) {
+    return NULL;
+}
+
+static void dummy_refresh(void) {
+}
+
+static void dummy_destroy(void) {
+}
+
+static void dummy_invalidate(void) {
+}
+
+static const SectionController dummy_controller = {
+    .build = dummy_build,
+    .refresh = dummy_refresh,
+    .destroy = dummy_destroy,
+    .invalidate = dummy_invalidate,
+};
 
 #define DEFINE_SECTION_GETTER(name) \
     const SectionController* name(void) { return &dummy_controller; }
@@ -95,7 +113,8 @@ static void test_display_entries_have_controllers(void) {
     for (gsize i = 0; i < shell_sections_display_count(); i++) {
         const ShellSectionDisplayEntry *entry = shell_sections_display_at(i);
         g_assert_nonnull(entry);
-        g_assert_nonnull(shell_sections_controller(entry->section));
+        g_assert_true(section_controller_has_required_callbacks(
+            shell_sections_controller(entry->section)));
     }
 }
 


### PR DESCRIPTION
Centralize Linux companion shell visibility policy in `shell_sections` and remove app_window-local Debug gating.

Add `shell_sections_is_visible()`, update `app_window` to use shared controller-safe helpers, and collapse
content-stack construction into a single pass so the shell host no longer owns section-specific visibility logic.

Strengthen shell test coverage by upgrading dummy
controllers to a full no-op contract and adding registry invariant checks for metadata completeness, controller completeness, display coverage and uniqueness, and visibility behavior.

No user-facing shell reorder or feature expansion is introduced.
