### PR TITLE
linux: unify reveal paths and add controller audit (#114)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -66,6 +66,7 @@ sources = [
   'src/diagnostics.c',
   'src/display_model.c',
   'src/runtime_paths.c',
+  'src/runtime_reveal.c',
   'src/session_filter.c',
   'src/markdown_render.c',
   'src/chat_blocks.c',
@@ -104,6 +105,16 @@ executable('openclaw-linux',
   sources,
   dependencies : [gtk4_dep, adwaita_dep, json_glib_dep, soup_dep, gio_dep, gio_unix_dep, sodium_dep],
   install : true)
+
+# Production translation units minus the app entrypoint, for tests that
+# need to link the real companion code (e.g. the section-controller
+# contract audit) and provide their own main().
+app_core_sources = []
+foreach src : sources
+  if src != 'src/main.c'
+    app_core_sources += src
+  endif
+endforeach
 
 # Tray helper (GTK3 + Ayatana AppIndicator)
 # Installed as a private implementation detail into libexec
@@ -177,9 +188,21 @@ test_shell_sections_display_exe = executable('test_shell_sections_display',
 test('shell_sections_display', test_shell_sections_display_exe)
 
 test_section_debug_exe = executable('test_section_debug',
-  ['tests/test_section_debug.c', 'src/section_debug.c'],
+  ['tests/test_section_debug.c', 'src/section_debug.c', 'src/runtime_reveal.c'],
   dependencies : [glib_dep, gio_dep, gtk4_dep, adwaita_dep])
 test('section_debug', test_section_debug_exe)
+
+# Real-controller contract audit (Tranche E.3). Links the production
+# section_*.c translation units through app_core_sources so every
+# AppSection's SectionController is validated against the full
+# required-callback contract. No GTK display is required: the test only
+# inspects the static controller tables and never invokes build/refresh/
+# destroy/invalidate. See tests/test_section_controllers_contract.c for
+# the audit rationale.
+test_section_controllers_contract_exe = executable('test_section_controllers_contract',
+  ['tests/test_section_controllers_contract.c'] + app_core_sources,
+  dependencies : [gtk4_dep, adwaita_dep, json_glib_dep, soup_dep, gio_dep, gio_unix_dep, sodium_dep])
+test('section_controllers_contract', test_section_controllers_contract_exe)
 
 test_onboarding_controller_exe = executable('test_onboarding_controller',
   ['tests/test_onboarding_controller.c', 'src/onboarding.c', 'src/test_seams.c'],

--- a/apps/linux/src/runtime_reveal.c
+++ b/apps/linux/src/runtime_reveal.c
@@ -1,0 +1,59 @@
+/*
+ * runtime_reveal.c
+ *
+ * Implementation of shared reveal URI builders for the Linux companion
+ * app. Kept separate from `runtime_paths.c` so the pure path-resolution
+ * contract remains linkable by tests that do not provide systemd /
+ * gateway-client stubs.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "runtime_reveal.h"
+
+#include "gateway_client.h"
+#include "runtime_paths.h"
+#include "state.h"
+
+static gchar* reveal_build_dir_uri(const gchar *path) {
+    if (!path || path[0] == '\0') {
+        return NULL;
+    }
+    return g_filename_to_uri(path, NULL, NULL);
+}
+
+gchar* runtime_reveal_build_config_dir_uri(void) {
+    g_autofree gchar *profile = NULL;
+    g_autofree gchar *state_dir = NULL;
+    g_autofree gchar *config_path = NULL;
+    systemd_get_runtime_context(&profile, &state_dir, &config_path);
+
+    GatewayConfig *cfg = gateway_client_get_config();
+    RuntimeEffectivePaths effective_paths = {0};
+    runtime_effective_paths_resolve(cfg, profile, state_dir, config_path, &effective_paths);
+
+    gchar *uri = NULL;
+    if (effective_paths.effective_config_path) {
+        g_autofree gchar *dir = g_path_get_dirname(effective_paths.effective_config_path);
+        uri = reveal_build_dir_uri(dir);
+    }
+
+    runtime_effective_paths_clear(&effective_paths);
+    return uri;
+}
+
+gchar* runtime_reveal_build_state_dir_uri(void) {
+    g_autofree gchar *profile = NULL;
+    g_autofree gchar *state_dir = NULL;
+    g_autofree gchar *config_path = NULL;
+    systemd_get_runtime_context(&profile, &state_dir, &config_path);
+
+    GatewayConfig *cfg = gateway_client_get_config();
+    RuntimeEffectivePaths effective_paths = {0};
+    runtime_effective_paths_resolve(cfg, profile, state_dir, config_path, &effective_paths);
+
+    gchar *uri = reveal_build_dir_uri(effective_paths.effective_state_dir);
+
+    runtime_effective_paths_clear(&effective_paths);
+    return uri;
+}

--- a/apps/linux/src/runtime_reveal.h
+++ b/apps/linux/src/runtime_reveal.h
@@ -1,0 +1,37 @@
+/*
+ * runtime_reveal.h
+ *
+ * Shared "reveal" URI builders for the Linux companion app.
+ *
+ * Every main-window section that exposes a "Reveal Config Folder" or
+ * "Reveal State Folder" affordance must resolve the *effective* runtime
+ * paths via the same precedence contract as `runtime_paths.h`. This
+ * module composes the live runtime context (systemd profile/state
+ * directory/config path) and the currently loaded gateway config into a
+ * single call that returns a `file://` URI ready for
+ * `g_app_info_launch_default_for_uri`.
+ *
+ * Kept in a separate translation unit so `runtime_paths.c` stays a pure
+ * leaf module that headless tests can link without stubbing systemd /
+ * gateway-client seams.
+ *
+ * Ownership contract: returned URIs are newly allocated and must be
+ * freed by the caller (g_free).
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#pragma once
+
+#include <glib.h>
+
+/* Builds a file:// URI pointing to the directory that contains the
+ * effective config path (loaded gateway config path, else resolved
+ * runtime config path, else raw runtime config path), or NULL if no
+ * effective config path can be determined. */
+gchar* runtime_reveal_build_config_dir_uri(void);
+
+/* Builds a file:// URI pointing to the effective state directory
+ * (runtime state dir, else dirname(effective config path)), or NULL
+ * if no effective state directory can be determined. */
+gchar* runtime_reveal_build_state_dir_uri(void);

--- a/apps/linux/src/section_adw_helpers.h
+++ b/apps/linux/src/section_adw_helpers.h
@@ -1,0 +1,44 @@
+/*
+ * section_adw_helpers.h
+ *
+ * Shared libadwaita-backed row helpers for main-window sections.
+ *
+ * These helpers live in their own header so that the core section
+ * controller contract (`section_controller.h`) can stay adwaita-free
+ * and be included by headless registry tests that do not link
+ * libadwaita. Sections that render AdwPreferencesPage content and
+ * need consistent key/value rows should include this header instead
+ * of duplicating row-building code locally.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#pragma once
+
+#include <adwaita.h>
+#include <gtk/gtk.h>
+
+/* Build a libadwaita key/value info row for preference pages.
+ *
+ * Creates an AdwActionRow titled `heading` with a right-aligned,
+ * selectable, wrapping GtkLabel suffix ("—" by default) that callers
+ * update in-place via gtk_label_set_text(). The suffix label is
+ * returned through `out_value` so refresh callbacks can rewrite it
+ * without tearing down the row. */
+static inline GtkWidget* section_adw_info_row(const char *heading, GtkWidget **out_value) {
+    GtkWidget *row = adw_action_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(row), heading);
+
+    GtkWidget *value = gtk_label_new("\u2014");
+    gtk_label_set_selectable(GTK_LABEL(value), TRUE);
+    gtk_label_set_wrap(GTK_LABEL(value), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(value), 1.0);
+    gtk_widget_set_hexpand(value, TRUE);
+    gtk_widget_set_halign(value, GTK_ALIGN_END);
+    adw_action_row_add_suffix(ADW_ACTION_ROW(row), value);
+
+    if (out_value) {
+        *out_value = value;
+    }
+    return row;
+}

--- a/apps/linux/src/section_config.c
+++ b/apps/linux/src/section_config.c
@@ -23,6 +23,8 @@
 #include "gateway_rpc.h"
 #include "json_access.h"
 #include "readiness.h"
+#include "runtime_reveal.h"
+#include "section_adw_helpers.h"
 #include "state.h"
 #include "ui_model_utils.h"
 
@@ -173,13 +175,9 @@ static void on_cfg_open_folder(GtkButton *button, gpointer user_data) {
     (void)button;
     (void)user_data;
 
-    GatewayConfig *cfg = gateway_client_get_config();
-    if (cfg && cfg->config_path) {
-        g_autofree gchar *dir = g_path_get_dirname(cfg->config_path);
-        g_autofree gchar *uri = g_filename_to_uri(dir, NULL, NULL);
-        if (uri) {
-            g_app_info_launch_default_for_uri(uri, NULL, NULL);
-        }
+    g_autofree gchar *uri = runtime_reveal_build_config_dir_uri();
+    if (uri) {
+        g_app_info_launch_default_for_uri(uri, NULL, NULL);
     }
 }
 
@@ -281,22 +279,6 @@ static void cfg_set_validation_message(const gchar *message, gboolean valid) {
     gtk_widget_remove_css_class(cfg_validation_label, "success");
     gtk_widget_remove_css_class(cfg_validation_label, "error");
     gtk_widget_add_css_class(cfg_validation_label, valid ? "success" : "error");
-}
-
-static GtkWidget* cfg_setup_fact_row(const gchar *title, GtkWidget **out_value) {
-    GtkWidget *row = adw_action_row_new();
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(row), title);
-
-    GtkWidget *value = gtk_label_new("—");
-    gtk_label_set_selectable(GTK_LABEL(value), TRUE);
-    gtk_label_set_wrap(GTK_LABEL(value), TRUE);
-    gtk_label_set_xalign(GTK_LABEL(value), 1.0);
-    gtk_widget_set_hexpand(value, TRUE);
-    gtk_widget_set_halign(value, GTK_ALIGN_END);
-    adw_action_row_add_suffix(ADW_ACTION_ROW(row), value);
-
-    *out_value = value;
-    return row;
 }
 
 static gboolean cfg_validate_and_track(const gchar *text) {
@@ -858,10 +840,10 @@ static GtkWidget* config_build(void) {
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(setup_group), setup_box);
 
     GtkWidget *facts_group = adw_preferences_group_new();
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(facts_group), cfg_setup_fact_row("Provider", &cfg_setup_provider_label));
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(facts_group), cfg_setup_fact_row("Default model", &cfg_setup_default_model_label));
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(facts_group), cfg_setup_fact_row("Catalog / Selected", &cfg_setup_catalog_label));
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(facts_group), cfg_setup_fact_row("Agents / Chat", &cfg_setup_readiness_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(facts_group), section_adw_info_row("Provider", &cfg_setup_provider_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(facts_group), section_adw_info_row("Default model", &cfg_setup_default_model_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(facts_group), section_adw_info_row("Catalog / Selected", &cfg_setup_catalog_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(facts_group), section_adw_info_row("Agents / Chat", &cfg_setup_readiness_label));
     gtk_box_append(GTK_BOX(setup_box), facts_group);
 
     cfg_setup_status_label = gtk_label_new("Use this section to complete provider/model setup for chat readiness.");

--- a/apps/linux/src/section_debug.c
+++ b/apps/linux/src/section_debug.c
@@ -15,7 +15,7 @@
 
 #include "gateway_client.h"
 #include "product_coordinator.h"
-#include "runtime_paths.h"
+#include "runtime_reveal.h"
 #include "state.h"
 
 extern void systemd_restart_gateway(void);
@@ -58,23 +58,7 @@ static void on_dbg_reveal_config(GtkButton *button, gpointer user_data) {
 }
 
 gchar* section_debug_test_build_reveal_config_uri(void) {
-    g_autofree gchar *profile = NULL;
-    g_autofree gchar *state_dir = NULL;
-    g_autofree gchar *config_path = NULL;
-    systemd_get_runtime_context(&profile, &state_dir, &config_path);
-
-    GatewayConfig *cfg = gateway_client_get_config();
-    RuntimeEffectivePaths effective_paths = {0};
-    runtime_effective_paths_resolve(cfg, profile, state_dir, config_path, &effective_paths);
-
-    gchar *uri = NULL;
-    if (effective_paths.effective_config_path) {
-        g_autofree gchar *dir = g_path_get_dirname(effective_paths.effective_config_path);
-        uri = g_filename_to_uri(dir, NULL, NULL);
-    }
-
-    runtime_effective_paths_clear(&effective_paths);
-    return uri;
+    return runtime_reveal_build_config_dir_uri();
 }
 
 static void on_dbg_copy_journal_cmd(GtkButton *button, gpointer user_data) {

--- a/apps/linux/src/section_general.c
+++ b/apps/linux/src/section_general.c
@@ -20,6 +20,8 @@
 #include "product_state.h"
 #include "readiness.h"
 #include "runtime_paths.h"
+#include "runtime_reveal.h"
+#include "section_adw_helpers.h"
 #include "state.h"
 #include "ui_model_utils.h"
 
@@ -175,47 +177,20 @@ static void on_gen_reveal_config(GtkButton *button, gpointer user_data) {
     (void)button;
     (void)user_data;
 
-    RuntimeEffectivePaths effective_paths = {0};
-    general_resolve_effective_paths(&effective_paths);
-    if (effective_paths.effective_config_path) {
-        g_autofree gchar *dir = g_path_get_dirname(effective_paths.effective_config_path);
-        g_autofree gchar *uri = g_filename_to_uri(dir, NULL, NULL);
-        if (uri) {
-            g_app_info_launch_default_for_uri(uri, NULL, NULL);
-        }
+    g_autofree gchar *uri = runtime_reveal_build_config_dir_uri();
+    if (uri) {
+        g_app_info_launch_default_for_uri(uri, NULL, NULL);
     }
-    runtime_effective_paths_clear(&effective_paths);
 }
 
 static void on_gen_reveal_state_dir(GtkButton *button, gpointer user_data) {
     (void)button;
     (void)user_data;
 
-    RuntimeEffectivePaths effective_paths = {0};
-    general_resolve_effective_paths(&effective_paths);
-    if (effective_paths.effective_state_dir) {
-        g_autofree gchar *uri = g_filename_to_uri(effective_paths.effective_state_dir, NULL, NULL);
-        if (uri) {
-            g_app_info_launch_default_for_uri(uri, NULL, NULL);
-        }
+    g_autofree gchar *uri = runtime_reveal_build_state_dir_uri();
+    if (uri) {
+        g_app_info_launch_default_for_uri(uri, NULL, NULL);
     }
-    runtime_effective_paths_clear(&effective_paths);
-}
-
-static GtkWidget* general_info_row(const char *heading, GtkWidget **out_value) {
-    GtkWidget *row = adw_action_row_new();
-    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(row), heading);
-
-    GtkWidget *value = gtk_label_new("—");
-    gtk_label_set_selectable(GTK_LABEL(value), TRUE);
-    gtk_label_set_wrap(GTK_LABEL(value), TRUE);
-    gtk_label_set_xalign(GTK_LABEL(value), 1.0);
-    gtk_widget_set_hexpand(value, TRUE);
-    gtk_widget_set_halign(value, GTK_ALIGN_END);
-    adw_action_row_add_suffix(ADW_ACTION_ROW(row), value);
-
-    *out_value = value;
-    return row;
 }
 
 static GtkWidget* general_action_row(const char *title,
@@ -253,11 +228,11 @@ static GtkWidget* general_build(void) {
     adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(status_group), "Status");
     adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(status_group));
 
-    GtkWidget *status_row = general_info_row("Status", &gen_status_label);
+    GtkWidget *status_row = section_adw_info_row("Status", &gen_status_label);
     gtk_widget_add_css_class(gen_status_label, "title-3");
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(status_group), status_row);
 
-    GtkWidget *runtime_row = general_info_row("Runtime", &gen_runtime_label);
+    GtkWidget *runtime_row = section_adw_info_row("Runtime", &gen_runtime_label);
     gtk_widget_add_css_class(gen_runtime_label, "dim-label");
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(status_group), runtime_row);
 
@@ -296,10 +271,10 @@ static GtkWidget* general_build(void) {
     gen_btn_open_dashboard = gtk_button_new_with_label("Open Dashboard");
     gtk_widget_add_css_class(gen_btn_open_dashboard, "suggested-action");
     g_signal_connect(gen_btn_open_dashboard, "clicked", G_CALLBACK(on_gen_open_dashboard), NULL);
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group), general_info_row("Endpoint", &gen_endpoint_label));
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group), general_info_row("Version", &gen_version_label));
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group), general_info_row("Auth Mode", &gen_auth_mode_label));
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group), general_info_row("Auth Source", &gen_auth_source_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group), section_adw_info_row("Endpoint", &gen_endpoint_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group), section_adw_info_row("Version", &gen_version_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group), section_adw_info_row("Auth Mode", &gen_auth_mode_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group), section_adw_info_row("Auth Source", &gen_auth_source_label));
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(gateway_group),
                               general_action_row("Open Dashboard",
                                                  "Open the local gateway dashboard in your browser.",
@@ -309,9 +284,9 @@ static GtkWidget* general_build(void) {
     adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(service_group), "Expected Service");
     adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(service_group));
 
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(service_group), general_info_row("Unit", &gen_unit_label));
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(service_group), general_info_row("Active State", &gen_active_state_label));
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(service_group), general_info_row("Sub State", &gen_sub_state_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(service_group), section_adw_info_row("Unit", &gen_unit_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(service_group), section_adw_info_row("Active State", &gen_active_state_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(service_group), section_adw_info_row("Sub State", &gen_sub_state_label));
 
     GtkWidget *svc_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
 
@@ -336,7 +311,7 @@ static GtkWidget* general_build(void) {
     adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(paths_group), "Paths");
     adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(paths_group));
 
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(paths_group), general_info_row("Config File", &gen_config_path_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(paths_group), section_adw_info_row("Config File", &gen_config_path_label));
     gtk_widget_add_css_class(gen_config_path_label, "monospace");
 
     GtkWidget *reveal_config_btn = gtk_button_new_with_label("Reveal Config Folder");
@@ -346,7 +321,7 @@ static GtkWidget* general_build(void) {
                                                  "Open the folder containing the effective config file.",
                                                  reveal_config_btn));
 
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(paths_group), general_info_row("State Dir", &gen_state_dir_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(paths_group), section_adw_info_row("State Dir", &gen_state_dir_label));
     gtk_widget_add_css_class(gen_state_dir_label, "monospace");
 
     GtkWidget *reveal_state_btn = gtk_button_new_with_label("Reveal State Folder");
