### PR TITLE
feat(linux): add in-app exec approval prompts (#118)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -61,6 +61,10 @@ sources = [
   'src/device_pair_approval_window.c',
   'src/pairing_bootstrap_window.c',
   'src/device_pair_prompter.c',
+  'src/exec_approval_request.c',
+  'src/exec_approval_store.c',
+  'src/exec_approval_window.c',
+  'src/exec_approval_prompter.c',
   'src/gateway_rpc.c',
   'src/gateway_data.c',
   'src/gateway_mutations.c',
@@ -318,6 +322,28 @@ test_device_pair_prompter_exe = executable('test_device_pair_prompter',
    'src/device_pair_prompter.c', 'src/device_pair_request_info.c', 'src/log.c'],
   dependencies : [glib_dep, gio_dep, json_glib_dep, gtk4_dep])
 test('device_pair_prompter', test_device_pair_prompter_exe)
+
+# Exec-approval Tranche B coverage. All three tests are headless: they
+# stub out gateway_ws / gateway_rpc / exec_approval_window symbols and
+# never spin up GTK/Adwaita.
+test_exec_approval_request_exe = executable('test_exec_approval_request',
+  ['tests/test_exec_approval_request.c', 'src/exec_approval_request.c'],
+  dependencies : [glib_dep, json_glib_dep])
+test('exec_approval_request', test_exec_approval_request_exe)
+
+test_exec_approval_store_exe = executable('test_exec_approval_store',
+  ['tests/test_exec_approval_store.c', 'src/exec_approval_store.c', 'src/log.c'],
+  dependencies : [glib_dep, gio_dep, json_glib_dep])
+test('exec_approval_store', test_exec_approval_store_exe)
+
+test_exec_approval_prompter_exe = executable('test_exec_approval_prompter',
+  ['tests/test_exec_approval_prompter.c',
+   'src/exec_approval_prompter.c',
+   'src/exec_approval_request.c',
+   'src/exec_approval_store.c',
+   'src/log.c'],
+  dependencies : [glib_dep, gio_dep, json_glib_dep, gtk4_dep])
+test('exec_approval_prompter', test_exec_approval_prompter_exe)
 
 # Pure-C coverage for the Pango-markup body builder used by the approval
 # dialog. Uses only GLib (g_markup_escape_text), so no GTK/Adwaita link.

--- a/apps/linux/src/app_window.c
+++ b/apps/linux/src/app_window.c
@@ -25,6 +25,7 @@
 #include "gateway_client.h"
 #include "diagnostics.h"
 #include "device_pair_prompter.h"
+#include "exec_approval_prompter.h"
 #include "gateway_ws.h"
 #include "chat_window.h"
 #include "gateway_rpc.h"
@@ -634,6 +635,8 @@ void app_window_show(void) {
      * newly-created main window. Safe to call even if the prompter has not
      * been initialized; calls before init are no-ops. */
     device_pair_prompter_set_parent(GTK_WINDOW(main_window));
+    /* Same for the exec-approval dialog. */
+    exec_approval_prompter_set_parent(GTK_WINDOW(main_window));
 
     /* Initial content fill for local/cheap sections + start auto-refresh */
     refresh_active_section(active_section);

--- a/apps/linux/src/exec_approval_prompter.c
+++ b/apps/linux/src/exec_approval_prompter.c
@@ -1,0 +1,399 @@
+/*
+ * exec_approval_prompter.c
+ *
+ * Subscribe to `exec.approval.requested` / `exec.approval.resolved`
+ * events, queue requests one-at-a-time, present an Adw dialog (or a
+ * test seam hook) for the operator's decision, and dispatch the result
+ * back to the gateway via `exec.approval.resolve` RPC.
+ *
+ * Mirrors the contract proven by `device_pair_prompter.c`. Per Tranche B
+ * scope, exec.approval.list seeding is intentionally NOT wired here —
+ * the response envelope is not yet contractually fixed for cross-client
+ * reuse.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "exec_approval_prompter.h"
+
+#include "exec_approval_store.h"
+#include "exec_approval_window.h"
+#include "gateway_rpc.h"
+#include "gateway_ws.h"
+#include "json_access.h"
+#include "log.h"
+
+#include <string.h>
+
+typedef struct {
+    guint                     event_listener_id;
+    GtkWindow                *parent;
+    GQueue                   *pending;            /* of OcExecApprovalRequest* */
+    gboolean                  presenting;
+    /* Active request id; tracked separately so the resolved-event
+     * handler can compare without dereferencing the hook-owned pointer. */
+    gchar                    *active_request_id;
+    /* Test seam */
+    OcExecApprovalPresentHook present_hook;
+    gpointer                  present_hook_user_data;
+} ExecPromptState;
+
+static ExecPromptState g_state = {0};
+
+/* ── Forward decls ── */
+static void try_present_next(void);
+static gboolean queue_contains_request_id(const gchar *request_id);
+static void     remove_request_from_queue(const gchar *request_id);
+static OcExecQuickMode resolve_effective_quick_mode(void);
+
+/* ── Parent lifetime (mirrors device_pair_prompter.c) ── */
+
+static void on_parent_destroyed(gpointer data, GObject *where_the_object_was) {
+    (void)data;
+    if (g_state.parent == (GtkWindow *)where_the_object_was) {
+        g_state.parent = NULL;
+    }
+}
+
+static void parent_clear_ref(void) {
+    if (g_state.parent) {
+        g_object_weak_unref(G_OBJECT(g_state.parent), on_parent_destroyed, NULL);
+        g_state.parent = NULL;
+    }
+}
+
+static void parent_assign(GtkWindow *parent) {
+    if (g_state.parent == parent) return;
+    parent_clear_ref();
+    if (parent) {
+        g_state.parent = parent;
+        g_object_weak_ref(G_OBJECT(parent), on_parent_destroyed, NULL);
+    }
+}
+
+/* ── RPC dispatch ── */
+
+static void on_resolve_rpc_response(const GatewayRpcResponse *response,
+                                    gpointer user_data) {
+    g_autofree gchar *id_copy = (gchar *)user_data;
+    if (!response) return;
+    if (!response->ok) {
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                    "exec.approval.resolve RPC failed (id=%s): %s",
+                    id_copy ? id_copy : "(null)",
+                    response->error_msg ? response->error_msg : "(no detail)");
+    }
+}
+
+static void send_resolve_rpc(const OcExecApprovalRequest *req,
+                             OcExecDecision decision) {
+    if (!req || !req->id || req->id[0] == '\0') {
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                    "exec.approval.resolve skipped: missing request id");
+        return;
+    }
+
+    const gchar *decision_str = oc_exec_decision_to_string(decision);
+
+    g_autoptr(JsonBuilder) b = json_builder_new();
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "id");
+    json_builder_add_string_value(b, req->id);
+    json_builder_set_member_name(b, "decision");
+    json_builder_add_string_value(b, decision_str);
+    json_builder_end_object(b);
+    g_autoptr(JsonNode) params = json_builder_get_root(b);
+
+    /* Pass a heap-owned id copy as user_data so the response logger can
+     * report which request the failure was for, without surviving the
+     * prompter teardown. */
+    gchar *id_copy = g_strdup(req->id);
+    g_autofree gchar *rpc_req_id = gateway_rpc_request(
+        "exec.approval.resolve", params, 0,
+        on_resolve_rpc_response, id_copy);
+    if (!rpc_req_id) {
+        g_free(id_copy);
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                    "exec.approval.resolve dispatch failed for id=%s "
+                    "(WS not ready)",
+                    req->id);
+    } else {
+        OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                    "exec.approval.resolve dispatched id=%s decision=%s",
+                    req->id, decision_str);
+    }
+}
+
+/* ── Queue core ── */
+
+static void on_decision_recorded(const OcExecApprovalRequest *req,
+                                 OcExecDecision decision,
+                                 gpointer user_data) {
+    (void)user_data;
+    g_state.presenting = FALSE;
+    g_clear_pointer(&g_state.active_request_id, g_free);
+
+    /* Honor `allowedDecisions`: if the gateway constrained the set and
+     * the operator (or auto-policy) picked an excluded decision,
+     * downgrade to allow-once or deny rather than forwarding garbage. */
+    if (!oc_exec_approval_request_allows_decision(req, oc_exec_decision_to_string(decision))) {
+        if (decision == OC_EXEC_DECISION_ALLOW_ALWAYS &&
+            oc_exec_approval_request_allows_decision(req, "allow-once")) {
+            OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
+                         "exec approval id=%s downgrading allow-always -> allow-once "
+                         "(not in allowedDecisions)",
+                         req->id ? req->id : "(null)");
+            decision = OC_EXEC_DECISION_ALLOW_ONCE;
+        } else {
+            OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
+                         "exec approval id=%s requested decision not allowed; sending deny",
+                         req->id ? req->id : "(null)");
+            decision = OC_EXEC_DECISION_DENY;
+        }
+    }
+
+    send_resolve_rpc(req, decision);
+    try_present_next();
+}
+
+static void default_present(const OcExecApprovalRequest *req,
+                            OcExecDecisionCallback record_decision,
+                            gpointer record_user_data,
+                            gpointer hook_user_data) {
+    (void)hook_user_data;
+    exec_approval_window_present(g_state.parent, req, record_decision, record_user_data);
+}
+
+static OcExecQuickMode resolve_effective_quick_mode(void) {
+    return exec_approval_store_get_quick_mode();
+}
+
+/*
+ * Decide whether the request can be auto-resolved without prompting,
+ * based on the persisted quick mode. Returns TRUE and writes
+ * `*out_decision` when auto-resolved.
+ */
+static gboolean try_auto_resolve(const OcExecApprovalRequest *req,
+                                 OcExecDecision *out_decision) {
+    OcExecQuickMode mode = resolve_effective_quick_mode();
+    switch (mode) {
+    case OC_EXEC_QUICK_MODE_DENY:
+        *out_decision = OC_EXEC_DECISION_DENY;
+        return TRUE;
+    case OC_EXEC_QUICK_MODE_ALLOW:
+        *out_decision = oc_exec_approval_request_allows_decision(req, "allow-once")
+                            ? OC_EXEC_DECISION_ALLOW_ONCE
+                            : OC_EXEC_DECISION_DENY;
+        return TRUE;
+    case OC_EXEC_QUICK_MODE_ASK:
+    default:
+        return FALSE;
+    }
+}
+
+static void try_present_next(void) {
+    if (g_state.presenting) return;
+    if (!g_state.pending || g_queue_is_empty(g_state.pending)) return;
+
+    OcExecApprovalRequest *req = g_queue_pop_head(g_state.pending);
+    if (!req) return;
+
+    /* Drop expired entries silently. The gateway's record is already
+     * cleared at this point, so any decision RPC we send would race a
+     * "not found" error path. */
+    gint64 now_ms = oc_exec_approval_now_ms();
+    if (oc_exec_approval_request_is_expired(req, now_ms)) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
+                     "exec approval id=%s expired (expiresAtMs=%" G_GINT64_FORMAT
+                     " now_ms=%" G_GINT64_FORMAT "); dropping",
+                     req->id, req->expires_at_ms, now_ms);
+        oc_exec_approval_request_free(req);
+        try_present_next();
+        return;
+    }
+
+    OcExecDecision auto_decision = OC_EXEC_DECISION_DENY;
+    if (try_auto_resolve(req, &auto_decision)) {
+        OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                    "exec approval id=%s auto-resolved as %s",
+                    req->id, oc_exec_decision_to_string(auto_decision));
+        send_resolve_rpc(req, auto_decision);
+        oc_exec_approval_request_free(req);
+        try_present_next();
+        return;
+    }
+
+    g_state.presenting = TRUE;
+    g_clear_pointer(&g_state.active_request_id, g_free);
+    g_state.active_request_id = g_strdup(req->id);
+
+    OcExecApprovalPresentHook hook = g_state.present_hook
+        ? g_state.present_hook
+        : default_present;
+
+    /* Hook MUST invoke `record_decision` exactly once. While it does
+     * not, `presenting` stays TRUE and further events only enqueue. */
+    hook(req, on_decision_recorded, NULL, g_state.present_hook_user_data);
+
+    /* The default presenter (or any well-behaved test hook) takes its
+     * own copy via oc_exec_approval_request_copy(). Free our local. */
+    oc_exec_approval_request_free(req);
+}
+
+/* ── Event pipeline ── */
+
+static gboolean queue_contains_request_id(const gchar *request_id) {
+    if (!request_id || !g_state.pending) return FALSE;
+    for (GList *it = g_state.pending->head; it; it = it->next) {
+        const OcExecApprovalRequest *entry = it->data;
+        if (entry && g_strcmp0(entry->id, request_id) == 0) return TRUE;
+    }
+    return FALSE;
+}
+
+static void remove_request_from_queue(const gchar *request_id) {
+    if (!request_id || !g_state.pending) return;
+    GList *it = g_state.pending->head;
+    while (it) {
+        GList *next = it->next;
+        OcExecApprovalRequest *entry = it->data;
+        if (entry && g_strcmp0(entry->id, request_id) == 0) {
+            g_queue_delete_link(g_state.pending, it);
+            oc_exec_approval_request_free(entry);
+        }
+        it = next;
+    }
+}
+
+static void handle_exec_approval_requested(JsonNode *payload) {
+    OcExecApprovalRequest *req = oc_exec_approval_request_new_from_event(payload);
+    if (!req) {
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                    "exec.approval.requested: invalid payload; dropping");
+        return;
+    }
+
+    /* Dedupe against active + queued ids. */
+    if (g_strcmp0(g_state.active_request_id, req->id) == 0 ||
+        queue_contains_request_id(req->id)) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
+                     "exec.approval.requested id=%s already tracked; "
+                     "dropping duplicate",
+                     req->id);
+        oc_exec_approval_request_free(req);
+        return;
+    }
+
+    OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                "exec.approval.requested id=%s agent=%s "
+                "(queue size %u -> %u)",
+                req->id,
+                req->agent_id ? req->agent_id : "",
+                g_state.pending ? g_queue_get_length(g_state.pending) : 0,
+                (g_state.pending ? g_queue_get_length(g_state.pending) : 0) + 1);
+
+    g_queue_push_tail(g_state.pending, req);
+    try_present_next();
+}
+
+static void handle_exec_approval_resolved(JsonNode *payload) {
+    if (!payload || !JSON_NODE_HOLDS_OBJECT(payload)) return;
+    JsonObject *obj = json_node_get_object(payload);
+    const gchar *request_id = oc_json_string_member(obj, "id");
+    if (!request_id) request_id = oc_json_string_member(obj, "requestId");
+    if (!request_id || !request_id[0]) return;
+
+    const gchar *decision = oc_json_string_member(obj, "decision");
+    OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                "exec.approval.resolved id=%s decision=%s",
+                request_id, decision ? decision : "(n/a)");
+
+    if (g_strcmp0(g_state.active_request_id, request_id) == 0) {
+        /* `dismiss_if` closes the dialog without firing the decision
+         * callback; we drive state forward here. */
+        exec_approval_window_dismiss_if(request_id);
+        g_state.presenting = FALSE;
+        g_clear_pointer(&g_state.active_request_id, g_free);
+        try_present_next();
+        return;
+    }
+    remove_request_from_queue(request_id);
+}
+
+static void on_ws_event(const gchar *event_type,
+                        const JsonNode *payload,
+                        gpointer user_data) {
+    (void)user_data;
+    if (!event_type) return;
+    if (g_strcmp0(event_type, "exec.approval.requested") == 0) {
+        handle_exec_approval_requested((JsonNode *)payload);
+    } else if (g_strcmp0(event_type, "exec.approval.resolved") == 0) {
+        handle_exec_approval_resolved((JsonNode *)payload);
+    }
+}
+
+/* ── Public API ── */
+
+void exec_approval_prompter_init(GtkWindow *parent) {
+    parent_assign(parent);
+    if (g_state.event_listener_id != 0) return;
+    if (!g_state.pending) {
+        g_state.pending = g_queue_new();
+    }
+    g_state.event_listener_id = gateway_ws_event_subscribe(on_ws_event, NULL);
+}
+
+void exec_approval_prompter_shutdown(void) {
+    if (g_state.event_listener_id != 0) {
+        gateway_ws_event_unsubscribe(g_state.event_listener_id);
+        g_state.event_listener_id = 0;
+    }
+    if (g_state.pending) {
+        while (!g_queue_is_empty(g_state.pending)) {
+            oc_exec_approval_request_free(g_queue_pop_head(g_state.pending));
+        }
+        g_queue_free(g_state.pending);
+        g_state.pending = NULL;
+    }
+    g_state.presenting = FALSE;
+    g_clear_pointer(&g_state.active_request_id, g_free);
+    parent_clear_ref();
+}
+
+void exec_approval_prompter_set_parent(GtkWindow *parent) {
+    parent_assign(parent);
+}
+
+guint exec_approval_prompter_pending_count(void) {
+    guint queued = g_state.pending ? g_queue_get_length(g_state.pending) : 0;
+    return queued + (g_state.presenting ? 1u : 0u);
+}
+
+void exec_approval_prompter_test_set_present_hook(OcExecApprovalPresentHook hook,
+                                                  gpointer hook_user_data) {
+    g_state.present_hook = hook;
+    g_state.present_hook_user_data = hook_user_data;
+}
+
+void exec_approval_prompter_test_inject_event(JsonNode *payload) {
+    if (!g_state.pending) g_state.pending = g_queue_new();
+    handle_exec_approval_requested(payload);
+}
+
+void exec_approval_prompter_test_inject_resolved(JsonNode *payload) {
+    if (!g_state.pending) g_state.pending = g_queue_new();
+    handle_exec_approval_resolved(payload);
+}
+
+guint exec_approval_prompter_test_queue_len(void) {
+    if (!g_state.pending) return 0;
+    return g_queue_get_length(g_state.pending);
+}
+
+gboolean exec_approval_prompter_test_is_presenting(void) {
+    return g_state.presenting;
+}
+
+gpointer exec_approval_prompter_test_get_parent(void) {
+    return g_state.parent;
+}

