### PR TITLE
fix(linux): align Debug config reveal with runtime paths (#112)

### DIFF
--- a/apps/linux/src/section_debug.c
+++ b/apps/linux/src/section_debug.c
@@ -15,6 +15,7 @@
 
 #include "gateway_client.h"
 #include "product_coordinator.h"
+#include "runtime_paths.h"
 #include "state.h"
 
 extern void systemd_restart_gateway(void);
@@ -50,14 +51,30 @@ static void on_dbg_reveal_config(GtkButton *button, gpointer user_data) {
     (void)button;
     (void)user_data;
 
-    GatewayConfig *cfg = gateway_client_get_config();
-    if (cfg && cfg->config_path) {
-        g_autofree gchar *dir = g_path_get_dirname(cfg->config_path);
-        g_autofree gchar *uri = g_filename_to_uri(dir, NULL, NULL);
-        if (uri) {
-            g_app_info_launch_default_for_uri(uri, NULL, NULL);
-        }
+    g_autofree gchar *uri = section_debug_test_build_reveal_config_uri();
+    if (uri) {
+        g_app_info_launch_default_for_uri(uri, NULL, NULL);
     }
+}
+
+gchar* section_debug_test_build_reveal_config_uri(void) {
+    g_autofree gchar *profile = NULL;
+    g_autofree gchar *state_dir = NULL;
+    g_autofree gchar *config_path = NULL;
+    systemd_get_runtime_context(&profile, &state_dir, &config_path);
+
+    GatewayConfig *cfg = gateway_client_get_config();
+    RuntimeEffectivePaths effective_paths = {0};
+    runtime_effective_paths_resolve(cfg, profile, state_dir, config_path, &effective_paths);
+
+    gchar *uri = NULL;
+    if (effective_paths.effective_config_path) {
+        g_autofree gchar *dir = g_path_get_dirname(effective_paths.effective_config_path);
+        uri = g_filename_to_uri(dir, NULL, NULL);
+    }
+
+    runtime_effective_paths_clear(&effective_paths);
+    return uri;
 }
 
 static void on_dbg_copy_journal_cmd(GtkButton *button, gpointer user_data) {

--- a/apps/linux/src/section_debug.h
+++ b/apps/linux/src/section_debug.h
@@ -4,3 +4,4 @@
 
 const SectionController* section_debug_get(void);
 gboolean section_debug_test_has_action_label(const gchar *label);
+gchar* section_debug_test_build_reveal_config_uri(void);

--- a/apps/linux/tests/test_section_debug.c
+++ b/apps/linux/tests/test_section_debug.c
@@ -2,15 +2,62 @@
 
 #include "../src/section_debug.h"
 #include "../src/gateway_config.h"
+#include "../src/runtime_paths.h"
 #include "../src/state.h"
 
 void gateway_client_refresh(void) {}
+static GatewayConfig stub_cfg = {0};
+static gchar *stub_runtime_profile = NULL;
+static gchar *stub_runtime_state_dir = NULL;
+static gchar *stub_runtime_config_path = NULL;
+static gchar *stub_effective_config_path = NULL;
+
+static void reset_debug_path_stubs(void) {
+    g_clear_pointer(&stub_cfg.config_path, g_free);
+    g_clear_pointer(&stub_runtime_profile, g_free);
+    g_clear_pointer(&stub_runtime_state_dir, g_free);
+    g_clear_pointer(&stub_runtime_config_path, g_free);
+    g_clear_pointer(&stub_effective_config_path, g_free);
+}
+
 GatewayConfig* gateway_client_get_config(void) {
-    return NULL;
+    return stub_cfg.config_path ? &stub_cfg : NULL;
 }
 void product_coordinator_request_rerun_onboarding(void) {}
 const gchar* systemd_get_canonical_unit_name(void) {
     return "openclaw-gateway.service";
+}
+void systemd_get_runtime_context(gchar **out_profile,
+                                 gchar **out_state_dir,
+                                 gchar **out_config_path) {
+    if (out_profile) {
+        *out_profile = g_strdup(stub_runtime_profile);
+    }
+    if (out_state_dir) {
+        *out_state_dir = g_strdup(stub_runtime_state_dir);
+    }
+    if (out_config_path) {
+        *out_config_path = g_strdup(stub_runtime_config_path);
+    }
+}
+void runtime_effective_paths_resolve(const GatewayConfig *loaded_config,
+                                     const gchar *profile,
+                                     const gchar *runtime_state_dir,
+                                     const gchar *runtime_config_path,
+                                     RuntimeEffectivePaths *out) {
+    (void)loaded_config;
+    (void)profile;
+    (void)runtime_state_dir;
+    (void)runtime_config_path;
+    out->effective_config_path = g_strdup(stub_effective_config_path);
+    out->effective_state_dir = NULL;
+}
+void runtime_effective_paths_clear(RuntimeEffectivePaths *paths) {
+    if (!paths) {
+        return;
+    }
+    g_clear_pointer(&paths->effective_config_path, g_free);
+    g_clear_pointer(&paths->effective_state_dir, g_free);
 }
 SystemdState* state_get_systemd(void) {
     static SystemdState sys = {0};
@@ -27,11 +74,47 @@ static void test_debug_actions_exclude_duplicate_diagnostics_affordance(void) {
     g_assert_false(section_debug_test_has_action_label("Copy Diagnostics"));
 }
 
+static void test_debug_reveal_config_uri_uses_effective_runtime_path(void) {
+    reset_debug_path_stubs();
+    stub_cfg.config_path = g_strdup("/tmp/openclaw-loaded/openclaw.json");
+    stub_runtime_profile = g_strdup("default");
+    stub_runtime_state_dir = g_strdup("/tmp/openclaw-state");
+    stub_runtime_config_path = g_strdup("/tmp/openclaw-runtime/openclaw.json");
+    stub_effective_config_path = g_strdup("/tmp/openclaw-effective/openclaw.json");
+
+    g_autofree gchar *uri = section_debug_test_build_reveal_config_uri();
+    g_autofree gchar *expected = g_filename_to_uri("/tmp/openclaw-effective", NULL, NULL);
+
+    g_assert_cmpstr(uri, ==, expected);
+
+    reset_debug_path_stubs();
+}
+
+static void test_debug_reveal_config_uri_returns_null_without_effective_path(void) {
+    reset_debug_path_stubs();
+    stub_cfg.config_path = g_strdup("/tmp/openclaw-loaded/openclaw.json");
+    stub_runtime_profile = g_strdup("default");
+    stub_runtime_state_dir = g_strdup("/tmp/openclaw-state");
+    stub_runtime_config_path = g_strdup("/tmp/openclaw-runtime/openclaw.json");
+
+    g_autofree gchar *uri = section_debug_test_build_reveal_config_uri();
+
+    g_assert_null(uri);
+
+    reset_debug_path_stubs();
+}
+
 int main(int argc, char **argv) {
     g_test_init(&argc, &argv, NULL);
 
     g_test_add_func("/section_debug/actions_exclude_duplicate_diagnostics_affordance",
                     test_debug_actions_exclude_duplicate_diagnostics_affordance);
+    g_test_add_func("/section_debug/reveal_config_uri_uses_effective_runtime_path",
+                    test_debug_reveal_config_uri_uses_effective_runtime_path);
+    g_test_add_func("/section_debug/reveal_config_uri_returns_null_without_effective_path",
+                    test_debug_reveal_config_uri_returns_null_without_effective_path);
 
-    return g_test_run();
+    int result = g_test_run();
+    reset_debug_path_stubs();
+    return result;
 }


### PR DESCRIPTION
Route the Debug pane’s `Reveal Config Folder` action through the canonical Linux runtime-path contract instead of relying only on `gateway_client_get_config()->config_path`.

Add a focused test seam for building the reveal-config URI and extend `test_section_debug.c` to verify that Debug uses the effective config path and returns `NULL` when no effective config path can be derived.

This keeps Debug consistent with General, Environment, Diagnostics, and onboarding path behavior.