@@ -356,7 +331,7 @@ static GtkWidget* general_build(void) {
                                                  "Open the local state directory used by the companion.",
                                                  reveal_state_btn));
 
-    adw_preferences_group_add(ADW_PREFERENCES_GROUP(paths_group), general_info_row("Profile", &gen_profile_label));
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(paths_group), section_adw_info_row("Profile", &gen_profile_label));
 
     GtkWidget *companion_group = adw_preferences_group_new();
     adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(companion_group), "Companion");

--- a/apps/linux/tests/test_section_controllers_contract.c
+++ b/apps/linux/tests/test_section_controllers_contract.c
@@ -1,0 +1,59 @@
+/*
+ * test_section_controllers_contract.c
+ *
+ * Real-controller contract audit for the Linux companion shell.
+ *
+ * Tranche D added a shared `SectionController` contract and a shared
+ * `section_controller_has_required_callbacks()` predicate, but
+ * enforcement in `test_shell_sections.c` runs against a dummy
+ * controller, not the real production `section_*_get()` tables. This
+ * test closes that loop by linking the actual section translation
+ * units and asserting, for every embedded `AppSection`, that the
+ * controller returned by `shell_sections_controller()` is non-NULL
+ * and has all four required callbacks populated.
+ *
+ * It does NOT invoke any callback. It only inspects the static
+ * controller tables, so no GTK display backend is required. The goal
+ * is to regression-guard the specific class of bug that caused the
+ * About-tab partial-controller crash (refresh/destroy/invalidate
+ * silently NULL), which the dummy-based registry test cannot catch.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include <glib.h>
+
+#include "../src/app_window.h"
+#include "../src/section_controller.h"
+#include "../src/shell_sections.h"
+
+/*
+ * `state.c` references `state_on_gateway_refresh_requested()` through an
+ * idle source and the real implementation lives in `main.c`, which the
+ * audit binary intentionally excludes so it can provide its own main().
+ * The test never schedules that idle source, so a no-op stub is safe
+ * and keeps the link closed. */
+void state_on_gateway_refresh_requested(void) {
+}
+
+static void test_every_real_controller_has_required_callbacks(void) {
+    for (int i = 0; i < SECTION_COUNT; i++) {
+        AppSection section = (AppSection)i;
+        const SectionController *controller = shell_sections_controller(section);
+
+        if (section == SECTION_CHAT) {
+            g_assert_null(controller);
+            continue;
+        }
+
+        g_assert_nonnull(controller);
+        g_assert_true(section_controller_has_required_callbacks(controller));
+    }
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/section_controllers_contract/every_real_controller_has_required_callbacks",
+                    test_every_real_controller_has_required_callbacks);
+    return g_test_run();
+}


### PR DESCRIPTION
Add shared runtime reveal helpers so General, Config, and Debug resolve effective config and state directories through the same path contract.

Introduce a shared libadwaita info-row helper and replace duplicated row builders in General and Config without changing visible widget behavior.

Add a real-controller contract audit test that links production section translation units and asserts every non-chat controller provides the required callback set.

Also update Meson for the new helper/test layout, including an `app_core_sources` list for production-TU controller auditing.