--- a/apps/linux/src/exec_approval_prompter.h
+++ b/apps/linux/src/exec_approval_prompter.h
@@ -1,0 +1,83 @@
+/*
+ * exec_approval_prompter.h
+ *
+ * Driver that subscribes to gateway `exec.approval.requested` /
+ * `exec.approval.resolved` events and presents the Linux operator with a
+ * single-active approval dialog, queueing concurrent inbound requests
+ * and dispatching decisions back via `exec.approval.resolve` RPC.
+ *
+ * Architecturally parallel to `device_pair_prompter.h` — same lifecycle,
+ * same parent-rebind semantics, same single-presented contract — but
+ * targeting the exec-approval flow instead of device-pair approval.
+ *
+ * Public entry points are safe to call from the main thread only.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_EXEC_APPROVAL_PROMPTER_H
+#define OPENCLAW_LINUX_EXEC_APPROVAL_PROMPTER_H
+
+#include <gtk/gtk.h>
+#include <glib.h>
+#include <json-glib/json-glib.h>
+
+#include "exec_approval_request.h"
+#include "exec_approval_window.h"
+
+/*
+ * Initialize the prompter and subscribe to gateway events.
+ * `parent` may be NULL; safe to call multiple times — subsequent calls
+ * update the parent only.
+ */
+void exec_approval_prompter_init(GtkWindow *parent);
+
+/* Unsubscribe and tear down all queued state. After this call, init may
+ * be invoked again. */
+void exec_approval_prompter_shutdown(void);
+
+/* Update the parent window used for future approval dialogs. */
+void exec_approval_prompter_set_parent(GtkWindow *parent);
+
+/*
+ * Number of pending exec approvals known to the prompter (queued plus
+ * the currently-presented request, if any). Useful for future tray
+ * badging; tray hookup itself is a later tranche.
+ */
+guint exec_approval_prompter_pending_count(void);
+
+/*
+ * Test seam: replace the window-present function with one that records
+ * a decision immediately. Pass NULL to restore the default Adw dialog
+ * presenter.
+ *
+ *   `req`            : ownership remains with the prompter; the test
+ *                      may read it but must call `record_decision`
+ *                      before returning or asynchronously.
+ *   `record_decision`: invoke exactly once with the chosen decision.
+ */
+typedef void (*OcExecApprovalPresentHook)(const OcExecApprovalRequest *req,
+                                          OcExecDecisionCallback record_decision,
+                                          gpointer record_user_data,
+                                          gpointer hook_user_data);
+
+void exec_approval_prompter_test_set_present_hook(OcExecApprovalPresentHook hook,
+                                                  gpointer hook_user_data);
+
+/* Test seam: inject a synthetic `exec.approval.requested` payload as if
+ * it arrived from the gateway event stream. */
+void exec_approval_prompter_test_inject_event(JsonNode *payload);
+
+/* Test seam: inject a synthetic `exec.approval.resolved` payload. */
+void exec_approval_prompter_test_inject_resolved(JsonNode *payload);
+
+/* Test seam: number of queued (not-yet-presented) requests. */
+guint exec_approval_prompter_test_queue_len(void);
+
+/* Test seam: whether a request is currently being presented. */
+gboolean exec_approval_prompter_test_is_presenting(void);
+
+/* Test seam: currently-tracked parent pointer (assertion only). */
+gpointer exec_approval_prompter_test_get_parent(void);
+
+#endif /* OPENCLAW_LINUX_EXEC_APPROVAL_PROMPTER_H */

--- a/apps/linux/src/exec_approval_request.c
+++ b/apps/linux/src/exec_approval_request.c
@@ -1,0 +1,140 @@
+/*
+ * exec_approval_request.c
+ *
+ * Pure-C parser/value-type implementation. See header for the payload
+ * contract.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "exec_approval_request.h"
+
+#include "json_access.h"
+
+#include <string.h>
+
+static gint64 json_object_int64_member_or(JsonObject *obj,
+                                          const gchar *member,
+                                          gint64 fallback) {
+    if (!obj || !member || !json_object_has_member(obj, member)) return fallback;
+    JsonNode *node = json_object_get_member(obj, member);
+    if (!node || !JSON_NODE_HOLDS_VALUE(node)) return fallback;
+    GType t = json_node_get_value_type(node);
+    if (t == G_TYPE_INT64) return json_node_get_int(node);
+    if (t == G_TYPE_DOUBLE) return (gint64)json_node_get_double(node);
+    return fallback;
+}
+
+static gchar** parse_string_array_member(JsonObject *obj, const gchar *member) {
+    JsonArray *arr = oc_json_array_member(obj, member);
+    if (!arr) return NULL;
+    guint n = json_array_get_length(arr);
+    GPtrArray *out = g_ptr_array_sized_new(n + 1);
+    for (guint i = 0; i < n; i++) {
+        JsonNode *node = json_array_get_element(arr, i);
+        if (!node || !JSON_NODE_HOLDS_VALUE(node)) continue;
+        if (json_node_get_value_type(node) != G_TYPE_STRING) continue;
+        const gchar *s = json_node_get_string(node);
+        if (!s || s[0] == '\0') continue;
+        g_ptr_array_add(out, g_strdup(s));
+    }
+    g_ptr_array_add(out, NULL);
+    return (gchar **)g_ptr_array_free(out, FALSE);
+}
+
+static gchar* dup_or_null(const gchar *s) {
+    return (s && s[0] != '\0') ? g_strdup(s) : NULL;
+}
+
+OcExecApprovalRequest* oc_exec_approval_request_new_from_event(JsonNode *payload) {
+    if (!payload || !JSON_NODE_HOLDS_OBJECT(payload)) return NULL;
+    JsonObject *root = json_node_get_object(payload);
+
+    const gchar *id = oc_json_string_member(root, "id");
+    if (!id || id[0] == '\0') return NULL;
+
+    JsonObject *request = oc_json_object_member(root, "request");
+    if (!request) return NULL;
+
+    const gchar *command = oc_json_string_member(request, "command");
+    if (!command || command[0] == '\0') return NULL;
+
+    gint64 created_at_ms = json_object_int64_member_or(root, "createdAtMs", 0);
+    gint64 expires_at_ms = json_object_int64_member_or(root, "expiresAtMs", 0);
+    if (created_at_ms <= 0 || expires_at_ms <= 0) return NULL;
+
+    OcExecApprovalRequest *req = g_new0(OcExecApprovalRequest, 1);
+    req->id = g_strdup(id);
+    req->command = g_strdup(command);
+    req->cwd = dup_or_null(oc_json_string_member(request, "cwd"));
+    req->host = dup_or_null(oc_json_string_member(request, "host"));
+    req->node_id = dup_or_null(oc_json_string_member(request, "nodeId"));
+    req->agent_id = dup_or_null(oc_json_string_member(request, "agentId"));
+    req->resolved_path = dup_or_null(oc_json_string_member(request, "resolvedPath"));
+    req->security = dup_or_null(oc_json_string_member(request, "security"));
+    req->ask = dup_or_null(oc_json_string_member(request, "ask"));
+    req->session_key = dup_or_null(oc_json_string_member(request, "sessionKey"));
+    req->allowed_decisions = parse_string_array_member(request, "allowedDecisions");
+    req->created_at_ms = created_at_ms;
+    req->expires_at_ms = expires_at_ms;
+    return req;
+}
+
+OcExecApprovalRequest* oc_exec_approval_request_copy(const OcExecApprovalRequest *src) {
+    if (!src) return NULL;
+    OcExecApprovalRequest *dst = g_new0(OcExecApprovalRequest, 1);
+    dst->id = g_strdup(src->id);
+    dst->command = g_strdup(src->command);
+    dst->cwd = src->cwd ? g_strdup(src->cwd) : NULL;
+    dst->host = src->host ? g_strdup(src->host) : NULL;
+    dst->node_id = src->node_id ? g_strdup(src->node_id) : NULL;
+    dst->agent_id = src->agent_id ? g_strdup(src->agent_id) : NULL;
+    dst->resolved_path = src->resolved_path ? g_strdup(src->resolved_path) : NULL;
+    dst->security = src->security ? g_strdup(src->security) : NULL;
+    dst->ask = src->ask ? g_strdup(src->ask) : NULL;
+    dst->session_key = src->session_key ? g_strdup(src->session_key) : NULL;
+    if (src->allowed_decisions) {
+        dst->allowed_decisions = g_strdupv(src->allowed_decisions);
+    }
+    dst->created_at_ms = src->created_at_ms;
+    dst->expires_at_ms = src->expires_at_ms;
+    return dst;
+}
+
+void oc_exec_approval_request_free(OcExecApprovalRequest *req) {
+    if (!req) return;
+    g_free(req->id);
+    g_free(req->command);
+    g_free(req->cwd);
+    g_free(req->host);
+    g_free(req->node_id);
+    g_free(req->agent_id);
+    g_free(req->resolved_path);
+    g_free(req->security);
+    g_free(req->ask);
+    g_free(req->session_key);
+    g_strfreev(req->allowed_decisions);
+    g_free(req);
+}
+
+gboolean oc_exec_approval_request_allows_decision(const OcExecApprovalRequest *req,
+                                                  const gchar *decision) {
+    if (!req || !decision) return FALSE;
+    /* Omitted constraint = all decisions allowed. */
+    if (!req->allowed_decisions) return TRUE;
+    for (gsize i = 0; req->allowed_decisions[i]; i++) {
+        if (g_strcmp0(req->allowed_decisions[i], decision) == 0) return TRUE;
+    }
+    return FALSE;
+}
+
+gboolean oc_exec_approval_request_is_expired(const OcExecApprovalRequest *req,
+                                             gint64 now_ms) {
+    if (!req) return TRUE;
+    if (req->expires_at_ms <= 0) return FALSE;
+    return now_ms >= req->expires_at_ms;
+}
+
+gint64 oc_exec_approval_now_ms(void) {
+    return g_get_real_time() / 1000;
+}

--- a/apps/linux/src/exec_approval_request.h
+++ b/apps/linux/src/exec_approval_request.h
@@ -1,0 +1,78 @@
+/*
+ * exec_approval_request.h
+ *
+ * Value type and JSON parser for `exec.approval.requested` gateway events.
+ * Mirrors the canonical payload emitted by the gateway server (see
+ * `src/gateway/server-methods/exec-approval.ts`):
+ *
+ *   {
+ *     "id":          string,
+ *     "request":     { command, cwd?, host?, nodeId?, agentId?, security?,
+ *                      ask?, resolvedPath?, sessionKey?, allowedDecisions? },
+ *     "createdAtMs": number,
+ *     "expiresAtMs": number
+ *   }
+ *
+ * Headless: pure-C / json-glib. No GTK, no Adwaita, no gateway_ws/rpc.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_EXEC_APPROVAL_REQUEST_H
+#define OPENCLAW_LINUX_EXEC_APPROVAL_REQUEST_H
+
+#include <glib.h>
+#include <json-glib/json-glib.h>
+
+typedef struct {
+    gchar  *id;
+    gchar  *command;
+    gchar  *cwd;
+    gchar  *host;
+    gchar  *node_id;
+    gchar  *agent_id;
+    gchar  *resolved_path;
+    gchar  *security;
+    gchar  *ask;
+    gchar  *session_key;
+    /* NULL-terminated array of decision strings, or NULL when the gateway
+     * did not constrain the allowed set (treat as "all decisions allowed"). */
+    gchar **allowed_decisions;
+    gint64  created_at_ms;
+    gint64  expires_at_ms;
+} OcExecApprovalRequest;
+
+/*
+ * Parse a `exec.approval.requested` payload into a freshly allocated
+ * OcExecApprovalRequest. Returns NULL when:
+ *   - payload is NULL or not an object;
+ *   - `id` is missing/empty;
+ *   - `request.command` is missing/empty;
+ *   - `createdAtMs` or `expiresAtMs` is missing/non-positive.
+ */
+OcExecApprovalRequest* oc_exec_approval_request_new_from_event(JsonNode *payload);
+
+/* Deep copy. Returns NULL when src is NULL. */
+OcExecApprovalRequest* oc_exec_approval_request_copy(const OcExecApprovalRequest *src);
+
+/* Free all owned members and the struct itself. NULL-safe. */
+void oc_exec_approval_request_free(OcExecApprovalRequest *req);
+
+/*
+ * Returns TRUE when `decision` is an allowed terminal decision for this
+ * request. When `req->allowed_decisions` is NULL all decisions are
+ * permitted (matches the gateway contract: omitted = no constraint).
+ */
+gboolean oc_exec_approval_request_allows_decision(const OcExecApprovalRequest *req,
+                                                  const gchar *decision);
+
+/* Returns TRUE when now_ms is at-or-after expires_at_ms. */
+gboolean oc_exec_approval_request_is_expired(const OcExecApprovalRequest *req,
+                                             gint64 now_ms);
+
+/* Wall-clock helper expressed in milliseconds since the unix epoch. */
+gint64 oc_exec_approval_now_ms(void);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(OcExecApprovalRequest, oc_exec_approval_request_free)
+
+#endif /* OPENCLAW_LINUX_EXEC_APPROVAL_REQUEST_H */

--- a/apps/linux/src/exec_approval_store.c
+++ b/apps/linux/src/exec_approval_store.c
@@ -1,0 +1,358 @@
+/*
+ * exec_approval_store.c
+ *
+ * JSON-backed quick-mode policy store with refreshable state-dir
+ * resolution. See header for the on-disk schema and lifecycle contract.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "exec_approval_store.h"
+
+#include "json_access.h"
+#include "log.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <gio/gio.h>
+#include <glib/gstdio.h>
+#include <json-glib/json-glib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define EXEC_APPROVAL_STORE_FILENAME  "exec-approvals.json"
+#define EXEC_APPROVAL_STORE_VERSION   1
+
+static gchar          *g_state_dir = NULL;
+static gchar          *g_storage_path_override = NULL;
+static OcExecQuickMode g_cached_mode = OC_EXEC_QUICK_MODE_ASK;
+static gboolean        g_loaded = FALSE;
+static gboolean        g_dirty  = FALSE;
+
+/*
+ * Carry-through node for keys this tranche does not edit (e.g. `agents`,
+ * `socket`). We preserve them on round-trip so a Linux operator who only
+ * touches the quick mode cannot accidentally drop policy data written by
+ * macOS or by a future Linux UI surface.
+ */
+static JsonNode *g_full_doc = NULL;
+
+static void quick_mode_to_strings(OcExecQuickMode mode,
+                                  const gchar **out_security,
+                                  const gchar **out_ask) {
+    switch (mode) {
+    case OC_EXEC_QUICK_MODE_DENY:
+        if (out_security) *out_security = "deny";
+        if (out_ask)      *out_ask      = "off";
+        return;
+    case OC_EXEC_QUICK_MODE_ALLOW:
+        if (out_security) *out_security = "full";
+        if (out_ask)      *out_ask      = "off";
+        return;
+    case OC_EXEC_QUICK_MODE_ASK:
+    default:
+        if (out_security) *out_security = "allowlist";
+        if (out_ask)      *out_ask      = "on-miss";
+        return;
+    }
+}
+
+/*
+ * Mirror of macOS `ExecApprovalQuickMode.from(security:ask:)`. The mode
+ * collapses across both axes; "ask" only meaningfully separates Deny vs
+ * Ask when security is allowlist, otherwise security wins.
+ */
+static OcExecQuickMode quick_mode_from_strings(const gchar *security,
+                                               const gchar *ask) {
+    (void)ask;
+    if (g_strcmp0(security, "deny") == 0) return OC_EXEC_QUICK_MODE_DENY;
+    if (g_strcmp0(security, "full") == 0) return OC_EXEC_QUICK_MODE_ALLOW;
+    /* Default and "allowlist" both map to Ask. */
+    return OC_EXEC_QUICK_MODE_ASK;
+}
+
+static gchar* resolve_storage_path(void) {
+    if (g_storage_path_override) return g_strdup(g_storage_path_override);
+    if (!g_state_dir || g_state_dir[0] == '\0') return NULL;
+    return g_build_filename(g_state_dir, EXEC_APPROVAL_STORE_FILENAME, NULL);
+}
+
+static gboolean ensure_parent_dir(const gchar *path) {
+    g_autofree gchar *dir = g_path_get_dirname(path);
+    if (!dir) return FALSE;
+    if (g_mkdir_with_parents(dir, 0700) != 0 && errno != EEXIST) {
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                    "exec-approval-store: mkdir %s failed: %s",
+                    dir, g_strerror(errno));
+        return FALSE;
+    }
+    (void)g_chmod(dir, 0700);
+    return TRUE;
+}
+
+static void replace_full_doc(JsonNode *node) {
+    if (g_full_doc) {
+        json_node_unref(g_full_doc);
+        g_full_doc = NULL;
+    }
+    g_full_doc = node;
+}
+
+static JsonNode* build_default_doc(void) {
+    JsonObject *root = json_object_new();
+    json_object_set_int_member(root, "version", EXEC_APPROVAL_STORE_VERSION);
+    JsonObject *defaults = json_object_new();
+    const gchar *sec = NULL, *ask = NULL;
+    quick_mode_to_strings(g_cached_mode, &sec, &ask);
+    json_object_set_string_member(defaults, "security", sec);
+    json_object_set_string_member(defaults, "ask", ask);
+    json_object_set_object_member(root, "defaults", defaults);
+    JsonNode *node = json_node_new(JSON_NODE_OBJECT);
+    json_node_take_object(node, root);
+    return node;
+}
+
+/*
+ * Reset the in-memory document AND cached quick-mode to the safe
+ * default (ASK).
+ *
+ * Used whenever a load yields no usable on-disk policy: missing file,
+ * corrupt JSON, or a non-object root. Critically, this MUST NOT inherit
+ * the previous cached mode, because that would let an `ALLOW` policy
+ * from one state dir bleed into another state dir that has no policy
+ * file of its own. The store contract is: "no valid file => ASK".
+ */
+static void reset_to_safe_default_doc(void) {
+    g_cached_mode = OC_EXEC_QUICK_MODE_ASK;
+    replace_full_doc(build_default_doc());
+}
+
+static void load_from_disk(void) {
+    g_autofree gchar *path = resolve_storage_path();
+    g_loaded = TRUE; /* mark loaded even on failure so we don't retry forever */
+
+    /* No path resolved (no state dir, no override) or the file does not
+     * exist at this path: fall back to the safe default. The reset is
+     * unconditional so a previously-loaded ALLOW from a different state
+     * dir does not survive a switch to an unconfigured one. */
+    if (!path || !g_file_test(path, G_FILE_TEST_EXISTS)) {
+        reset_to_safe_default_doc();
+        return;
+    }
+
+    g_autoptr(JsonParser) parser = json_parser_new();
+    g_autoptr(GError) error = NULL;
+    if (!json_parser_load_from_file(parser, path, &error)) {
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                    "exec-approval-store: parse %s failed: %s — falling back to defaults",
+                    path, error ? error->message : "?");
+        /* Corrupt JSON must reset to ASK, not preserve whatever mode we
+         * happened to be holding from a prior load. */
+        reset_to_safe_default_doc();
+        return;
+    }
+
+    JsonNode *root = json_parser_get_root(parser);
+    if (!root || !JSON_NODE_HOLDS_OBJECT(root)) {
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                    "exec-approval-store: %s does not contain a JSON object",
+                    path);
+        reset_to_safe_default_doc();
+        return;
+    }
+
+    /* Take a deep copy of the root so we own the lifetime independently
+     * of the parser. */
+    replace_full_doc(json_node_copy(root));
+
+    JsonObject *root_obj = json_node_get_object(g_full_doc);
+    JsonObject *defaults = oc_json_object_member(root_obj, "defaults");
+    const gchar *security = defaults ? oc_json_string_member(defaults, "security") : NULL;
+    const gchar *ask = defaults ? oc_json_string_member(defaults, "ask") : NULL;
+    g_cached_mode = quick_mode_from_strings(security, ask);
+}
+
+static gboolean write_to_disk_atomic(void) {
+    g_autofree gchar *path = resolve_storage_path();
+    if (!path) return FALSE;
+    if (!ensure_parent_dir(path)) return FALSE;
+
+    if (!g_full_doc) replace_full_doc(build_default_doc());
+
+    /* Update defaults.security/.ask in the carry-through doc. */
+    JsonObject *root_obj = json_node_get_object(g_full_doc);
+    if (!json_object_has_member(root_obj, "version")) {
+        json_object_set_int_member(root_obj, "version", EXEC_APPROVAL_STORE_VERSION);
+    }
+    JsonObject *defaults = oc_json_object_member(root_obj, "defaults");
+    if (!defaults) {
+        defaults = json_object_new();
+        json_object_set_object_member(root_obj, "defaults", defaults);
+    }
+    const gchar *sec = NULL, *ask = NULL;
+    quick_mode_to_strings(g_cached_mode, &sec, &ask);
+    json_object_set_string_member(defaults, "security", sec);
+    json_object_set_string_member(defaults, "ask", ask);
+
+    g_autoptr(JsonGenerator) gen = json_generator_new();
+    json_generator_set_pretty(gen, TRUE);
+    json_generator_set_indent(gen, 2);
+    json_generator_set_root(gen, g_full_doc);
+    g_autofree gchar *data = json_generator_to_data(gen, NULL);
+    if (!data) return FALSE;
+    gsize data_len = strlen(data);
+
+    g_autofree gchar *tmp = g_strdup_printf("%s.tmp.%u", path, g_random_int());
+    int fd = g_open(tmp, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) {
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                    "exec-approval-store: open %s failed: %s",
+                    tmp, g_strerror(errno));
+        return FALSE;
+    }
+    gsize written = 0;
+    while (written < data_len) {
+        gssize n = write(fd, data + written, data_len - written);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            g_close(fd, NULL);
+            (void)g_unlink(tmp);
+            OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                        "exec-approval-store: write %s failed: %s",
+                        tmp, g_strerror(errno));
+            return FALSE;
+        }
+        written += (gsize)n;
+    }
+    (void)fsync(fd);
+    g_close(fd, NULL);
+    (void)g_chmod(tmp, 0600);
+    if (g_rename(tmp, path) != 0) {
+        (void)g_unlink(tmp);
+        OC_LOG_WARN(OPENCLAW_LOG_CAT_GATEWAY,
+                    "exec-approval-store: rename %s -> %s failed: %s",
+                    tmp, path, g_strerror(errno));
+        return FALSE;
+    }
+    (void)g_chmod(path, 0600);
+    g_dirty = FALSE;
+    return TRUE;
+}
+
+void exec_approval_store_init(void) {
+    /* Idempotent: subsequent calls are a no-op. The first call leaves
+     * the cache in defaults until either set_state_dir or get_quick_mode
+     * actually triggers disk I/O. */
+}
+
+void exec_approval_store_shutdown(void) {
+    g_clear_pointer(&g_state_dir, g_free);
+    g_clear_pointer(&g_storage_path_override, g_free);
+    if (g_full_doc) {
+        json_node_unref(g_full_doc);
+        g_full_doc = NULL;
+    }
+    g_cached_mode = OC_EXEC_QUICK_MODE_ASK;
+    g_loaded = FALSE;
+    g_dirty = FALSE;
+}
+
+void exec_approval_store_set_state_dir(const gchar *state_dir) {
+    /* Treat NULL and "" identically: no resolvable path, defer writes. */
+    const gchar *normalized = (state_dir && state_dir[0] != '\0') ? state_dir : NULL;
+
+    if (g_strcmp0(g_state_dir, normalized) == 0) {
+        /* Same dir — flush any pending mutation if we have one and haven't yet. */
+        if (g_dirty && normalized) {
+            (void)write_to_disk_atomic();
+        }
+        return;
+    }
+
+    g_clear_pointer(&g_state_dir, g_free);
+    g_state_dir = normalized ? g_strdup(normalized) : NULL;
+
+    if (!normalized) {
+        /* Cleared dir: keep the in-memory cache so the picker still
+         * reflects the operator's choice, but force a re-read on the
+         * next non-NULL set so we pick up whatever lives at that path. */
+        g_loaded = FALSE;
+        return;
+    }
+
+    if (g_dirty) {
+        /* We had unflushed mutations (e.g. operator toggled the quick
+         * mode before the gateway client resolved the state dir). Flush
+         * them to the freshly-known path so we don't silently lose the
+         * choice. The carry-through doc may not match what's on disk;
+         * we deliberately favor the operator's local intent here. */
+        (void)write_to_disk_atomic();
+        g_loaded = TRUE;
+        return;
+    }
+
+    /*
+     * New dir, no pending dirty state: drop any cached document and
+     * cached mode from the previous state dir BEFORE reading. This is
+     * the critical step that prevents an ALLOW policy from one state
+     * dir leaking into another that has no `exec-approvals.json` file.
+     *
+     * load_from_disk() then either populates the cache from a real file
+     * at the new path, or hits reset_to_safe_default_doc() and lands on
+     * ASK with a fresh default document.
+     */
+    if (g_full_doc) {
+        json_node_unref(g_full_doc);
+        g_full_doc = NULL;
+    }
+    g_cached_mode = OC_EXEC_QUICK_MODE_ASK;
+    g_loaded = FALSE;
+    load_from_disk();
+}
+
+OcExecQuickMode exec_approval_store_get_quick_mode(void) {
+    if (!g_loaded) load_from_disk();
+    return g_cached_mode;
+}
+
+gboolean exec_approval_store_set_quick_mode(OcExecQuickMode mode) {
+    if (!g_loaded) load_from_disk();
+    if (g_cached_mode == mode && !g_dirty) {
+        return resolve_storage_path() != NULL;
+    }
+    g_cached_mode = mode;
+
+    g_autofree gchar *path = resolve_storage_path();
+    if (!path) {
+        /* No state dir yet — buffer until set_state_dir() is called. */
+        g_dirty = TRUE;
+        return FALSE;
+    }
+
+    if (write_to_disk_atomic()) return TRUE;
+    g_dirty = TRUE;
+    return FALSE;
+}
+
+void exec_approval_store_test_set_storage_path(const gchar *path) {
+    g_clear_pointer(&g_storage_path_override, g_free);
+    if (path) g_storage_path_override = g_strdup(path);
+    g_loaded = FALSE;
+    g_dirty = FALSE;
+    if (g_full_doc) {
+        json_node_unref(g_full_doc);
+        g_full_doc = NULL;
+    }
+}
+
+void exec_approval_store_test_reset(void) {
+    g_clear_pointer(&g_state_dir, g_free);
+    g_clear_pointer(&g_storage_path_override, g_free);
+    if (g_full_doc) {
+        json_node_unref(g_full_doc);
+        g_full_doc = NULL;
+    }
+    g_cached_mode = OC_EXEC_QUICK_MODE_ASK;
+    g_loaded = FALSE;
+    g_dirty = FALSE;
+}

--- a/apps/linux/src/exec_approval_store.h
+++ b/apps/linux/src/exec_approval_store.h
@@ -1,0 +1,94 @@
+/*
+ * exec_approval_store.h
+ *
+ * Persisted policy store for in-app exec approvals on Linux.
+ *
+ * Tranche B scope: a single "Quick Mode" default — Deny / Ask / Allow —
+ * mapped onto the macOS-compatible `ExecApprovalsFile` shape so that the
+ * on-disk file can be read by the macOS companion (and vice-versa) when
+ * a state directory is shared:
+ *
+ *   {
+ *     "version":  1,
+ *     "defaults": { "security": "deny|allowlist|full",
+ *                   "ask":      "off|on-miss|always" }
+ *   }
+ *
+ * The `agents` map is reserved for future per-agent overrides and is
+ * preserved on round-trip but never edited by this tranche.
+ *
+ * Path resolution
+ * ───────────────
+ * The state-dir for the file is supplied externally by the caller via
+ * `exec_approval_store_set_state_dir()`. This is required because:
+ *   - the runtime state dir is only known after the gateway client
+ *     resolves it (see gateway_client.c::apply_runtime_paths_*),
+ *   - and may switch on remote/local mode toggles or profile changes.
+ *
+ * Until a state-dir is supplied, mutations are kept in an in-memory
+ * cache and flushed on the first set_state_dir() call.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_EXEC_APPROVAL_STORE_H
+#define OPENCLAW_LINUX_EXEC_APPROVAL_STORE_H
+
+#include <glib.h>
+
+typedef enum {
+    OC_EXEC_QUICK_MODE_DENY  = 0,  /* security=deny,      ask=off    */
+    OC_EXEC_QUICK_MODE_ASK   = 1,  /* security=allowlist, ask=on-miss */
+    OC_EXEC_QUICK_MODE_ALLOW = 2,  /* security=full,      ask=off    */
+} OcExecQuickMode;
+
+/* Init / shutdown the in-process singleton. Idempotent. */
+void exec_approval_store_init(void);
+void exec_approval_store_shutdown(void);
+
+/*
+ * Set or clear the runtime state directory used to resolve the storage
+ * file path (`<state_dir>/exec-approvals.json`).
+ *
+ * Pass NULL to clear (e.g. on connection-mode switch when the new dir
+ * is not yet known); subsequent reads return the in-memory cache and
+ * subsequent mutations are buffered until the next non-NULL call.
+ *
+ * Calling with the same path is a no-op. Calling with a different path
+ * triggers a re-read from the new location, replacing the in-memory
+ * cache and any pending unflushed mutations.
+ *
+ * Safe to call repeatedly; mirrors `gateway_ws_set_identity_context()`
+ * and `remote_tunnel_set_state_dir()` so the gateway client can wire
+ * all three from a single resolve point.
+ */
+void exec_approval_store_set_state_dir(const gchar *state_dir);
+
+/* Current in-memory quick-mode default. Lazy-loads from disk on first
+ * call after init / set_state_dir. */
+OcExecQuickMode exec_approval_store_get_quick_mode(void);
+
+/*
+ * Update the quick-mode default. Persists immediately when a state_dir
+ * is set; otherwise updates the in-memory cache only and defers the
+ * disk write to the next `exec_approval_store_set_state_dir()` call.
+ *
+ * Returns TRUE on persistent write, FALSE when the value was buffered
+ * (no state dir) or when disk I/O failed.
+ */
+gboolean exec_approval_store_set_quick_mode(OcExecQuickMode mode);
+
+/*
+ * Test seam: bypass `set_state_dir()` and pin the storage file path
+ * verbatim. Pass NULL to clear and revert to state-dir resolution.
+ */
+void exec_approval_store_test_set_storage_path(const gchar *path);
+
+/*
+ * Test seam: clear all in-memory state and forget any storage path.
+ * Equivalent to `exec_approval_store_shutdown()` followed by
+ * `exec_approval_store_init()` but does not log.
+ */
+void exec_approval_store_test_reset(void);
+
+#endif /* OPENCLAW_LINUX_EXEC_APPROVAL_STORE_H */

--- a/apps/linux/src/exec_approval_window.c
+++ b/apps/linux/src/exec_approval_window.c
@@ -1,0 +1,205 @@
+/*
+ * exec_approval_window.c
+ *
+ * AdwMessageDialog-based exec-approval prompt. See header for contract.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "exec_approval_window.h"
+
+#include "log.h"
+
+#include <adwaita.h>
+#include <string.h>
+
+typedef struct {
+    OcExecApprovalRequest *req;
+    OcExecDecisionCallback cb;
+    gpointer               user_data;
+    gboolean               silenced;
+} ExecApprovalContext;
+
+/* Track the currently-presented dialog for dismiss/raise. */
+static AdwMessageDialog    *s_active_dialog = NULL;
+static ExecApprovalContext *s_active_ctx    = NULL;
+
+const gchar* oc_exec_decision_to_string(OcExecDecision d) {
+    switch (d) {
+    case OC_EXEC_DECISION_ALLOW_ONCE:   return "allow-once";
+    case OC_EXEC_DECISION_ALLOW_ALWAYS: return "allow-always";
+    case OC_EXEC_DECISION_DENY:
+    default:                            return "deny";
+    }
+}
+
+gboolean oc_exec_decision_from_string(const gchar *value, OcExecDecision *out) {
+    if (!value || !out) return FALSE;
+    if (g_strcmp0(value, "allow-once") == 0)   { *out = OC_EXEC_DECISION_ALLOW_ONCE;   return TRUE; }
+    if (g_strcmp0(value, "allow-always") == 0) { *out = OC_EXEC_DECISION_ALLOW_ALWAYS; return TRUE; }
+    if (g_strcmp0(value, "deny") == 0)         { *out = OC_EXEC_DECISION_DENY;         return TRUE; }
+    return FALSE;
+}
+
+static void append_escaped(GString *out, const gchar *raw) {
+    if (!raw || !raw[0]) return;
+    g_autofree gchar *esc = g_markup_escape_text(raw, -1);
+    if (esc) g_string_append(out, esc);
+}
+
+static void append_kv_row(GString *out, const gchar *label, const gchar *value) {
+    if (!value || !value[0]) return;
+    g_string_append(out, "<b>");
+    append_escaped(out, label);
+    g_string_append(out, ":</b> ");
+    append_escaped(out, value);
+    g_string_append_c(out, '\n');
+}
+
+gchar* oc_exec_approval_build_body_markup(const OcExecApprovalRequest *req) {
+    GString *g = g_string_new(NULL);
+    if (!req) return g_string_free(g, FALSE);
+
+    if (req->command && req->command[0]) {
+        g_string_append(g, "<b>Command</b>\n");
+        g_string_append(g, "<tt>");
+        append_escaped(g, req->command);
+        g_string_append(g, "</tt>\n\n");
+    }
+
+    append_kv_row(g, "Working directory", req->cwd);
+    append_kv_row(g, "Agent",             req->agent_id);
+    append_kv_row(g, "Executable",        req->resolved_path);
+    append_kv_row(g, "Host",              req->host);
+    append_kv_row(g, "Security",          req->security);
+    append_kv_row(g, "Ask mode",          req->ask);
+
+    return g_string_free(g, FALSE);
+}
+
+static void exec_approval_context_free(gpointer data) {
+    ExecApprovalContext *ctx = data;
+    if (!ctx) return;
+    oc_exec_approval_request_free(ctx->req);
+    g_free(ctx);
+}
+
+static void on_dialog_response(AdwMessageDialog *dialog,
+                               const char       *response,
+                               gpointer          user_data) {
+    ExecApprovalContext *ctx = user_data;
+
+    /*
+     * Remote-resolve path: the gateway told us another client handled
+     * this request. Skip the decision callback and tear down quietly.
+     * Mirrors `device_pair_approval_window.c::on_dialog_response`.
+     */
+    if (ctx->silenced) {
+        OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                    "exec approval dialog silenced (remote resolve) id=%s",
+                    ctx->req ? ctx->req->id : "(null)");
+        if (s_active_dialog == dialog) {
+            s_active_dialog = NULL;
+            s_active_ctx    = NULL;
+        }
+        gtk_window_destroy(GTK_WINDOW(dialog));
+        return;
+    }
+
+    OcExecDecision decision = OC_EXEC_DECISION_DENY;
+    if (g_strcmp0(response, "allow-once") == 0)        decision = OC_EXEC_DECISION_ALLOW_ONCE;
+    else if (g_strcmp0(response, "allow-always") == 0) decision = OC_EXEC_DECISION_ALLOW_ALWAYS;
+    else                                               decision = OC_EXEC_DECISION_DENY;
+
+    OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                "exec approval dialog response=%s id=%s",
+                response ? response : "(null)",
+                ctx->req ? ctx->req->id : "(null)");
+
+    if (s_active_dialog == dialog) {
+        s_active_dialog = NULL;
+        s_active_ctx    = NULL;
+    }
+    if (ctx->cb) {
+        ctx->cb(ctx->req, decision, ctx->user_data);
+    }
+    gtk_window_destroy(GTK_WINDOW(dialog));
+}
+
+void exec_approval_window_present(GtkWindow *parent,
+                                  const OcExecApprovalRequest *req,
+                                  OcExecDecisionCallback cb,
+                                  gpointer user_data) {
+    g_return_if_fail(req != NULL);
+
+    ExecApprovalContext *ctx = g_new0(ExecApprovalContext, 1);
+    ctx->req = oc_exec_approval_request_copy(req);
+    ctx->cb = cb;
+    ctx->user_data = user_data;
+
+    g_autofree gchar *body = oc_exec_approval_build_body_markup(req);
+
+    AdwMessageDialog *dialog = ADW_MESSAGE_DIALOG(adw_message_dialog_new(
+        parent,
+        "Allow this command?",
+        NULL));
+    adw_message_dialog_set_body_use_markup(dialog, TRUE);
+    adw_message_dialog_set_body(dialog, body);
+
+    gboolean allow_always_permitted =
+        oc_exec_approval_request_allows_decision(req, "allow-always");
+
+    if (allow_always_permitted) {
+        adw_message_dialog_add_responses(dialog,
+            "deny",         "Don't Allow",
+            "allow-always", "Always Allow",
+            "allow-once",   "Allow Once",
+            NULL);
+    } else {
+        /* Hide the second button entirely — gateway will reject it.
+         * Aligns with `request.allowedDecisions` contract. */
+        adw_message_dialog_add_responses(dialog,
+            "deny",       "Don't Allow",
+            "allow-once", "Allow Once",
+            NULL);
+    }
+    adw_message_dialog_set_response_appearance(dialog, "deny",       ADW_RESPONSE_DESTRUCTIVE);
+    adw_message_dialog_set_response_appearance(dialog, "allow-once", ADW_RESPONSE_SUGGESTED);
+    adw_message_dialog_set_default_response(dialog, "allow-once");
+    /* Close-response = deny: dismissing the dialog (Esc, window-close, etc.)
+     * must never accidentally allow a command. */
+    adw_message_dialog_set_close_response(dialog, "deny");
+
+    g_object_set_data_full(G_OBJECT(dialog),
+                           "oc_exec_approval_ctx",
+                           ctx,
+                           exec_approval_context_free);
+    g_signal_connect(dialog, "response", G_CALLBACK(on_dialog_response), ctx);
+
+    s_active_dialog = dialog;
+    s_active_ctx    = ctx;
+
+    gtk_window_present(GTK_WINDOW(dialog));
+}
+
+gboolean exec_approval_window_dismiss_if(const gchar *request_id) {
+    if (!request_id || !s_active_dialog || !s_active_ctx || !s_active_ctx->req) {
+        return FALSE;
+    }
+    if (g_strcmp0(s_active_ctx->req->id, request_id) != 0) {
+        return FALSE;
+    }
+    AdwMessageDialog *dialog = s_active_dialog;
+    s_active_ctx->silenced = TRUE;
+    /* Drive the response handler via the close response; on_dialog_response
+     * honours `silenced` and skips the decision callback. */
+    adw_message_dialog_response(dialog,
+                                adw_message_dialog_get_close_response(dialog));
+    return TRUE;
+}
+
+void exec_approval_window_raise_active(void) {
+    if (s_active_dialog) {
+        gtk_window_present(GTK_WINDOW(s_active_dialog));
+    }
+}

--- a/apps/linux/src/exec_approval_window.h
+++ b/apps/linux/src/exec_approval_window.h
@@ -1,0 +1,80 @@
+/*
+ * exec_approval_window.h
+ *
+ * Native Linux operator-approval surface for inbound `exec.approval.requested`
+ * events. Mirrors the macOS `ExecApprovalsPromptPresenter` (NSAlert-based
+ * three-button flow) using AdwMessageDialog under libadwaita-1.
+ *
+ * Three decisions are offered:
+ *   - Allow Once   : permit this command this time only
+ *   - Always Allow : permit and remember (gateway adds to allowlist).
+ *                    Hidden when the request's `allowedDecisions` excludes
+ *                    "allow-always" (e.g. effective ask policy = always).
+ *   - Don't Allow  : reject, treated as the close response so dismissing
+ *                    the dialog never accidentally allows.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_EXEC_APPROVAL_WINDOW_H
+#define OPENCLAW_LINUX_EXEC_APPROVAL_WINDOW_H
+
+#include <gtk/gtk.h>
+
+#include "exec_approval_request.h"
+
+typedef enum {
+    OC_EXEC_DECISION_ALLOW_ONCE = 0,
+    OC_EXEC_DECISION_ALLOW_ALWAYS,
+    OC_EXEC_DECISION_DENY,
+} OcExecDecision;
+
+/* Map a decision to its on-the-wire string ("allow-once" / "allow-always" /
+ * "deny"), as required by `exec.approval.resolve` params. Never NULL. */
+const gchar* oc_exec_decision_to_string(OcExecDecision decision);
+
+/* Inverse of the above. Returns FALSE when `value` is unrecognised. */
+gboolean oc_exec_decision_from_string(const gchar *value,
+                                      OcExecDecision *out);
+
+typedef void (*OcExecDecisionCallback)(const OcExecApprovalRequest *req,
+                                       OcExecDecision decision,
+                                       gpointer user_data);
+
+/*
+ * Present the approval dialog. The callback is invoked exactly once on
+ * the main thread when the operator picks one of the three options or
+ * dismisses the dialog (dismissal is reported as DENY).
+ *
+ * `parent` may be NULL.
+ */
+void exec_approval_window_present(GtkWindow *parent,
+                                  const OcExecApprovalRequest *req,
+                                  OcExecDecisionCallback cb,
+                                  gpointer user_data);
+
+/*
+ * If the currently-presented approval dialog is for `request_id`, silently
+ * close it WITHOUT firing the decision callback. Used when the gateway
+ * signals `exec.approval.resolved` for a request another client handled.
+ *
+ * Returns TRUE when a dialog was dismissed.
+ */
+gboolean exec_approval_window_dismiss_if(const gchar *request_id);
+
+/* Raise the active approval dialog if any. */
+void exec_approval_window_raise_active(void);
+
+/*
+ * Build the Pango-markup body shown inside the dialog. All dynamic
+ * fields are passed through `g_markup_escape_text()` before being
+ * interpolated; only the wrapper tags (`<b>...</b>`) are raw markup.
+ *
+ * Pure helper: GLib-only. Exposed so tests can assert the escaping
+ * contract without spinning up GTK / Adwaita.
+ *
+ * Caller frees with `g_free()`.
+ */
+gchar* oc_exec_approval_build_body_markup(const OcExecApprovalRequest *req);
+
+#endif /* OPENCLAW_LINUX_EXEC_APPROVAL_WINDOW_H */

--- a/apps/linux/src/gateway_client.c
+++ b/apps/linux/src/gateway_client.c
@@ -22,6 +22,7 @@
 #include "json_access.h"
 #include "runtime_paths.h"
 #include "device_pair_prompter.h"
+#include "exec_approval_store.h"
 #include "display_model.h"        /* model_catalog_entry_matches_configured_default */
 #include "state.h"
 #include "log.h"
@@ -1027,6 +1028,14 @@ static void apply_runtime_paths_from_current_config(void) {
                                     &paths);
     gateway_ws_set_identity_context(paths.effective_state_dir);
     remote_tunnel_set_state_dir(paths.effective_state_dir);
+    /*
+     * Refresh the exec-approval policy store's state-dir alongside the
+     * other state-dir-rooted singletons. The store buffers any pending
+     * mutation made before this point (e.g. operator toggled the quick
+     * mode while the runtime context was still being resolved) and
+     * flushes it here. Idempotent on repeat calls with the same path.
+     */
+    exec_approval_store_set_state_dir(paths.effective_state_dir);
     runtime_effective_paths_clear(&paths);
     g_free(derived_profile);
     g_free(derived_state_dir);

--- a/apps/linux/src/product_coordinator.c
+++ b/apps/linux/src/product_coordinator.c
@@ -14,6 +14,8 @@
 
 #include "device_pair_prompter.h"
 #include "display_model.h"
+#include "exec_approval_prompter.h"
+#include "exec_approval_store.h"
 #include "gateway_client.h"
 #include "onboarding.h"
 #include "product_state.h"
@@ -45,6 +47,8 @@ static void product_coordinator_boot_runtime_lanes(void) {
     systemd_refresh();
     gateway_client_init();
     device_pair_prompter_init(NULL);
+    exec_approval_store_init();
+    exec_approval_prompter_init(NULL);
 }
 
 static ProductStartupPresentationAction product_coordinator_decide_startup_presentation(

--- a/apps/linux/src/section_general.c
+++ b/apps/linux/src/section_general.c
@@ -15,6 +15,7 @@
 
 #include "connection_mode_resolver.h"
 #include "display_model.h"
+#include "exec_approval_store.h"
 #include "gateway_client.h"
 #include "gateway_config.h"
 #include "gateway_remote_config.h"
@@ -40,6 +41,10 @@ static GtkWidget *gen_connection_mode_dropdown = NULL;
 static GtkStringList *gen_connection_mode_dropdown_model = NULL;
 static GtkWidget *gen_connection_mode_detail_row = NULL;
 static gboolean gen_connection_mode_programmatic_change = FALSE;
+static GtkWidget *gen_approval_mode_dropdown = NULL;
+static GtkStringList *gen_approval_mode_dropdown_model = NULL;
+static GtkWidget *gen_approval_mode_detail_row = NULL;
+static gboolean gen_approval_mode_programmatic_change = FALSE;
 static GtkWidget *gen_endpoint_label = NULL;
 static GtkWidget *gen_version_label = NULL;
 static GtkWidget *gen_auth_mode_label = NULL;
@@ -184,6 +189,81 @@ static void on_gen_connection_mode_selected_notify(GObject *object,
     if (!product_coordinator_request_set_connection_mode(gen_connection_mode_for_selection(selected))) {
         refresh_general_connection_mode_controls();
     }
+}
+
+/* ── Exec approval quick-mode picker ── */
+
+static guint gen_approval_mode_selection_for_mode(OcExecQuickMode mode) {
+    switch (mode) {
+    case OC_EXEC_QUICK_MODE_DENY:  return 0u;
+    case OC_EXEC_QUICK_MODE_ALLOW: return 2u;
+    case OC_EXEC_QUICK_MODE_ASK:
+    default:                       return 1u;
+    }
+}
+
+static OcExecQuickMode gen_approval_mode_for_selection(guint selected) {
+    switch (selected) {
+    case 0u:  return OC_EXEC_QUICK_MODE_DENY;
+    case 2u:  return OC_EXEC_QUICK_MODE_ALLOW;
+    case 1u:
+    default:  return OC_EXEC_QUICK_MODE_ASK;
+    }
+}
+
+static const gchar* gen_approval_mode_detail_text(OcExecQuickMode mode) {
+    switch (mode) {
+    case OC_EXEC_QUICK_MODE_DENY:
+        return "Automatically deny every command without prompting.";
+    case OC_EXEC_QUICK_MODE_ALLOW:
+        return "Automatically allow every command without prompting. Use with care.";
+    case OC_EXEC_QUICK_MODE_ASK:
+    default:
+        return "Show a prompt for each command and decide per request.";
+    }
+}
+
+static void refresh_general_approval_mode_controls(void) {
+    OcExecQuickMode mode = exec_approval_store_get_quick_mode();
+    guint selected = gen_approval_mode_selection_for_mode(mode);
+
+    if (gen_approval_mode_dropdown && ADW_IS_COMBO_ROW(gen_approval_mode_dropdown)) {
+        gen_approval_mode_programmatic_change = TRUE;
+        adw_combo_row_set_selected(ADW_COMBO_ROW(gen_approval_mode_dropdown), selected);
+        gen_approval_mode_programmatic_change = FALSE;
+    }
+
+    if (gen_approval_mode_detail_row && ADW_IS_ACTION_ROW(gen_approval_mode_detail_row)) {
+        adw_action_row_set_subtitle(ADW_ACTION_ROW(gen_approval_mode_detail_row),
+                                    gen_approval_mode_detail_text(mode));
+    }
+}
+
+static void on_gen_approval_mode_selected_notify(GObject *object,
+                                                 GParamSpec *pspec,
+                                                 gpointer user_data) {
+    (void)pspec;
+    (void)user_data;
+
+    if (gen_approval_mode_programmatic_change || !ADW_IS_COMBO_ROW(object)) {
+        return;
+    }
+
+    guint selected = adw_combo_row_get_selected(ADW_COMBO_ROW(object));
+    if (selected == GTK_INVALID_LIST_POSITION) {
+        refresh_general_approval_mode_controls();
+        return;
+    }
+
+    OcExecQuickMode mode = gen_approval_mode_for_selection(selected);
+    /*
+     * `set_quick_mode` returns FALSE when the value was buffered (no
+     * state dir resolved yet) or when disk I/O failed. Both are
+     * non-fatal: the in-memory cache is updated either way and the
+     * gateway-client refresh will flush buffered values to disk.
+     */
+    (void)exec_approval_store_set_quick_mode(mode);
+    refresh_general_approval_mode_controls();
 }
 
 static void general_resolve_effective_paths(RuntimeEffectivePaths *out) {
@@ -694,6 +774,36 @@ static GtkWidget* general_build(void) {
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(connection_group), gen_connection_mode_detail_row);
     refresh_general_connection_mode_controls();
 
+    /* ── Exec approvals quick-mode picker ── */
+    GtkWidget *approvals_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(approvals_group), "Approvals");
+    adw_preferences_group_set_description(ADW_PREFERENCES_GROUP(approvals_group),
+        "Default policy applied to inbound exec approval requests.");
+    adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(approvals_group));
+
+    gen_approval_mode_dropdown = adw_combo_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(gen_approval_mode_dropdown),
+                                  "Approval Mode");
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(approvals_group), gen_approval_mode_dropdown);
+
+    GtkStringList *approval_mode_model = gtk_string_list_new(NULL);
+    /* Order matches gen_approval_mode_for_selection: 0 deny, 1 ask, 2 allow. */
+    gtk_string_list_append(approval_mode_model, "Deny (auto-deny)");
+    gtk_string_list_append(approval_mode_model, "Ask (prompt for each command)");
+    gtk_string_list_append(approval_mode_model, "Allow (auto-allow)");
+    ui_combo_row_replace_model(gen_approval_mode_dropdown,
+                               (gpointer *)&gen_approval_mode_dropdown_model,
+                               G_LIST_MODEL(approval_mode_model),
+                               0);
+    g_signal_connect(gen_approval_mode_dropdown,
+                     "notify::selected",
+                     G_CALLBACK(on_gen_approval_mode_selected_notify),
+                     NULL);
+
+    gen_approval_mode_detail_row = general_note_row("Behavior");
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(approvals_group), gen_approval_mode_detail_row);
+    refresh_general_approval_mode_controls();
+
     /* ── Remote settings group (visible only in remote mode) ── */
     gen_remote_group = adw_preferences_group_new();
     adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(gen_remote_group), "Remote Settings");
@@ -946,6 +1056,7 @@ static void general_refresh(void) {
     runtime_effective_paths_clear(&effective_paths);
 
     refresh_general_connection_mode_controls();
+    refresh_general_approval_mode_controls();
     gen_remote_refresh_group_visibility();
     gen_remote_refresh_status_row();
 
@@ -964,6 +1075,11 @@ static void general_destroy(void) {
     gen_connection_mode_dropdown_model = NULL;
     gen_connection_mode_detail_row = NULL;
     gen_connection_mode_programmatic_change = FALSE;
+    ui_combo_row_detach_model(gen_approval_mode_dropdown, (gpointer *)&gen_approval_mode_dropdown_model);
+    gen_approval_mode_dropdown = NULL;
+    gen_approval_mode_dropdown_model = NULL;
+    gen_approval_mode_detail_row = NULL;
+    gen_approval_mode_programmatic_change = FALSE;
     gen_endpoint_label = NULL;
     gen_version_label = NULL;
     gen_auth_mode_label = NULL;

--- a/apps/linux/tests/test_exec_approval_prompter.c
+++ b/apps/linux/tests/test_exec_approval_prompter.c
@@ -1,0 +1,590 @@
+/*
+ * test_exec_approval_prompter.c
+ *
+ * Headless coverage for the exec-approval prompter state machine. Uses
+ * the test seam present hook plus stubs for gateway_ws / gateway_rpc /
+ * exec_approval_window so the translation unit links without GTK or a
+ * live gateway.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "../src/exec_approval_prompter.h"
+#include "../src/exec_approval_request.h"
+#include "../src/exec_approval_store.h"
+#include "../src/exec_approval_window.h"
+
+#include "../src/gateway_rpc.h"
+#include "../src/gateway_ws.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <json-glib/json-glib.h>
+#include <string.h>
+
+/* ── gateway_ws stubs ── */
+
+static GatewayWsEventCallback g_ws_event_cb = NULL;
+static gpointer               g_ws_event_user = NULL;
+static guint                  g_ws_event_id_counter = 0;
+
+guint gateway_ws_event_subscribe(GatewayWsEventCallback callback, gpointer user_data) {
+    g_ws_event_cb = callback;
+    g_ws_event_user = user_data;
+    return ++g_ws_event_id_counter;
+}
+
+void gateway_ws_event_unsubscribe(guint listener_id) {
+    (void)listener_id;
+    g_ws_event_cb = NULL;
+    g_ws_event_user = NULL;
+}
+
+/* ── gateway_rpc stub ── */
+
+typedef struct {
+    gchar *method;
+    gchar *id;
+    gchar *decision;
+} RecordedRpc;
+
+static GPtrArray *g_rpc_calls = NULL;
+
+static void recorded_rpc_free(gpointer data) {
+    RecordedRpc *r = data;
+    if (!r) return;
+    g_free(r->method);
+    g_free(r->id);
+    g_free(r->decision);
+    g_free(r);
+}
+
+gchar* gateway_rpc_request(const gchar *method,
+                           JsonNode *params_json,
+                           guint timeout_ms,
+                           GatewayRpcCallback callback,
+                           gpointer user_data) {
+    (void)timeout_ms;
+    (void)callback;
+    /* The prompter passes a heap-owned id copy as user_data; if we never
+     * invoke the callback the prompter never frees it, so we free it
+     * here to keep tests leak-clean. */
+    g_free(user_data);
+
+    if (!g_rpc_calls) g_rpc_calls = g_ptr_array_new_with_free_func(recorded_rpc_free);
+    RecordedRpc *rec = g_new0(RecordedRpc, 1);
+    rec->method = g_strdup(method);
+    if (params_json && JSON_NODE_HOLDS_OBJECT(params_json)) {
+        JsonObject *obj = json_node_get_object(params_json);
+        if (json_object_has_member(obj, "id")) {
+            rec->id = g_strdup(json_object_get_string_member(obj, "id"));
+        }
+        if (json_object_has_member(obj, "decision")) {
+            rec->decision = g_strdup(json_object_get_string_member(obj, "decision"));
+        }
+    }
+    g_ptr_array_add(g_rpc_calls, rec);
+    return g_strdup("rpc-test-0001");
+}
+
+/* ── exec_approval_window stubs ── */
+
+static int    g_dismiss_calls = 0;
+static gchar *g_dismiss_last_id = NULL;
+static int    g_raise_calls = 0;
+
+void exec_approval_window_present(GtkWindow *parent,
+                                  const OcExecApprovalRequest *req,
+                                  OcExecDecisionCallback cb,
+                                  gpointer user_data) {
+    (void)parent; (void)req; (void)cb; (void)user_data;
+    g_error("exec_approval_window_present stub invoked — test hook not installed");
+}
+
+gboolean exec_approval_window_dismiss_if(const gchar *request_id) {
+    g_dismiss_calls++;
+    g_clear_pointer(&g_dismiss_last_id, g_free);
+    if (request_id) g_dismiss_last_id = g_strdup(request_id);
+    return TRUE;
+}
+
+void exec_approval_window_raise_active(void) {
+    g_raise_calls++;
+}
+
+const gchar* oc_exec_decision_to_string(OcExecDecision d) {
+    switch (d) {
+    case OC_EXEC_DECISION_ALLOW_ONCE:   return "allow-once";
+    case OC_EXEC_DECISION_ALLOW_ALWAYS: return "allow-always";
+    case OC_EXEC_DECISION_DENY:
+    default:                            return "deny";
+    }
+}
+
+gboolean oc_exec_decision_from_string(const gchar *value, OcExecDecision *out) {
+    if (!value || !out) return FALSE;
+    if (g_strcmp0(value, "allow-once") == 0)   { *out = OC_EXEC_DECISION_ALLOW_ONCE;   return TRUE; }
+    if (g_strcmp0(value, "allow-always") == 0) { *out = OC_EXEC_DECISION_ALLOW_ALWAYS; return TRUE; }
+    if (g_strcmp0(value, "deny") == 0)         { *out = OC_EXEC_DECISION_DENY;         return TRUE; }
+    return FALSE;
+}
+
+gchar* oc_exec_approval_build_body_markup(const OcExecApprovalRequest *req) {
+    (void)req;
+    return g_strdup("");
+}
+
+/* ── Test seam: scripted recorder hook ── */
+
+typedef struct {
+    OcExecDecision *scripted_decisions;
+    gsize           count;
+    gsize           index;
+    GPtrArray      *seen_ids;
+} ScriptedHook;
+
+static void scripted_present(const OcExecApprovalRequest *req,
+                             OcExecDecisionCallback record_decision,
+                             gpointer record_user_data,
+                             gpointer hook_user_data) {
+    ScriptedHook *s = hook_user_data;
+    g_ptr_array_add(s->seen_ids, g_strdup(req->id));
+    OcExecDecision d = OC_EXEC_DECISION_ALLOW_ONCE;
+    if (s->index < s->count) d = s->scripted_decisions[s->index++];
+    record_decision(req, d, record_user_data);
+}
+
+typedef struct {
+    GPtrArray *seen_ids;
+} PendingHook;
+
+static void pending_present(const OcExecApprovalRequest *req,
+                            OcExecDecisionCallback record_decision,
+                            gpointer record_user_data,
+                            gpointer hook_user_data) {
+    (void)record_decision; (void)record_user_data;
+    PendingHook *p = hook_user_data;
+    g_ptr_array_add(p->seen_ids, g_strdup(req->id));
+    /* Intentionally do not call record_decision; prompter stays presenting. */
+}
+
+/* ── Helpers ── */
+
+static void reset_globals(void) {
+    if (g_rpc_calls) {
+        g_ptr_array_free(g_rpc_calls, TRUE);
+        g_rpc_calls = NULL;
+    }
+    g_dismiss_calls = 0;
+    g_clear_pointer(&g_dismiss_last_id, g_free);
+    g_raise_calls = 0;
+    g_ws_event_cb = NULL;
+    g_ws_event_user = NULL;
+    g_ws_event_id_counter = 0;
+    /* Reset the policy store and pin to ASK so we exercise the
+     * prompt-presenting path by default. Individual tests that need
+     * Deny/Allow override via exec_approval_store_set_quick_mode. */
+    exec_approval_store_test_reset();
+    exec_approval_store_test_set_storage_path(NULL);
+}
+
+static JsonNode* make_requested_payload_full(const gchar *id,
+                                             const gchar *command,
+                                             gint64 created_ms,
+                                             gint64 expires_ms,
+                                             const gchar * const *allowed_decisions) {
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "id");
+    json_builder_add_string_value(b, id);
+    json_builder_set_member_name(b, "request");
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "command");
+    json_builder_add_string_value(b, command ? command : "ls");
+    if (allowed_decisions) {
+        json_builder_set_member_name(b, "allowedDecisions");
+        json_builder_begin_array(b);
+        for (gsize i = 0; allowed_decisions[i]; i++) {
+            json_builder_add_string_value(b, allowed_decisions[i]);
+        }
+        json_builder_end_array(b);
+    }
+    json_builder_end_object(b);
+    json_builder_set_member_name(b, "createdAtMs");
+    json_builder_add_int_value(b, created_ms);
+    json_builder_set_member_name(b, "expiresAtMs");
+    json_builder_add_int_value(b, expires_ms);
+    json_builder_end_object(b);
+    JsonNode *root = json_builder_get_root(b);
+    g_object_unref(b);
+    return root;
+}
+
+static JsonNode* make_requested_payload(const gchar *id) {
+    /* Default: not-yet-expired window from now+1s..now+60s. */
+    gint64 now = oc_exec_approval_now_ms();
+    return make_requested_payload_full(id, "echo hi",
+                                       now + 1000, now + 60000, NULL);
+}
+
+static JsonNode* make_resolved_payload(const gchar *id, const gchar *decision) {
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "id");
+    json_builder_add_string_value(b, id);
+    if (decision) {
+        json_builder_set_member_name(b, "decision");
+        json_builder_add_string_value(b, decision);
+    }
+    json_builder_end_object(b);
+    JsonNode *root = json_builder_get_root(b);
+    g_object_unref(b);
+    return root;
+}
+
+/* ── Tests ── */
+
+static void test_single_request_allowed_once(void) {
+    reset_globals();
+    exec_approval_prompter_init(NULL);
+
+    OcExecDecision decisions[] = { OC_EXEC_DECISION_ALLOW_ONCE };
+    ScriptedHook s = {
+        .scripted_decisions = decisions,
+        .count = 1,
+        .seen_ids = g_ptr_array_new_with_free_func(g_free),
+    };
+    exec_approval_prompter_test_set_present_hook(scripted_present, &s);
+
+    g_autoptr(JsonNode) payload = make_requested_payload("req-1");
+    exec_approval_prompter_test_inject_event(payload);
+
+    g_assert_cmpuint(s.seen_ids->len, ==, 1);
+    g_assert_cmpstr(g_ptr_array_index(s.seen_ids, 0), ==, "req-1");
+    g_assert_cmpuint(exec_approval_prompter_test_queue_len(), ==, 0);
+    g_assert_false(exec_approval_prompter_test_is_presenting());
+
+    g_assert_nonnull(g_rpc_calls);
+    g_assert_cmpuint(g_rpc_calls->len, ==, 1);
+    RecordedRpc *r = g_ptr_array_index(g_rpc_calls, 0);
+    g_assert_cmpstr(r->method, ==, "exec.approval.resolve");
+    g_assert_cmpstr(r->id, ==, "req-1");
+    g_assert_cmpstr(r->decision, ==, "allow-once");
+
+    exec_approval_prompter_test_set_present_hook(NULL, NULL);
+    exec_approval_prompter_shutdown();
+    g_ptr_array_free(s.seen_ids, TRUE);
+}
+
+static void test_concurrent_requests_serialized(void) {
+    reset_globals();
+    exec_approval_prompter_init(NULL);
+
+    OcExecDecision decisions[] = {
+        OC_EXEC_DECISION_ALLOW_ONCE,
+        OC_EXEC_DECISION_DENY,
+        OC_EXEC_DECISION_ALLOW_ONCE,
+    };
+    ScriptedHook s = {
+        .scripted_decisions = decisions,
+        .count = 3,
+        .seen_ids = g_ptr_array_new_with_free_func(g_free),
+    };
+    exec_approval_prompter_test_set_present_hook(scripted_present, &s);
+
+    g_autoptr(JsonNode) p1 = make_requested_payload("req-A");
+    g_autoptr(JsonNode) p2 = make_requested_payload("req-B");
+    g_autoptr(JsonNode) p3 = make_requested_payload("req-C");
+    exec_approval_prompter_test_inject_event(p1);
+    exec_approval_prompter_test_inject_event(p2);
+    exec_approval_prompter_test_inject_event(p3);
+
+    g_assert_cmpuint(s.seen_ids->len, ==, 3);
+    g_assert_cmpstr(g_ptr_array_index(s.seen_ids, 0), ==, "req-A");
+    g_assert_cmpstr(g_ptr_array_index(s.seen_ids, 1), ==, "req-B");
+    g_assert_cmpstr(g_ptr_array_index(s.seen_ids, 2), ==, "req-C");
+    g_assert_cmpuint(g_rpc_calls->len, ==, 3);
+    g_assert_cmpstr(((RecordedRpc *)g_ptr_array_index(g_rpc_calls, 1))->decision,
+                    ==, "deny");
+
+    exec_approval_prompter_test_set_present_hook(NULL, NULL);
+    exec_approval_prompter_shutdown();
+    g_ptr_array_free(s.seen_ids, TRUE);
+}
+
+static void test_invalid_payload_dropped(void) {
+    reset_globals();
+    exec_approval_prompter_init(NULL);
+
+    PendingHook p = { .seen_ids = g_ptr_array_new_with_free_func(g_free) };
+    exec_approval_prompter_test_set_present_hook(pending_present, &p);
+
+    /* Missing id. */
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "request");
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "command");
+    json_builder_add_string_value(b, "ls");
+    json_builder_end_object(b);
+    json_builder_set_member_name(b, "createdAtMs");
+    json_builder_add_int_value(b, 1);
+    json_builder_set_member_name(b, "expiresAtMs");
+    json_builder_add_int_value(b, 100);
+    json_builder_end_object(b);
+    g_autoptr(JsonNode) bad = json_builder_get_root(b);
+    g_object_unref(b);
+
+    exec_approval_prompter_test_inject_event(bad);
+    g_assert_cmpuint(p.seen_ids->len, ==, 0);
+    g_assert_cmpuint(exec_approval_prompter_test_queue_len(), ==, 0);
+    g_assert_null(g_rpc_calls);
+
+    exec_approval_prompter_test_set_present_hook(NULL, NULL);
+    exec_approval_prompter_shutdown();
+    g_ptr_array_free(p.seen_ids, TRUE);
+}
+
+static void test_expired_request_dropped_silently(void) {
+    reset_globals();
+    exec_approval_prompter_init(NULL);
+
+    PendingHook p = { .seen_ids = g_ptr_array_new_with_free_func(g_free) };
+    exec_approval_prompter_test_set_present_hook(pending_present, &p);
+
+    /* Expires in the distant past. */
+    g_autoptr(JsonNode) payload = make_requested_payload_full(
+        "req-old", "ls", 100, 200, NULL);
+    exec_approval_prompter_test_inject_event(payload);
+
+    g_assert_cmpuint(p.seen_ids->len, ==, 0);
+    g_assert_false(exec_approval_prompter_test_is_presenting());
+    g_assert_cmpuint(exec_approval_prompter_test_queue_len(), ==, 0);
+    g_assert_null(g_rpc_calls);
+
+    exec_approval_prompter_test_set_present_hook(NULL, NULL);
+    exec_approval_prompter_shutdown();
+    g_ptr_array_free(p.seen_ids, TRUE);
+}
+
+static void test_resolved_while_active_silences_dialog(void) {
+    reset_globals();
+    exec_approval_prompter_init(NULL);
+
+    PendingHook p = { .seen_ids = g_ptr_array_new_with_free_func(g_free) };
+    exec_approval_prompter_test_set_present_hook(pending_present, &p);
+
+    g_autoptr(JsonNode) payload = make_requested_payload("req-XYZ");
+    exec_approval_prompter_test_inject_event(payload);
+    g_assert_true(exec_approval_prompter_test_is_presenting());
+    g_assert_cmpuint(exec_approval_prompter_pending_count(), ==, 1);
+
+    g_autoptr(JsonNode) resolved = make_resolved_payload("req-XYZ", "allow-once");
+    exec_approval_prompter_test_inject_resolved(resolved);
+
+    g_assert_cmpint(g_dismiss_calls, ==, 1);
+    g_assert_cmpstr(g_dismiss_last_id, ==, "req-XYZ");
+    g_assert_false(exec_approval_prompter_test_is_presenting());
+    g_assert_cmpuint(exec_approval_prompter_pending_count(), ==, 0);
+    g_assert_null(g_rpc_calls); /* No RPC issued by us. */
+
+    exec_approval_prompter_test_set_present_hook(NULL, NULL);
+    exec_approval_prompter_shutdown();
+    g_ptr_array_free(p.seen_ids, TRUE);
+}
+
+static void test_resolved_while_queued_drops_silently(void) {
+    reset_globals();
+    exec_approval_prompter_init(NULL);
+
+    PendingHook p = { .seen_ids = g_ptr_array_new_with_free_func(g_free) };
+    exec_approval_prompter_test_set_present_hook(pending_present, &p);
+
+    g_autoptr(JsonNode) first  = make_requested_payload("req-1");
+    g_autoptr(JsonNode) queued = make_requested_payload("req-2");
+    exec_approval_prompter_test_inject_event(first);
+    exec_approval_prompter_test_inject_event(queued);
+    g_assert_cmpuint(exec_approval_prompter_test_queue_len(), ==, 1);
+
+    g_autoptr(JsonNode) resolved = make_resolved_payload("req-2", "deny");
+    exec_approval_prompter_test_inject_resolved(resolved);
+
+    g_assert_cmpint(g_dismiss_calls, ==, 0);
+    g_assert_cmpuint(exec_approval_prompter_test_queue_len(), ==, 0);
+    g_assert_true(exec_approval_prompter_test_is_presenting());
+    g_assert_cmpuint(exec_approval_prompter_pending_count(), ==, 1);
+
+    exec_approval_prompter_test_set_present_hook(NULL, NULL);
+    exec_approval_prompter_shutdown();
+    g_ptr_array_free(p.seen_ids, TRUE);
+}
+
+static void test_duplicate_request_id_dedups(void) {
+    reset_globals();
+    exec_approval_prompter_init(NULL);
+
+    PendingHook p = { .seen_ids = g_ptr_array_new_with_free_func(g_free) };
+    exec_approval_prompter_test_set_present_hook(pending_present, &p);
+
+    g_autoptr(JsonNode) first = make_requested_payload("req-1");
+    g_autoptr(JsonNode) dup   = make_requested_payload("req-1");
+    exec_approval_prompter_test_inject_event(first);
+    exec_approval_prompter_test_inject_event(dup);
+
+    g_assert_cmpuint(p.seen_ids->len, ==, 1);
+    g_assert_cmpuint(exec_approval_prompter_test_queue_len(), ==, 0);
+    g_assert_cmpuint(exec_approval_prompter_pending_count(), ==, 1);
+
+    exec_approval_prompter_test_set_present_hook(NULL, NULL);
+    exec_approval_prompter_shutdown();
+    g_ptr_array_free(p.seen_ids, TRUE);
+}
+
+static void test_quick_mode_deny_auto_resolves_without_prompting(void) {
+    reset_globals();
+    exec_approval_prompter_init(NULL);
+
+    PendingHook p = { .seen_ids = g_ptr_array_new_with_free_func(g_free) };
+    exec_approval_prompter_test_set_present_hook(pending_present, &p);
+
+    /* Force the policy to Deny without touching disk. */
+    g_autofree gchar *tmpfile = g_build_filename(g_get_tmp_dir(),
+                                                 "openclaw-exec-approval-test-deny.json",
+                                                 NULL);
+    g_unlink(tmpfile);
+    exec_approval_store_test_set_storage_path(tmpfile);
+    g_assert_false(exec_approval_store_set_quick_mode(OC_EXEC_QUICK_MODE_DENY) == FALSE
+                   && exec_approval_store_get_quick_mode() != OC_EXEC_QUICK_MODE_DENY);
+
+    g_autoptr(JsonNode) payload = make_requested_payload("req-deny");
+    exec_approval_prompter_test_inject_event(payload);
+
+    g_assert_cmpuint(p.seen_ids->len, ==, 0);
+    g_assert_false(exec_approval_prompter_test_is_presenting());
+    g_assert_nonnull(g_rpc_calls);
+    g_assert_cmpuint(g_rpc_calls->len, ==, 1);
+    RecordedRpc *r = g_ptr_array_index(g_rpc_calls, 0);
+    g_assert_cmpstr(r->decision, ==, "deny");
+
+    g_unlink(tmpfile);
+    exec_approval_prompter_test_set_present_hook(NULL, NULL);
+    exec_approval_prompter_shutdown();
+    g_ptr_array_free(p.seen_ids, TRUE);
+}
+
+static void test_quick_mode_allow_auto_resolves_as_allow_once(void) {
+    reset_globals();
+    exec_approval_prompter_init(NULL);
+
+    PendingHook p = { .seen_ids = g_ptr_array_new_with_free_func(g_free) };
+    exec_approval_prompter_test_set_present_hook(pending_present, &p);
+
+    g_autofree gchar *tmpfile = g_build_filename(g_get_tmp_dir(),
+                                                 "openclaw-exec-approval-test-allow.json",
+                                                 NULL);
+    g_unlink(tmpfile);
+    exec_approval_store_test_set_storage_path(tmpfile);
+    (void)exec_approval_store_set_quick_mode(OC_EXEC_QUICK_MODE_ALLOW);
+
+    /* Constrain allowedDecisions to allow-once + deny only — confirms we
+     * never request allow-always when the gateway forbade it. */
+    const gchar *allowed[] = { "allow-once", "deny", NULL };
+    g_autoptr(JsonNode) payload = make_requested_payload_full(
+        "req-allow", "ls",
+        oc_exec_approval_now_ms() + 1000,
+        oc_exec_approval_now_ms() + 60000,
+        allowed);
+    exec_approval_prompter_test_inject_event(payload);
+
+    g_assert_cmpuint(p.seen_ids->len, ==, 0);
+    g_assert_nonnull(g_rpc_calls);
+    g_assert_cmpuint(g_rpc_calls->len, ==, 1);
+    RecordedRpc *r = g_ptr_array_index(g_rpc_calls, 0);
+    g_assert_cmpstr(r->decision, ==, "allow-once");
+
+    g_unlink(tmpfile);
+    exec_approval_prompter_test_set_present_hook(NULL, NULL);
+    exec_approval_prompter_shutdown();
+    g_ptr_array_free(p.seen_ids, TRUE);
+}
+
+static void test_allow_always_downgraded_when_not_permitted(void) {
+    reset_globals();
+    exec_approval_prompter_init(NULL);
+
+    OcExecDecision decisions[] = { OC_EXEC_DECISION_ALLOW_ALWAYS };
+    ScriptedHook s = {
+        .scripted_decisions = decisions,
+        .count = 1,
+        .seen_ids = g_ptr_array_new_with_free_func(g_free),
+    };
+    exec_approval_prompter_test_set_present_hook(scripted_present, &s);
+
+    /* Quick mode = ASK so we present. allowedDecisions excludes
+     * allow-always; the prompter must downgrade to allow-once. */
+    const gchar *allowed[] = { "allow-once", "deny", NULL };
+    g_autoptr(JsonNode) payload = make_requested_payload_full(
+        "req-downgrade", "ls",
+        oc_exec_approval_now_ms() + 1000,
+        oc_exec_approval_now_ms() + 60000,
+        allowed);
+    exec_approval_prompter_test_inject_event(payload);
+
+    g_assert_nonnull(g_rpc_calls);
+    g_assert_cmpuint(g_rpc_calls->len, ==, 1);
+    RecordedRpc *r = g_ptr_array_index(g_rpc_calls, 0);
+    g_assert_cmpstr(r->id, ==, "req-downgrade");
+    g_assert_cmpstr(r->decision, ==, "allow-once");
+
+    exec_approval_prompter_test_set_present_hook(NULL, NULL);
+    exec_approval_prompter_shutdown();
+    g_ptr_array_free(s.seen_ids, TRUE);
+}
+
+static void test_parent_weak_ref_cleared_on_destroy(void) {
+    reset_globals();
+    exec_approval_prompter_init(NULL);
+
+    GObject *fake_window = g_object_new(G_TYPE_OBJECT, NULL);
+    exec_approval_prompter_set_parent((GtkWindow *)fake_window);
+    g_assert_true(exec_approval_prompter_test_get_parent() == fake_window);
+
+    g_object_unref(fake_window);
+    g_assert_null(exec_approval_prompter_test_get_parent());
+
+    exec_approval_prompter_shutdown();
+}
+
+static void test_shutdown_detaches_weak_ref(void) {
+    reset_globals();
+    GObject *fake_window = g_object_new(G_TYPE_OBJECT, NULL);
+    exec_approval_prompter_init((GtkWindow *)fake_window);
+    g_assert_true(exec_approval_prompter_test_get_parent() == fake_window);
+
+    exec_approval_prompter_shutdown();
+    g_assert_null(exec_approval_prompter_test_get_parent());
+
+    g_object_unref(fake_window);
+    g_assert_null(exec_approval_prompter_test_get_parent());
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    /* The prompter intentionally emits g_warning for negative-path
+     * scenarios (invalid payload, RPC dispatch failure). Don't abort
+     * the test process on those — only on hard errors / criticals. */
+    g_log_set_always_fatal((GLogLevelFlags)(G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL));
+    g_test_add_func("/exec_approval_prompter/single_request",        test_single_request_allowed_once);
+    g_test_add_func("/exec_approval_prompter/concurrent_serialized", test_concurrent_requests_serialized);
+    g_test_add_func("/exec_approval_prompter/invalid_payload",       test_invalid_payload_dropped);
+    g_test_add_func("/exec_approval_prompter/expired_dropped",       test_expired_request_dropped_silently);
+    g_test_add_func("/exec_approval_prompter/resolved_active",       test_resolved_while_active_silences_dialog);
+    g_test_add_func("/exec_approval_prompter/resolved_queued",       test_resolved_while_queued_drops_silently);
+    g_test_add_func("/exec_approval_prompter/dedupe_request_id",     test_duplicate_request_id_dedups);
+    g_test_add_func("/exec_approval_prompter/auto_deny",             test_quick_mode_deny_auto_resolves_without_prompting);
+    g_test_add_func("/exec_approval_prompter/auto_allow_once",       test_quick_mode_allow_auto_resolves_as_allow_once);
+    g_test_add_func("/exec_approval_prompter/allow_always_downgrade", test_allow_always_downgraded_when_not_permitted);
+    g_test_add_func("/exec_approval_prompter/parent_weak_ref",       test_parent_weak_ref_cleared_on_destroy);
+    g_test_add_func("/exec_approval_prompter/shutdown_weak_ref",     test_shutdown_detaches_weak_ref);
+    return g_test_run();
+}

--- a/apps/linux/tests/test_exec_approval_request.c
+++ b/apps/linux/tests/test_exec_approval_request.c
@@ -1,0 +1,222 @@
+/*
+ * test_exec_approval_request.c
+ *
+ * Headless coverage for the exec-approval request parser. Pure-C /
+ * json-glib; no GTK linkage required.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "../src/exec_approval_request.h"
+
+#include <glib.h>
+#include <json-glib/json-glib.h>
+#include <string.h>
+
+static JsonNode* build_full_payload(void) {
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "id");
+    json_builder_add_string_value(b, "req-1");
+
+    json_builder_set_member_name(b, "request");
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "command");
+    json_builder_add_string_value(b, "rm -rf /");
+    json_builder_set_member_name(b, "cwd");
+    json_builder_add_string_value(b, "/tmp");
+    json_builder_set_member_name(b, "host");
+    json_builder_add_string_value(b, "node");
+    json_builder_set_member_name(b, "nodeId");
+    json_builder_add_string_value(b, "node-7");
+    json_builder_set_member_name(b, "agentId");
+    json_builder_add_string_value(b, "agent-007");
+    json_builder_set_member_name(b, "resolvedPath");
+    json_builder_add_string_value(b, "/usr/bin/rm");
+    json_builder_set_member_name(b, "security");
+    json_builder_add_string_value(b, "allowlist");
+    json_builder_set_member_name(b, "ask");
+    json_builder_add_string_value(b, "always");
+    json_builder_set_member_name(b, "sessionKey");
+    json_builder_add_string_value(b, "sess-9");
+    json_builder_set_member_name(b, "allowedDecisions");
+    json_builder_begin_array(b);
+    json_builder_add_string_value(b, "allow-once");
+    json_builder_add_string_value(b, "deny");
+    json_builder_end_array(b);
+    json_builder_end_object(b);
+
+    json_builder_set_member_name(b, "createdAtMs");
+    json_builder_add_int_value(b, 1000);
+    json_builder_set_member_name(b, "expiresAtMs");
+    json_builder_add_int_value(b, 60000);
+    json_builder_end_object(b);
+
+    JsonNode *root = json_builder_get_root(b);
+    g_object_unref(b);
+    return root;
+}
+
+static void test_parse_full_payload(void) {
+    g_autoptr(JsonNode) payload = build_full_payload();
+    OcExecApprovalRequest *req = oc_exec_approval_request_new_from_event(payload);
+    g_assert_nonnull(req);
+
+    g_assert_cmpstr(req->id, ==, "req-1");
+    g_assert_cmpstr(req->command, ==, "rm -rf /");
+    g_assert_cmpstr(req->cwd, ==, "/tmp");
+    g_assert_cmpstr(req->host, ==, "node");
+    g_assert_cmpstr(req->node_id, ==, "node-7");
+    g_assert_cmpstr(req->agent_id, ==, "agent-007");
+    g_assert_cmpstr(req->resolved_path, ==, "/usr/bin/rm");
+    g_assert_cmpstr(req->security, ==, "allowlist");
+    g_assert_cmpstr(req->ask, ==, "always");
+    g_assert_cmpstr(req->session_key, ==, "sess-9");
+    g_assert_cmpint(req->created_at_ms, ==, 1000);
+    g_assert_cmpint(req->expires_at_ms, ==, 60000);
+
+    g_assert_nonnull(req->allowed_decisions);
+    g_assert_cmpstr(req->allowed_decisions[0], ==, "allow-once");
+    g_assert_cmpstr(req->allowed_decisions[1], ==, "deny");
+    g_assert_null(req->allowed_decisions[2]);
+
+    g_assert_true(oc_exec_approval_request_allows_decision(req, "allow-once"));
+    g_assert_true(oc_exec_approval_request_allows_decision(req, "deny"));
+    g_assert_false(oc_exec_approval_request_allows_decision(req, "allow-always"));
+
+    oc_exec_approval_request_free(req);
+}
+
+static void test_parse_minimal_payload(void) {
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "id");
+    json_builder_add_string_value(b, "req-min");
+    json_builder_set_member_name(b, "request");
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "command");
+    json_builder_add_string_value(b, "ls");
+    json_builder_end_object(b);
+    json_builder_set_member_name(b, "createdAtMs");
+    json_builder_add_int_value(b, 1);
+    json_builder_set_member_name(b, "expiresAtMs");
+    json_builder_add_int_value(b, 100);
+    json_builder_end_object(b);
+    g_autoptr(JsonNode) payload = json_builder_get_root(b);
+    g_object_unref(b);
+
+    OcExecApprovalRequest *req = oc_exec_approval_request_new_from_event(payload);
+    g_assert_nonnull(req);
+    g_assert_cmpstr(req->id, ==, "req-min");
+    g_assert_cmpstr(req->command, ==, "ls");
+    g_assert_null(req->cwd);
+    g_assert_null(req->agent_id);
+    g_assert_null(req->allowed_decisions);
+    /* Omitted constraint = all decisions allowed. */
+    g_assert_true(oc_exec_approval_request_allows_decision(req, "allow-once"));
+    g_assert_true(oc_exec_approval_request_allows_decision(req, "allow-always"));
+    g_assert_true(oc_exec_approval_request_allows_decision(req, "deny"));
+    oc_exec_approval_request_free(req);
+}
+
+static void test_reject_missing_id(void) {
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "request");
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "command");
+    json_builder_add_string_value(b, "ls");
+    json_builder_end_object(b);
+    json_builder_set_member_name(b, "createdAtMs");
+    json_builder_add_int_value(b, 1);
+    json_builder_set_member_name(b, "expiresAtMs");
+    json_builder_add_int_value(b, 100);
+    json_builder_end_object(b);
+    g_autoptr(JsonNode) payload = json_builder_get_root(b);
+    g_object_unref(b);
+
+    OcExecApprovalRequest *req = oc_exec_approval_request_new_from_event(payload);
+    g_assert_null(req);
+}
+
+static void test_reject_missing_command(void) {
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "id");
+    json_builder_add_string_value(b, "req-x");
+    json_builder_set_member_name(b, "request");
+    json_builder_begin_object(b);
+    json_builder_end_object(b);
+    json_builder_set_member_name(b, "createdAtMs");
+    json_builder_add_int_value(b, 1);
+    json_builder_set_member_name(b, "expiresAtMs");
+    json_builder_add_int_value(b, 100);
+    json_builder_end_object(b);
+    g_autoptr(JsonNode) payload = json_builder_get_root(b);
+    g_object_unref(b);
+
+    OcExecApprovalRequest *req = oc_exec_approval_request_new_from_event(payload);
+    g_assert_null(req);
+}
+
+static void test_reject_missing_timestamps(void) {
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "id");
+    json_builder_add_string_value(b, "req-x");
+    json_builder_set_member_name(b, "request");
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "command");
+    json_builder_add_string_value(b, "ls");
+    json_builder_end_object(b);
+    json_builder_end_object(b);
+    g_autoptr(JsonNode) payload = json_builder_get_root(b);
+    g_object_unref(b);
+
+    OcExecApprovalRequest *req = oc_exec_approval_request_new_from_event(payload);
+    g_assert_null(req);
+}
+
+static void test_expired_helper(void) {
+    g_autoptr(JsonNode) payload = build_full_payload();
+    OcExecApprovalRequest *req = oc_exec_approval_request_new_from_event(payload);
+    g_assert_nonnull(req);
+    g_assert_false(oc_exec_approval_request_is_expired(req, 0));
+    g_assert_false(oc_exec_approval_request_is_expired(req, 59999));
+    g_assert_true(oc_exec_approval_request_is_expired(req, 60000));
+    g_assert_true(oc_exec_approval_request_is_expired(req, 70000));
+    oc_exec_approval_request_free(req);
+}
+
+static void test_copy_round_trip(void) {
+    g_autoptr(JsonNode) payload = build_full_payload();
+    OcExecApprovalRequest *src = oc_exec_approval_request_new_from_event(payload);
+    g_assert_nonnull(src);
+
+    OcExecApprovalRequest *dup = oc_exec_approval_request_copy(src);
+    g_assert_nonnull(dup);
+    g_assert_cmpstr(dup->id, ==, src->id);
+    g_assert_cmpstr(dup->command, ==, src->command);
+    g_assert_cmpstr(dup->agent_id, ==, src->agent_id);
+    g_assert_cmpint(dup->expires_at_ms, ==, src->expires_at_ms);
+    g_assert_nonnull(dup->allowed_decisions);
+    g_assert_cmpstr(dup->allowed_decisions[0], ==, "allow-once");
+    /* Distinct allocations. */
+    g_assert_true(dup->id != src->id);
+    g_assert_true(dup->command != src->command);
+
+    oc_exec_approval_request_free(src);
+    oc_exec_approval_request_free(dup);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/exec_approval_request/parse_full",       test_parse_full_payload);
+    g_test_add_func("/exec_approval_request/parse_minimal",    test_parse_minimal_payload);
+    g_test_add_func("/exec_approval_request/reject_no_id",     test_reject_missing_id);
+    g_test_add_func("/exec_approval_request/reject_no_cmd",    test_reject_missing_command);
+    g_test_add_func("/exec_approval_request/reject_no_times",  test_reject_missing_timestamps);
+    g_test_add_func("/exec_approval_request/expired_helper",   test_expired_helper);
+    g_test_add_func("/exec_approval_request/copy_round_trip",  test_copy_round_trip);
+    return g_test_run();
+}

--- a/apps/linux/tests/test_exec_approval_store.c
+++ b/apps/linux/tests/test_exec_approval_store.c
@@ -1,0 +1,305 @@
+/*
+ * test_exec_approval_store.c
+ *
+ * Coverage for the quick-mode policy store: round-trip via explicit
+ * state-dir, lazy buffering when state-dir is unset, file permissions,
+ * and tolerance to corrupt input.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "../src/exec_approval_store.h"
+#include "../src/json_access.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <json-glib/json-glib.h>
+#include <sys/stat.h>
+#include <string.h>
+
+static gchar* make_tempdir(const gchar *suffix) {
+    /* g_dir_make_tmp expects a basename-only template (no path segments)
+     * and places the directory under TMPDIR. */
+    g_autofree gchar *tpl = g_strdup_printf("openclaw-exec-approval-%s-XXXXXX",
+                                            suffix);
+    g_autoptr(GError) err = NULL;
+    gchar *out = g_dir_make_tmp(tpl, &err);
+    if (!out) {
+        g_test_message("g_dir_make_tmp(%s) failed: %s", tpl,
+                       err ? err->message : "(no detail)");
+    }
+    return out;
+}
+
+static gchar* read_file_or_null(const gchar *path) {
+    g_autoptr(GError) error = NULL;
+    gchar *contents = NULL;
+    if (!g_file_get_contents(path, &contents, NULL, &error)) {
+        return NULL;
+    }
+    return contents;
+}
+
+static void assert_defaults_match(const gchar *path,
+                                  const gchar *expected_security,
+                                  const gchar *expected_ask) {
+    g_autofree gchar *contents = read_file_or_null(path);
+    g_assert_nonnull(contents);
+
+    g_autoptr(JsonParser) parser = json_parser_new();
+    g_autoptr(GError) error = NULL;
+    g_assert_true(json_parser_load_from_data(parser, contents, -1, &error));
+    JsonNode *root = json_parser_get_root(parser);
+    g_assert_true(JSON_NODE_HOLDS_OBJECT(root));
+    JsonObject *obj = json_node_get_object(root);
+    JsonObject *defaults = oc_json_object_member(obj, "defaults");
+    g_assert_nonnull(defaults);
+    g_assert_cmpstr(oc_json_string_member(defaults, "security"), ==, expected_security);
+    g_assert_cmpstr(oc_json_string_member(defaults, "ask"), ==, expected_ask);
+}
+
+static void test_default_quick_mode_is_ask(void) {
+    exec_approval_store_test_reset();
+    g_assert_cmpint(exec_approval_store_get_quick_mode(), ==, OC_EXEC_QUICK_MODE_ASK);
+}
+
+static void test_round_trip_via_state_dir(void) {
+    exec_approval_store_test_reset();
+    g_autofree gchar *dir = make_tempdir("rt");
+    g_assert_nonnull(dir);
+
+    exec_approval_store_set_state_dir(dir);
+    g_assert_cmpint(exec_approval_store_get_quick_mode(), ==, OC_EXEC_QUICK_MODE_ASK);
+
+    g_assert_true(exec_approval_store_set_quick_mode(OC_EXEC_QUICK_MODE_DENY));
+    g_autofree gchar *path = g_build_filename(dir, "exec-approvals.json", NULL);
+    g_assert_true(g_file_test(path, G_FILE_TEST_EXISTS));
+    assert_defaults_match(path, "deny", "off");
+
+    g_assert_true(exec_approval_store_set_quick_mode(OC_EXEC_QUICK_MODE_ALLOW));
+    assert_defaults_match(path, "full", "off");
+
+    g_assert_true(exec_approval_store_set_quick_mode(OC_EXEC_QUICK_MODE_ASK));
+    assert_defaults_match(path, "allowlist", "on-miss");
+
+    /* Re-init to a fresh process state and verify reload. */
+    exec_approval_store_test_reset();
+    exec_approval_store_set_state_dir(dir);
+    g_assert_cmpint(exec_approval_store_get_quick_mode(), ==, OC_EXEC_QUICK_MODE_ASK);
+
+    /* Cleanup */
+    g_unlink(path);
+    g_rmdir(dir);
+}
+
+static void test_buffer_until_state_dir_is_known(void) {
+    exec_approval_store_test_reset();
+    g_autofree gchar *dir = make_tempdir("buf");
+    g_assert_nonnull(dir);
+
+    /* Operator toggles before the gateway client resolves the state dir. */
+    g_assert_false(exec_approval_store_set_quick_mode(OC_EXEC_QUICK_MODE_DENY));
+    /* In-memory cache reflects the choice. */
+    g_assert_cmpint(exec_approval_store_get_quick_mode(), ==, OC_EXEC_QUICK_MODE_DENY);
+
+    /* No file should have been written yet. */
+    g_autofree gchar *path = g_build_filename(dir, "exec-approvals.json", NULL);
+    g_assert_false(g_file_test(path, G_FILE_TEST_EXISTS));
+
+    /* Once the state dir lands, the buffered value flushes to disk. */
+    exec_approval_store_set_state_dir(dir);
+    g_assert_true(g_file_test(path, G_FILE_TEST_EXISTS));
+    assert_defaults_match(path, "deny", "off");
+
+    g_unlink(path);
+    g_rmdir(dir);
+}
+
+static void test_set_state_dir_reads_existing_file(void) {
+    exec_approval_store_test_reset();
+    g_autofree gchar *dir = make_tempdir("read");
+    g_autofree gchar *path = g_build_filename(dir, "exec-approvals.json", NULL);
+
+    /* Pre-seed an on-disk file with allow defaults. */
+    const gchar *seed =
+        "{\n"
+        "  \"version\": 1,\n"
+        "  \"defaults\": { \"security\": \"full\", \"ask\": \"off\" },\n"
+        "  \"agents\": { \"keepme\": { \"security\": \"deny\" } }\n"
+        "}\n";
+    g_assert_true(g_file_set_contents(path, seed, -1, NULL));
+    g_chmod(path, 0600);
+
+    exec_approval_store_set_state_dir(dir);
+    g_assert_cmpint(exec_approval_store_get_quick_mode(), ==, OC_EXEC_QUICK_MODE_ALLOW);
+
+    /* Mutating the quick mode must preserve the agents subtree. */
+    g_assert_true(exec_approval_store_set_quick_mode(OC_EXEC_QUICK_MODE_DENY));
+    g_autofree gchar *contents = read_file_or_null(path);
+    g_assert_nonnull(contents);
+    g_assert_nonnull(strstr(contents, "\"keepme\""));
+
+    g_unlink(path);
+    g_rmdir(dir);
+}
+
+static void test_corrupt_file_falls_back_to_defaults(void) {
+    exec_approval_store_test_reset();
+    g_autofree gchar *dir = make_tempdir("corrupt");
+    g_autofree gchar *path = g_build_filename(dir, "exec-approvals.json", NULL);
+    g_assert_true(g_file_set_contents(path, "{ this is not json", -1, NULL));
+
+    exec_approval_store_set_state_dir(dir);
+    g_assert_cmpint(exec_approval_store_get_quick_mode(), ==, OC_EXEC_QUICK_MODE_ASK);
+
+    /* And the next mutation should rewrite the file cleanly. */
+    g_assert_true(exec_approval_store_set_quick_mode(OC_EXEC_QUICK_MODE_DENY));
+    assert_defaults_match(path, "deny", "off");
+
+    g_unlink(path);
+    g_rmdir(dir);
+}
+
+static void test_file_permissions_are_0600(void) {
+    exec_approval_store_test_reset();
+    g_autofree gchar *dir = make_tempdir("perms");
+    g_autofree gchar *path = g_build_filename(dir, "exec-approvals.json", NULL);
+
+    exec_approval_store_set_state_dir(dir);
+    g_assert_true(exec_approval_store_set_quick_mode(OC_EXEC_QUICK_MODE_DENY));
+
+    struct stat st;
+    g_assert_cmpint(g_stat(path, &st), ==, 0);
+    /* Permission bits only — clear file-type bits. */
+    g_assert_cmpint(st.st_mode & 0777, ==, 0600);
+
+    g_unlink(path);
+    g_rmdir(dir);
+}
+
+static void test_storage_path_override(void) {
+    exec_approval_store_test_reset();
+    g_autofree gchar *dir = make_tempdir("override");
+    g_autofree gchar *path = g_build_filename(dir, "custom-approvals.json", NULL);
+
+    exec_approval_store_test_set_storage_path(path);
+    g_assert_cmpint(exec_approval_store_get_quick_mode(), ==, OC_EXEC_QUICK_MODE_ASK);
+    g_assert_true(exec_approval_store_set_quick_mode(OC_EXEC_QUICK_MODE_ALLOW));
+    assert_defaults_match(path, "full", "off");
+
+    /* Clearing the override returns to state-dir-based resolution. */
+    exec_approval_store_test_set_storage_path(NULL);
+    g_unlink(path);
+    g_rmdir(dir);
+}
+
+/*
+ * Regression: switching from a state dir whose policy was ALLOW to a
+ * state dir with no exec-approvals.json must NOT inherit ALLOW. The
+ * store contract is "no valid file => ASK". This guards against a
+ * release-blocking policy leak across profiles/state roots.
+ */
+static void test_switch_to_empty_state_dir_resets_to_ask(void) {
+    exec_approval_store_test_reset();
+
+    g_autofree gchar *dir_a = make_tempdir("switch-a");
+    g_autofree gchar *dir_b = make_tempdir("switch-b");
+    g_assert_nonnull(dir_a);
+    g_assert_nonnull(dir_b);
+
+    exec_approval_store_set_state_dir(dir_a);
+    g_assert_true(exec_approval_store_set_quick_mode(OC_EXEC_QUICK_MODE_ALLOW));
+    g_assert_cmpint(exec_approval_store_get_quick_mode(), ==, OC_EXEC_QUICK_MODE_ALLOW);
+
+    /* dir_b has no exec-approvals.json. It must not inherit ALLOW. */
+    exec_approval_store_set_state_dir(dir_b);
+    g_assert_cmpint(exec_approval_store_get_quick_mode(), ==, OC_EXEC_QUICK_MODE_ASK);
+
+    /* Switching back to dir_a must rediscover the ALLOW we wrote earlier. */
+    exec_approval_store_set_state_dir(dir_a);
+    g_assert_cmpint(exec_approval_store_get_quick_mode(), ==, OC_EXEC_QUICK_MODE_ALLOW);
+
+    g_autofree gchar *path_a = g_build_filename(dir_a, "exec-approvals.json", NULL);
+    g_unlink(path_a);
+    g_rmdir(dir_a);
+    g_rmdir(dir_b);
+}
+
+/*
+ * Regression: corrupt-file fallback must reset to ASK even when the
+ * store was previously loaded with ALLOW. The fallback must never
+ * preserve the prior cached mode.
+ */
+static void test_corrupt_file_after_allow_falls_back_to_ask(void) {
+    exec_approval_store_test_reset();
+
+    g_autofree gchar *dir_a = make_tempdir("corrupt-prev");
+    g_autofree gchar *dir_b = make_tempdir("corrupt-next");
+    g_assert_nonnull(dir_a);
+    g_assert_nonnull(dir_b);
+
+    exec_approval_store_set_state_dir(dir_a);
+    g_assert_true(exec_approval_store_set_quick_mode(OC_EXEC_QUICK_MODE_ALLOW));
+    g_assert_cmpint(exec_approval_store_get_quick_mode(), ==, OC_EXEC_QUICK_MODE_ALLOW);
+
+    g_autofree gchar *path_b = g_build_filename(dir_b, "exec-approvals.json", NULL);
+    g_assert_true(g_file_set_contents(path_b, "{ not json", -1, NULL));
+
+    exec_approval_store_set_state_dir(dir_b);
+    g_assert_cmpint(exec_approval_store_get_quick_mode(), ==, OC_EXEC_QUICK_MODE_ASK);
+
+    g_autofree gchar *path_a = g_build_filename(dir_a, "exec-approvals.json", NULL);
+    g_unlink(path_a);
+    g_unlink(path_b);
+    g_rmdir(dir_a);
+    g_rmdir(dir_b);
+}
+
+/*
+ * Regression: a non-object JSON root (valid syntactically but wrong
+ * shape, e.g. an array or a bare value) must also reset to ASK rather
+ * than preserve a prior cached mode.
+ */
+static void test_non_object_root_falls_back_to_ask(void) {
+    exec_approval_store_test_reset();
+
+    g_autofree gchar *dir_a = make_tempdir("nonobj-prev");
+    g_autofree gchar *dir_b = make_tempdir("nonobj-next");
+    g_assert_nonnull(dir_a);
+    g_assert_nonnull(dir_b);
+
+    exec_approval_store_set_state_dir(dir_a);
+    g_assert_true(exec_approval_store_set_quick_mode(OC_EXEC_QUICK_MODE_ALLOW));
+
+    g_autofree gchar *path_b = g_build_filename(dir_b, "exec-approvals.json", NULL);
+    /* Valid JSON, wrong shape. */
+    g_assert_true(g_file_set_contents(path_b, "[\"not\", \"an\", \"object\"]", -1, NULL));
+
+    exec_approval_store_set_state_dir(dir_b);
+    g_assert_cmpint(exec_approval_store_get_quick_mode(), ==, OC_EXEC_QUICK_MODE_ASK);
+
+    g_autofree gchar *path_a = g_build_filename(dir_a, "exec-approvals.json", NULL);
+    g_unlink(path_a);
+    g_unlink(path_b);
+    g_rmdir(dir_a);
+    g_rmdir(dir_b);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    /* The store emits g_warning for non-fatal disk-IO / parse failures
+     * (corrupt file fallback, missing parent dir on first write). Don't
+     * let those abort the test process. */
+    g_log_set_always_fatal((GLogLevelFlags)(G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL));
+    g_test_add_func("/exec_approval_store/default_is_ask",          test_default_quick_mode_is_ask);
+    g_test_add_func("/exec_approval_store/round_trip",              test_round_trip_via_state_dir);
+    g_test_add_func("/exec_approval_store/buffer_until_dir",        test_buffer_until_state_dir_is_known);
+    g_test_add_func("/exec_approval_store/read_existing_file",      test_set_state_dir_reads_existing_file);
+    g_test_add_func("/exec_approval_store/corrupt_file_fallback",   test_corrupt_file_falls_back_to_defaults);
+    g_test_add_func("/exec_approval_store/file_perms_0600",         test_file_permissions_are_0600);
+    g_test_add_func("/exec_approval_store/storage_path_override",   test_storage_path_override);
+    g_test_add_func("/exec_approval_store/switch_to_empty_resets",  test_switch_to_empty_state_dir_resets_to_ask);
+    g_test_add_func("/exec_approval_store/corrupt_after_allow_resets", test_corrupt_file_after_allow_falls_back_to_ask);
+    g_test_add_func("/exec_approval_store/non_object_root_resets",  test_non_object_root_falls_back_to_ask);
+    return g_test_run();
+}

--- a/apps/linux/tests/test_product_coordinator.c
+++ b/apps/linux/tests/test_product_coordinator.c
@@ -110,6 +110,14 @@ void device_pair_prompter_init(GtkWindow *parent) {
     stub_device_pair_prompter_init_calls++;
 }
 
+void exec_approval_store_init(void) {
+    /* No state to track for the coordinator-level smoke test. */
+}
+
+void exec_approval_prompter_init(GtkWindow *parent) {
+    (void)parent;
+}
+
 void onboarding_show(void) {
     stub_onboarding_show_calls++;
 }


### PR DESCRIPTION
Implement native Linux handling for gateway exec approval requests by adding a request parser, quick-mode policy store, Adwaita approval dialog, and queued WebSocket/RPC prompter.

Subscribe to `exec.approval.requested` and
`exec.approval.resolved`, present one request at a time, resolve decisions through `exec.approval.resolve`, deduplicate request IDs, drop expired requests, honor `allowedDecisions`, and dismiss prompts resolved by another client.

Add a macOS-compatible `exec-approvals.json` policy store under the effective runtime state directory, expose the quick-mode picker in General settings, wire the subsystem into app boot and window parenting, and add headless tests for parsing, persistence, queueing, auto-resolution, dedupe, remote dismissal, and state-root isolation.