### PR TITLE
feat(linux): expand onboarding into guided setup flow (#120)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -109,6 +109,11 @@ sources = [
   'src/section_instances.c',
   'src/onboarding.c',
   'src/onboarding_view.c',
+  'src/onboarding_bootstrap_resolver.c',
+  'src/onboarding_bootstrap.c',
+  'src/onboarding_cli_detect.c',
+  'src/onboarding_chat_validation.c',
+  'src/onboarding_wizard.c',
   'src/log.c',
   'src/test_seams.c'
 ]
@@ -288,6 +293,33 @@ test_onboarding_controller_exe = executable('test_onboarding_controller',
   ['tests/test_onboarding_controller.c', 'src/onboarding.c', 'src/test_seams.c'],
   dependencies : [glib_dep, gio_dep, json_glib_dep, gtk4_dep, adwaita_dep])
 test('onboarding_controller', test_onboarding_controller_exe)
+
+test_onboarding_bootstrap_resolver_exe = executable('test_onboarding_bootstrap_resolver',
+  ['tests/test_onboarding_bootstrap_resolver.c', 'src/onboarding_bootstrap_resolver.c'],
+  dependencies : [glib_dep, gio_dep])
+test('onboarding_bootstrap_resolver', test_onboarding_bootstrap_resolver_exe)
+
+test_onboarding_bootstrap_exe = executable('test_onboarding_bootstrap',
+  ['tests/test_onboarding_bootstrap.c',
+   'src/onboarding_bootstrap.c',
+   'src/onboarding_bootstrap_resolver.c'],
+  dependencies : [glib_dep, gio_dep])
+test('onboarding_bootstrap', test_onboarding_bootstrap_exe)
+
+test_onboarding_wizard_model_exe = executable('test_onboarding_wizard_model',
+  ['tests/test_onboarding_wizard_model.c', 'src/onboarding_wizard.c'],
+  dependencies : [glib_dep, json_glib_dep])
+test('onboarding_wizard_model', test_onboarding_wizard_model_exe)
+
+test_onboarding_cli_detect_exe = executable('test_onboarding_cli_detect',
+  ['tests/test_onboarding_cli_detect.c', 'src/onboarding_cli_detect.c'],
+  dependencies : [glib_dep])
+test('onboarding_cli_detect', test_onboarding_cli_detect_exe)
+
+test_onboarding_chat_validation_exe = executable('test_onboarding_chat_validation',
+  ['tests/test_onboarding_chat_validation.c', 'src/onboarding_chat_validation.c'],
+  dependencies : [glib_dep])
+test('onboarding_chat_validation', test_onboarding_chat_validation_exe)
 
 test_gateway_exe = executable('test_gateway',
   ['tests/test_gateway.c', 'src/gateway_config.c', 'src/gateway_remote_config.c', 'src/gateway_protocol.c',

--- a/apps/linux/src/display_model.c
+++ b/apps/linux/src/display_model.c
@@ -576,3 +576,62 @@ OnboardingRoute onboarding_routing_decide(
         return ONBOARDING_SHOW_FULL;
     }
 }
+
+static void onboarding_flow_append(OnboardingFlowPages *out, OnboardingFlowPage page) {
+    if (!out || out->count >= ONBOARDING_FLOW_MAX_PAGES) {
+        return;
+    }
+    out->pages[out->count++] = page;
+}
+
+static gboolean onboarding_flow_state_needs_setup(AppState state) {
+    return state == STATE_NEEDS_SETUP;
+}
+
+void onboarding_flow_pages_visible(const OnboardingFlowInput *input,
+                                   OnboardingFlowPages *out) {
+    if (!out) {
+        return;
+    }
+    memset(out, 0, sizeof(*out));
+    if (!input || input->route == ONBOARDING_SKIP) {
+        return;
+    }
+
+    onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_WELCOME);
+    onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_CONNECTION);
+
+    if (input->connection_mode == PRODUCT_CONNECTION_MODE_REMOTE) {
+        onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_REMOTE_SETUP);
+        onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_CHAT_VALIDATION);
+        onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_WHATS_NEXT);
+        return;
+    }
+
+    if (input->connection_mode == PRODUCT_CONNECTION_MODE_UNSPECIFIED) {
+        onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_CHAT_VALIDATION);
+        onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_WHATS_NEXT);
+        return;
+    }
+
+    if (!input->cli_present) {
+        onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_CLI_INSTALL);
+        return;
+    }
+
+    if (onboarding_flow_state_needs_setup(input->app_state)) {
+        onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_BOOTSTRAP_SETUP);
+    }
+    if (!input->sys_installed) {
+        onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_BOOTSTRAP_INSTALL_UNIT);
+    }
+    if (!input->sys_active) {
+        onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_BOOTSTRAP_START_GATEWAY);
+    }
+    if (!input->has_wizard_onboard_marker && !input->wizard_should_skip) {
+        onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_SETUP_WIZARD);
+    }
+
+    onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_CHAT_VALIDATION);
+    onboarding_flow_append(out, ONBOARDING_FLOW_PAGE_WHATS_NEXT);
+}

--- a/apps/linux/src/display_model.h
+++ b/apps/linux/src/display_model.h
@@ -24,6 +24,7 @@
 
 #include "state.h"
 #include "readiness.h"
+#include "product_state.h"
 #include <glib.h>
 
 /* ── Dashboard display model ── */
@@ -236,6 +237,40 @@ OnboardingRoute onboarding_routing_decide(
     AppState state,
     int seen_version,
     int current_version);
+
+typedef enum {
+    ONBOARDING_FLOW_PAGE_WELCOME,
+    ONBOARDING_FLOW_PAGE_CONNECTION,
+    ONBOARDING_FLOW_PAGE_CLI_INSTALL,
+    ONBOARDING_FLOW_PAGE_BOOTSTRAP_SETUP,
+    ONBOARDING_FLOW_PAGE_BOOTSTRAP_INSTALL_UNIT,
+    ONBOARDING_FLOW_PAGE_BOOTSTRAP_START_GATEWAY,
+    ONBOARDING_FLOW_PAGE_SETUP_WIZARD,
+    ONBOARDING_FLOW_PAGE_REMOTE_SETUP,
+    ONBOARDING_FLOW_PAGE_CHAT_VALIDATION,
+    ONBOARDING_FLOW_PAGE_WHATS_NEXT,
+} OnboardingFlowPage;
+
+#define ONBOARDING_FLOW_MAX_PAGES 12
+
+typedef struct {
+    OnboardingRoute route;
+    ProductConnectionMode connection_mode;
+    AppState app_state;
+    gboolean cli_present;
+    gboolean sys_installed;
+    gboolean sys_active;
+    gboolean has_wizard_onboard_marker;
+    gboolean wizard_should_skip;
+} OnboardingFlowInput;
+
+typedef struct {
+    OnboardingFlowPage pages[ONBOARDING_FLOW_MAX_PAGES];
+    guint count;
+} OnboardingFlowPages;
+
+void onboarding_flow_pages_visible(const OnboardingFlowInput *input,
+                                   OnboardingFlowPages *out);
 
 /* ── HTTP probe label ── */
 

--- a/apps/linux/src/onboarding.h
+++ b/apps/linux/src/onboarding.h
@@ -24,7 +24,7 @@
 
 #include <glib.h>
 
-#define ONBOARDING_CURRENT_VERSION 1
+#define ONBOARDING_CURRENT_VERSION 2
 
 void onboarding_check_and_show(void);
 void onboarding_show(void);

--- a/apps/linux/src/onboarding_bootstrap.c
+++ b/apps/linux/src/onboarding_bootstrap.c
@@ -1,0 +1,439 @@
+/*
+ * onboarding_bootstrap.c
+ *
+ * Async subprocess runner for Linux onboarding bootstrap steps.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "onboarding_bootstrap.h"
+
+struct _OnboardingBootstrapRun {
+    gint ref_count;
+    GSubprocess *process;
+    GCancellable *cancellable;
+    GDataInputStream *stdout_stream;
+    GDataInputStream *stderr_stream;
+    OnboardingBootstrapCallback callback;
+    gpointer user_data;
+    guint timeout_id;
+    guint force_exit_id;
+    gboolean stdout_done;
+    gboolean stderr_done;
+    gboolean process_done;
+    gboolean process_ok;
+    gboolean cancel_requested;
+    gboolean timed_out;
+    gboolean suppress_events;
+    gboolean completed;
+    gint exit_code;
+    gchar *process_error;
+};
+
+static OnboardingBootstrapRun* bootstrap_run_ref(OnboardingBootstrapRun *run) {
+    g_atomic_int_inc(&run->ref_count);
+    return run;
+}
+
+static void bootstrap_run_unref(OnboardingBootstrapRun *run) {
+    if (!run || !g_atomic_int_dec_and_test(&run->ref_count)) {
+        return;
+    }
+    if (run->timeout_id != 0) {
+        g_source_remove(run->timeout_id);
+    }
+    if (run->force_exit_id != 0) {
+        g_source_remove(run->force_exit_id);
+    }
+    g_clear_object(&run->process);
+    g_clear_object(&run->cancellable);
+    g_clear_object(&run->stdout_stream);
+    g_clear_object(&run->stderr_stream);
+    g_clear_pointer(&run->process_error, g_free);
+    g_free(run);
+}
+
+static OnboardingBootstrapSpawnerForTest test_spawner = NULL;
+static gpointer test_spawner_user_data = NULL;
+static OnboardingBootstrapRun *test_pending_run = NULL;
+static OnboardingBootstrapTestSpawnResult test_pending_result = {0};
+static gboolean test_force_exit_scheduled = FALSE;
+
+void onboarding_bootstrap_set_spawner_for_test(OnboardingBootstrapSpawnerForTest spawner,
+                                               gpointer user_data) {
+    if (test_pending_run) {
+        bootstrap_run_unref(test_pending_run);
+        test_pending_run = NULL;
+    }
+    memset(&test_pending_result, 0, sizeof(test_pending_result));
+    test_spawner = spawner;
+    test_spawner_user_data = user_data;
+    test_force_exit_scheduled = FALSE;
+}
+
+static gchar* bootstrap_sanitized_path(void) {
+    const gchar *home = g_get_home_dir();
+    g_autofree gchar *home_local = home ? g_build_filename(home, ".local", "bin", NULL) : NULL;
+    g_autofree gchar *npm_global = home ? g_build_filename(home, ".npm-global", "bin", NULL) : NULL;
+    g_autofree gchar *pnpm = home ? g_build_filename(home, "Library", "pnpm", NULL) : NULL;
+    return g_strjoin(":",
+                     "/usr/local/sbin",
+                     "/usr/local/bin",
+                     "/usr/sbin",
+                     "/usr/bin",
+                     "/sbin",
+                     "/bin",
+                     home_local ? home_local : "",
+                     npm_global ? npm_global : "",
+                     pnpm ? pnpm : "",
+                     NULL);
+}
+
+static void emit_event(OnboardingBootstrapRun *run,
+                       OnboardingBootstrapEventKind kind,
+                       gint exit_code,
+                       const gchar *output,
+                       const gchar *message) {
+    if (!run || run->suppress_events || !run->callback) {
+        return;
+    }
+    OnboardingBootstrapEvent event = {
+        .kind = kind,
+        .exit_code = exit_code,
+        .output = output,
+        .message = message,
+    };
+    run->callback(&event, run->user_data);
+}
+
+static gboolean bootstrap_force_exit_cb(gpointer user_data) {
+    OnboardingBootstrapRun *run = user_data;
+    if (!run) {
+        return G_SOURCE_REMOVE;
+    }
+    run->force_exit_id = 0;
+    if (run->process && !g_subprocess_get_if_exited(run->process)) {
+        g_subprocess_force_exit(run->process);
+    }
+    return G_SOURCE_REMOVE;
+}
+
+static void bootstrap_schedule_force_exit(OnboardingBootstrapRun *run) {
+    if (!run || !run->process || run->force_exit_id != 0) {
+        if (test_spawner && run && !run->process) {
+            test_force_exit_scheduled = TRUE;
+        }
+        return;
+    }
+    run->force_exit_id = g_timeout_add_seconds_full(G_PRIORITY_DEFAULT,
+                                                    2,
+                                                    bootstrap_force_exit_cb,
+                                                    bootstrap_run_ref(run),
+                                                    (GDestroyNotify)bootstrap_run_unref);
+}
+
+static gboolean bootstrap_timeout_cb(gpointer user_data) {
+    OnboardingBootstrapRun *run = user_data;
+    if (run) {
+        run->timeout_id = 0;
+        run->timed_out = TRUE;
+        run->cancel_requested = TRUE;
+        if (run->cancellable) {
+            g_cancellable_cancel(run->cancellable);
+        }
+        bootstrap_schedule_force_exit(run);
+    }
+    return G_SOURCE_REMOVE;
+}
+
+static void bootstrap_maybe_finish(OnboardingBootstrapRun *run) {
+    if (!run || run->completed || !run->process_done || !run->stdout_done || !run->stderr_done) {
+        return;
+    }
+    run->completed = TRUE;
+    if (run->timeout_id != 0) {
+        g_source_remove(run->timeout_id);
+        run->timeout_id = 0;
+    }
+    if (run->force_exit_id != 0) {
+        g_source_remove(run->force_exit_id);
+        run->force_exit_id = 0;
+    }
+    if (run->suppress_events) {
+        return;
+    }
+    if (run->timed_out) {
+        emit_event(run, ONBOARDING_BOOTSTRAP_EVENT_ERROR, -1, NULL, "Bootstrap step timed out.");
+        return;
+    }
+    if (run->cancel_requested || g_cancellable_is_cancelled(run->cancellable)) {
+        emit_event(run, ONBOARDING_BOOTSTRAP_EVENT_CANCELLED, -1, NULL, "Bootstrap step cancelled.");
+        return;
+    }
+    if (!run->process_ok) {
+        emit_event(run, ONBOARDING_BOOTSTRAP_EVENT_ERROR, -1, NULL,
+                   run->process_error ? run->process_error : "Bootstrap step failed.");
+        return;
+    }
+    if (run->exit_code == 0) {
+        emit_event(run, ONBOARDING_BOOTSTRAP_EVENT_DONE, run->exit_code, NULL, "Bootstrap step completed.");
+    } else {
+        emit_event(run, ONBOARDING_BOOTSTRAP_EVENT_ERROR, run->exit_code, NULL, "Bootstrap command exited with a non-zero status.");
+    }
+}
+
+static void bootstrap_complete_test_run(OnboardingBootstrapRun *run,
+                                        const OnboardingBootstrapTestSpawnResult *result) {
+    if (!run || !result) {
+        return;
+    }
+    if (result->stdout_lines) {
+        for (const gchar * const *it = result->stdout_lines; *it; it++) {
+            emit_event(run, ONBOARDING_BOOTSTRAP_EVENT_OUTPUT, -1, *it, NULL);
+        }
+    }
+    if (result->stderr_lines) {
+        for (const gchar * const *it = result->stderr_lines; *it; it++) {
+            emit_event(run, ONBOARDING_BOOTSTRAP_EVENT_OUTPUT, -1, *it, NULL);
+        }
+    }
+    run->stdout_done = TRUE;
+    run->stderr_done = TRUE;
+    run->process_done = TRUE;
+    run->process_ok = result->wait_ok;
+    run->exit_code = result->exit_code;
+    if (!result->wait_ok && !run->process_error) {
+        run->process_error = g_strdup("Test process failed.");
+    }
+    bootstrap_maybe_finish(run);
+}
+
+void onboarding_bootstrap_test_complete_pending(void) {
+    if (!test_pending_run) {
+        return;
+    }
+    OnboardingBootstrapRun *run = test_pending_run;
+    test_pending_run = NULL;
+    bootstrap_complete_test_run(run, &test_pending_result);
+    bootstrap_run_unref(run);
+}
+
+void onboarding_bootstrap_test_timeout_pending(void) {
+    if (!test_pending_run) {
+        return;
+    }
+    OnboardingBootstrapRun *run = test_pending_run;
+    test_pending_run = NULL;
+    run->timed_out = TRUE;
+    run->cancel_requested = TRUE;
+    bootstrap_schedule_force_exit(run);
+    run->stdout_done = TRUE;
+    run->stderr_done = TRUE;
+    run->process_done = TRUE;
+    run->process_ok = FALSE;
+    run->exit_code = -1;
+    bootstrap_maybe_finish(run);
+    bootstrap_run_unref(run);
+}
+
+gboolean onboarding_bootstrap_test_force_exit_was_scheduled(void) {
+    return test_force_exit_scheduled;
+}
+
+static void bootstrap_stdout_line_done(GObject *source, GAsyncResult *result, gpointer user_data);
+static void bootstrap_stderr_line_done(GObject *source, GAsyncResult *result, gpointer user_data);
+
+static void bootstrap_schedule_stdout_read(OnboardingBootstrapRun *run) {
+    g_data_input_stream_read_line_async(run->stdout_stream,
+                                        G_PRIORITY_DEFAULT,
+                                        run->cancellable,
+                                        bootstrap_stdout_line_done,
+                                        bootstrap_run_ref(run));
+}
+
+static void bootstrap_schedule_stderr_read(OnboardingBootstrapRun *run) {
+    g_data_input_stream_read_line_async(run->stderr_stream,
+                                        G_PRIORITY_DEFAULT,
+                                        run->cancellable,
+                                        bootstrap_stderr_line_done,
+                                        bootstrap_run_ref(run));
+}
+
+static void bootstrap_handle_line_done(OnboardingBootstrapRun *run,
+                                       GDataInputStream *stream,
+                                       GAsyncResult *result,
+                                       gboolean is_stderr) {
+    gsize length = 0;
+    g_autoptr(GError) error = NULL;
+    g_autofree gchar *line = g_data_input_stream_read_line_finish_utf8(stream,
+                                                                       result,
+                                                                       &length,
+                                                                       &error);
+    if (line) {
+        emit_event(run, ONBOARDING_BOOTSTRAP_EVENT_OUTPUT, -1, line, NULL);
+        if (is_stderr) {
+            bootstrap_schedule_stderr_read(run);
+        } else {
+            bootstrap_schedule_stdout_read(run);
+        }
+        return;
+    }
+    if (is_stderr) {
+        run->stderr_done = TRUE;
+    } else {
+        run->stdout_done = TRUE;
+    }
+    bootstrap_maybe_finish(run);
+}
+
+static void bootstrap_stdout_line_done(GObject *source, GAsyncResult *result, gpointer user_data) {
+    OnboardingBootstrapRun *run = user_data;
+    bootstrap_handle_line_done(run, G_DATA_INPUT_STREAM(source), result, FALSE);
+    bootstrap_run_unref(run);
+}
+
+static void bootstrap_stderr_line_done(GObject *source, GAsyncResult *result, gpointer user_data) {
+    OnboardingBootstrapRun *run = user_data;
+    bootstrap_handle_line_done(run, G_DATA_INPUT_STREAM(source), result, TRUE);
+    bootstrap_run_unref(run);
+}
+
+static void bootstrap_wait_done(GObject *source, GAsyncResult *result, gpointer user_data) {
+    OnboardingBootstrapRun *run = user_data;
+    g_autoptr(GError) error = NULL;
+    run->process_ok = g_subprocess_wait_check_finish(G_SUBPROCESS(source), result, &error);
+    run->exit_code = g_subprocess_get_exit_status(G_SUBPROCESS(source));
+    if (error) {
+        run->process_error = g_strdup(error->message);
+    }
+    run->process_done = TRUE;
+    bootstrap_maybe_finish(run);
+    bootstrap_run_unref(run);
+}
+
+OnboardingBootstrapRun* onboarding_bootstrap_run_step(OnboardingBootstrapStep step,
+                                                      OnboardingBootstrapCallback callback,
+                                                      gpointer user_data) {
+    OnboardingBootstrapResolution resolution = {0};
+    if (!onboarding_bootstrap_resolve_commands(&resolution)) {
+        OnboardingBootstrapEvent event = {
+            .kind = ONBOARDING_BOOTSTRAP_EVENT_ERROR,
+            .exit_code = -1,
+            .message = resolution.missing_reason ? resolution.missing_reason : "No bootstrap command is available.",
+        };
+        if (callback) {
+            callback(&event, user_data);
+        }
+        onboarding_bootstrap_resolution_clear(&resolution);
+        return NULL;
+    }
+
+    g_auto(GStrv) argv = onboarding_bootstrap_resolution_dup_argv(&resolution, step);
+    onboarding_bootstrap_resolution_clear(&resolution);
+    if (!argv || !argv[0]) {
+        OnboardingBootstrapEvent event = {
+            .kind = ONBOARDING_BOOTSTRAP_EVENT_ERROR,
+            .exit_code = -1,
+            .message = "Bootstrap command resolution returned an empty argv.",
+        };
+        if (callback) {
+            callback(&event, user_data);
+        }
+        return NULL;
+    }
+
+    OnboardingBootstrapRun *run = g_new0(OnboardingBootstrapRun, 1);
+    run->ref_count = 1;
+    run->callback = callback;
+    run->user_data = user_data;
+    run->cancellable = g_cancellable_new();
+
+    if (test_spawner) {
+        OnboardingBootstrapTestSpawnResult spawn_result = {0};
+        if (!test_spawner((const gchar * const *)argv, &spawn_result, test_spawner_user_data) ||
+            !spawn_result.spawn_ok) {
+            OnboardingBootstrapEvent event = {
+                .kind = ONBOARDING_BOOTSTRAP_EVENT_ERROR,
+                .exit_code = -1,
+                .message = spawn_result.spawn_error ? spawn_result.spawn_error : "Failed to spawn bootstrap command.",
+            };
+            if (callback) {
+                callback(&event, user_data);
+            }
+            onboarding_bootstrap_run_free(run);
+            return NULL;
+        }
+        emit_event(run, ONBOARDING_BOOTSTRAP_EVENT_STARTED, -1, NULL, "Bootstrap command started.");
+        test_pending_result = spawn_result;
+        test_pending_run = bootstrap_run_ref(run);
+        if (spawn_result.complete_immediately) {
+            onboarding_bootstrap_test_complete_pending();
+        }
+        return run;
+    }
+
+    g_autoptr(GSubprocessLauncher) launcher =
+        g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_STDOUT_PIPE | G_SUBPROCESS_FLAGS_STDERR_PIPE);
+    g_autofree gchar *path = bootstrap_sanitized_path();
+    g_subprocess_launcher_setenv(launcher, "PATH", path, TRUE);
+    g_subprocess_launcher_setenv(launcher, "LANG", "C.UTF-8", TRUE);
+
+    g_autoptr(GError) error = NULL;
+    run->process = g_subprocess_launcher_spawnv(launcher, (const gchar * const *)argv, &error);
+    if (!run->process) {
+        OnboardingBootstrapEvent event = {
+            .kind = ONBOARDING_BOOTSTRAP_EVENT_ERROR,
+            .exit_code = -1,
+            .message = error ? error->message : "Failed to spawn bootstrap command.",
+        };
+        if (callback) {
+            callback(&event, user_data);
+        }
+        onboarding_bootstrap_run_free(run);
+        return NULL;
+    }
+
+    emit_event(run, ONBOARDING_BOOTSTRAP_EVENT_STARTED, -1, NULL, "Bootstrap command started.");
+    run->timeout_id = g_timeout_add_seconds_full(G_PRIORITY_DEFAULT,
+                                                 90,
+                                                 bootstrap_timeout_cb,
+                                                 bootstrap_run_ref(run),
+                                                 (GDestroyNotify)bootstrap_run_unref);
+    GInputStream *stdout_pipe = g_subprocess_get_stdout_pipe(run->process);
+    GInputStream *stderr_pipe = g_subprocess_get_stderr_pipe(run->process);
+    run->stdout_stream = g_data_input_stream_new(stdout_pipe);
+    run->stderr_stream = g_data_input_stream_new(stderr_pipe);
+    bootstrap_schedule_stdout_read(run);
+    bootstrap_schedule_stderr_read(run);
+    g_subprocess_wait_check_async(run->process,
+                                  NULL,
+                                  bootstrap_wait_done,
+                                  bootstrap_run_ref(run));
+    return run;
+}
+
+void onboarding_bootstrap_run_cancel(OnboardingBootstrapRun *run) {
+    if (!run) {
+        return;
+    }
+    if (run->completed) {
+        return;
+    }
+    run->cancel_requested = TRUE;
+    if (run->cancellable) {
+        g_cancellable_cancel(run->cancellable);
+    }
+    bootstrap_schedule_force_exit(run);
+}
+
+void onboarding_bootstrap_run_free(OnboardingBootstrapRun *run) {
+    if (!run) {
+        return;
+    }
+    run->suppress_events = TRUE;
+    run->callback = NULL;
+    run->user_data = NULL;
+    onboarding_bootstrap_run_cancel(run);
+    bootstrap_run_unref(run);
+}
+

--- a/apps/linux/src/onboarding_bootstrap.h
+++ b/apps/linux/src/onboarding_bootstrap.h
@@ -1,0 +1,61 @@
+/*
+ * onboarding_bootstrap.h
+ *
+ * Subprocess runner API for Linux onboarding bootstrap commands.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib.h>
+
+#include "onboarding_bootstrap_resolver.h"
+
+typedef enum {
+    ONBOARDING_BOOTSTRAP_EVENT_STARTED,
+    ONBOARDING_BOOTSTRAP_EVENT_OUTPUT,
+    ONBOARDING_BOOTSTRAP_EVENT_DONE,
+    ONBOARDING_BOOTSTRAP_EVENT_ERROR,
+    ONBOARDING_BOOTSTRAP_EVENT_CANCELLED,
+} OnboardingBootstrapEventKind;
+
+typedef struct {
+    OnboardingBootstrapEventKind kind;
+    gint exit_code;
+    const gchar *output;
+    const gchar *message;
+} OnboardingBootstrapEvent;
+
+typedef void (*OnboardingBootstrapCallback)(const OnboardingBootstrapEvent *event,
+                                            gpointer user_data);
+
+typedef struct _OnboardingBootstrapRun OnboardingBootstrapRun;
+
+OnboardingBootstrapRun* onboarding_bootstrap_run_step(OnboardingBootstrapStep step,
+                                                      OnboardingBootstrapCallback callback,
+                                                      gpointer user_data);
+void onboarding_bootstrap_run_cancel(OnboardingBootstrapRun *run);
+void onboarding_bootstrap_run_free(OnboardingBootstrapRun *run);
+
+typedef struct {
+    gboolean spawn_ok;
+    const gchar *spawn_error;
+    const gchar * const *stdout_lines;
+    const gchar * const *stderr_lines;
+    gboolean wait_ok;
+    gint exit_code;
+    gboolean complete_immediately;
+} OnboardingBootstrapTestSpawnResult;
+
+typedef gboolean (*OnboardingBootstrapSpawnerForTest)(const gchar * const *argv,
+                                                      OnboardingBootstrapTestSpawnResult *out,
+                                                      gpointer user_data);
+
+void onboarding_bootstrap_set_spawner_for_test(OnboardingBootstrapSpawnerForTest spawner,
+                                               gpointer user_data);
+void onboarding_bootstrap_test_complete_pending(void);
+void onboarding_bootstrap_test_timeout_pending(void);
+gboolean onboarding_bootstrap_test_force_exit_was_scheduled(void);
+

--- a/apps/linux/src/onboarding_bootstrap_resolver.c
+++ b/apps/linux/src/onboarding_bootstrap_resolver.c
@@ -1,0 +1,192 @@
+/*
+ * onboarding_bootstrap_resolver.c
+ *
+ * Deterministic command resolution for the Linux onboarding bootstrap flow.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "onboarding_bootstrap_resolver.h"
+
+#include <glib/gstdio.h>
+
+static OnboardingBootstrapFindProgramFunc test_find_program = NULL;
+static OnboardingBootstrapPathFunc test_executable_path = NULL;
+static OnboardingBootstrapPathFunc test_current_dir = NULL;
+
+static gchar* default_find_program(const gchar *program) {
+    return g_find_program_in_path(program);
+}
+
+static gchar* default_executable_path(void) {
+#ifdef __linux__
+    return g_file_read_link("/proc/self/exe", NULL);
+#else
+    return NULL;
+#endif
+}
+
+static gchar* default_current_dir(void) {
+    return g_get_current_dir();
+}
+
+void onboarding_bootstrap_resolver_set_test_hooks(OnboardingBootstrapFindProgramFunc find_program,
+                                                  OnboardingBootstrapPathFunc executable_path,
+                                                  OnboardingBootstrapPathFunc current_dir) {
+    test_find_program = find_program;
+    test_executable_path = executable_path;
+    test_current_dir = current_dir;
+}
+
+static gchar* call_find_program(const gchar *program) {
+    OnboardingBootstrapFindProgramFunc fn = test_find_program ? test_find_program : default_find_program;
+    return fn(program);
+}
+
+static gchar* call_executable_path(void) {
+    OnboardingBootstrapPathFunc fn = test_executable_path ? test_executable_path : default_executable_path;
+    return fn();
+}
+
+static gchar* call_current_dir(void) {
+    OnboardingBootstrapPathFunc fn = test_current_dir ? test_current_dir : default_current_dir;
+    return fn();
+}
+
+static gboolean path_has_dev_root_files(const gchar *dir) {
+    if (!dir || dir[0] == '\0') {
+        return FALSE;
+    }
+    g_autofree gchar *openclaw_mjs = g_build_filename(dir, "openclaw.mjs", NULL);
+    g_autofree gchar *package_json = g_build_filename(dir, "package.json", NULL);
+    return g_file_test(openclaw_mjs, G_FILE_TEST_IS_REGULAR) &&
+           g_file_test(package_json, G_FILE_TEST_IS_REGULAR);
+}
+
+static gchar* find_dev_root_from(const gchar *start_path) {
+    if (!start_path || start_path[0] == '\0') {
+        return NULL;
+    }
+
+    g_autofree gchar *canonical = g_canonicalize_filename(start_path, NULL);
+    g_autofree gchar *cursor = g_file_test(canonical, G_FILE_TEST_IS_DIR)
+        ? g_strdup(canonical)
+        : g_path_get_dirname(canonical);
+
+    while (cursor && cursor[0] != '\0') {
+        if (path_has_dev_root_files(cursor)) {
+            return g_steal_pointer(&cursor);
+        }
+        g_autofree gchar *parent = g_path_get_dirname(cursor);
+        if (!parent || g_strcmp0(parent, cursor) == 0) {
+            break;
+        }
+        g_free(cursor);
+        cursor = g_steal_pointer(&parent);
+    }
+
+    return NULL;
+}
+
+static gchar* find_dev_root(void) {
+    g_autofree gchar *exe_path = call_executable_path();
+    g_autofree gchar *from_exe = find_dev_root_from(exe_path);
+    if (from_exe) {
+        return g_steal_pointer(&from_exe);
+    }
+
+    g_autofree gchar *cwd = call_current_dir();
+    return find_dev_root_from(cwd);
+}
+
+static gchar** make_openclaw_setup_argv(void) {
+    return g_new0(gchar *, 3);
+}
+
+static gchar** make_openclaw_gateway_install_argv(void) {
+    return g_new0(gchar *, 4);
+}
+
+static gchar** make_dev_setup_argv(const gchar *node, const gchar *repo_root) {
+    gchar **argv = g_new0(gchar *, 4);
+    argv[0] = g_strdup(node);
+    argv[1] = g_build_filename(repo_root, "openclaw.mjs", NULL);
+    argv[2] = g_strdup("setup");
+    return argv;
+}
+
+static gchar** make_dev_gateway_install_argv(const gchar *node, const gchar *repo_root) {
+    gchar **argv = g_new0(gchar *, 5);
+    argv[0] = g_strdup(node);
+    argv[1] = g_build_filename(repo_root, "openclaw.mjs", NULL);
+    argv[2] = g_strdup("gateway");
+    argv[3] = g_strdup("install");
+    return argv;
+}
+
+static void fill_openclaw_argv(OnboardingBootstrapResolution *out, const gchar *openclaw_path) {
+    out->kind = ONBOARDING_BOOTSTRAP_RESOLUTION_OPENCLAW_PATH;
+    out->setup_argv = make_openclaw_setup_argv();
+    out->setup_argv[0] = g_strdup(openclaw_path);
+    out->setup_argv[1] = g_strdup("setup");
+    out->gateway_install_argv = make_openclaw_gateway_install_argv();
+    out->gateway_install_argv[0] = g_strdup(openclaw_path);
+    out->gateway_install_argv[1] = g_strdup("gateway");
+    out->gateway_install_argv[2] = g_strdup("install");
+}
+
+gboolean onboarding_bootstrap_resolve_commands(OnboardingBootstrapResolution *out) {
+    if (!out) {
+        return FALSE;
+    }
+    memset(out, 0, sizeof(*out));
+
+    g_autofree gchar *openclaw = call_find_program("openclaw");
+    if (openclaw) {
+        fill_openclaw_argv(out, openclaw);
+        return TRUE;
+    }
+
+    g_autofree gchar *node = call_find_program("node");
+    if (!node) {
+        out->kind = ONBOARDING_BOOTSTRAP_RESOLUTION_MISSING;
+        out->missing_reason = g_strdup("The openclaw CLI is not on PATH, and node is not available for the development checkout fallback.");
+        return FALSE;
+    }
+
+    g_autofree gchar *repo_root = find_dev_root();
+    if (!repo_root) {
+        out->kind = ONBOARDING_BOOTSTRAP_RESOLUTION_MISSING;
+        out->missing_reason = g_strdup("The openclaw CLI is not on PATH, and no development checkout with openclaw.mjs and package.json was found.");
+        return FALSE;
+    }
+
+    out->kind = ONBOARDING_BOOTSTRAP_RESOLUTION_DEV_TREE;
+    out->repo_root = g_strdup(repo_root);
+    out->setup_argv = make_dev_setup_argv(node, repo_root);
+    out->gateway_install_argv = make_dev_gateway_install_argv(node, repo_root);
+    return TRUE;
+}
+
+gchar** onboarding_bootstrap_resolution_dup_argv(const OnboardingBootstrapResolution *resolution,
+                                                 OnboardingBootstrapStep step) {
+    if (!resolution) {
+        return NULL;
+    }
+    gchar **source = step == ONBOARDING_BOOTSTRAP_STEP_SETUP
+        ? resolution->setup_argv
+        : resolution->gateway_install_argv;
+    return source ? g_strdupv(source) : NULL;
+}
+
+void onboarding_bootstrap_resolution_clear(OnboardingBootstrapResolution *resolution) {
+    if (!resolution) {
+        return;
+    }
+    g_clear_pointer(&resolution->repo_root, g_free);
+    g_clear_pointer(&resolution->missing_reason, g_free);
+    g_clear_pointer(&resolution->setup_argv, g_strfreev);
+    g_clear_pointer(&resolution->gateway_install_argv, g_strfreev);
+    memset(resolution, 0, sizeof(*resolution));
+}
+

--- a/apps/linux/src/onboarding_bootstrap_resolver.h
+++ b/apps/linux/src/onboarding_bootstrap_resolver.h
@@ -1,0 +1,44 @@
+/*
+ * onboarding_bootstrap_resolver.h
+ *
+ * Public resolver API for Linux onboarding bootstrap commands.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#pragma once
+
+#include <glib.h>
+
+typedef enum {
+    ONBOARDING_BOOTSTRAP_RESOLUTION_OPENCLAW_PATH = 0,
+    ONBOARDING_BOOTSTRAP_RESOLUTION_DEV_TREE = 1,
+    ONBOARDING_BOOTSTRAP_RESOLUTION_MISSING = 2,
+} OnboardingBootstrapResolutionKind;
+
+typedef enum {
+    ONBOARDING_BOOTSTRAP_STEP_SETUP = 0,
+    ONBOARDING_BOOTSTRAP_STEP_GATEWAY_INSTALL = 1,
+} OnboardingBootstrapStep;
+
+typedef struct {
+    OnboardingBootstrapResolutionKind kind;
+    gchar *repo_root;
+    gchar *missing_reason;
+    gchar **setup_argv;
+    gchar **gateway_install_argv;
+    gboolean uses_shell;
+} OnboardingBootstrapResolution;
+
+typedef gchar* (*OnboardingBootstrapFindProgramFunc)(const gchar *program);
+typedef gchar* (*OnboardingBootstrapPathFunc)(void);
+
+gboolean onboarding_bootstrap_resolve_commands(OnboardingBootstrapResolution *out);
+gchar** onboarding_bootstrap_resolution_dup_argv(const OnboardingBootstrapResolution *resolution,
+                                                 OnboardingBootstrapStep step);
+void onboarding_bootstrap_resolution_clear(OnboardingBootstrapResolution *resolution);
+
+void onboarding_bootstrap_resolver_set_test_hooks(OnboardingBootstrapFindProgramFunc find_program,
+                                                  OnboardingBootstrapPathFunc executable_path,
+                                                  OnboardingBootstrapPathFunc current_dir);
+

--- a/apps/linux/src/onboarding_chat_validation.c
+++ b/apps/linux/src/onboarding_chat_validation.c
@@ -1,0 +1,71 @@
+/*
+ * onboarding_chat_validation.c
+ *
+ * Maps companion readiness state into onboarding chat-validation copy.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "onboarding_chat_validation.h"
+
+OnboardingChatValidationStatus onboarding_chat_validation_status(AppState state,
+                                                                 const ChatGateInfo *gate,
+                                                                 const SystemdState *sys) {
+    if (gate && gate->ready) {
+        return ONBOARDING_CHAT_VALIDATION_READY;
+    }
+    if (sys && sys->activating) {
+        return ONBOARDING_CHAT_VALIDATION_GATEWAY_STARTING;
+    }
+    if (state == STATE_STARTING || state == STATE_STOPPING) {
+        return ONBOARDING_CHAT_VALIDATION_GATEWAY_STARTING;
+    }
+    if (!gate) {
+        return ONBOARDING_CHAT_VALIDATION_UNKNOWN;
+    }
+    switch (gate->reason) {
+    case CHAT_BLOCK_NO_CONFIG:
+    case CHAT_BLOCK_CONFIG_INVALID:
+    case CHAT_BLOCK_BOOTSTRAP_INCOMPLETE:
+    case CHAT_BLOCK_SERVICE_INACTIVE:
+    case CHAT_BLOCK_GATEWAY_UNREACHABLE:
+        return ONBOARDING_CHAT_VALIDATION_CHAT_UNCONFIGURED;
+    case CHAT_BLOCK_AUTH_INVALID:
+        return ONBOARDING_CHAT_VALIDATION_AUTH_REQUIRED;
+    case CHAT_BLOCK_PROVIDER_MISSING:
+        return ONBOARDING_CHAT_VALIDATION_PROVIDER_MISSING;
+    case CHAT_BLOCK_DEFAULT_MODEL_MISSING:
+    case CHAT_BLOCK_MODEL_CATALOG_EMPTY:
+    case CHAT_BLOCK_SELECTED_MODEL_UNRESOLVED:
+        return ONBOARDING_CHAT_VALIDATION_MODEL_MISSING;
+    case CHAT_BLOCK_AGENTS_UNAVAILABLE:
+    case CHAT_BLOCK_UNKNOWN:
+        return ONBOARDING_CHAT_VALIDATION_UNKNOWN;
+    case CHAT_BLOCK_NONE:
+    default:
+        return ONBOARDING_CHAT_VALIDATION_UNKNOWN;
+    }
+}
+
+const char* onboarding_chat_validation_title(OnboardingChatValidationStatus status) {
+    switch (status) {
+    case ONBOARDING_CHAT_VALIDATION_READY:
+        return "Chat is ready";
+    case ONBOARDING_CHAT_VALIDATION_GATEWAY_STARTING:
+        return "Gateway is starting";
+    case ONBOARDING_CHAT_VALIDATION_AUTH_REQUIRED:
+        return "Gateway authentication needs attention";
+    case ONBOARDING_CHAT_VALIDATION_PAIRING_REQUIRED:
+        return "Pairing is required";
+    case ONBOARDING_CHAT_VALIDATION_PROVIDER_MISSING:
+        return "Provider setup needed";
+    case ONBOARDING_CHAT_VALIDATION_MODEL_MISSING:
+        return "Model setup needed";
+    case ONBOARDING_CHAT_VALIDATION_CHAT_UNCONFIGURED:
+        return "Chat is not configured yet";
+    case ONBOARDING_CHAT_VALIDATION_UNKNOWN:
+    default:
+        return "Chat status unknown";
+    }
+}
+

--- a/apps/linux/src/onboarding_chat_validation.h
+++ b/apps/linux/src/onboarding_chat_validation.h
@@ -1,0 +1,28 @@
+/*
+ * onboarding_chat_validation.h
+ *
+ * Pure chat-readiness model for the Linux onboarding validation page.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#pragma once
+
+#include "readiness.h"
+
+typedef enum {
+    ONBOARDING_CHAT_VALIDATION_READY = 0,
+    ONBOARDING_CHAT_VALIDATION_GATEWAY_STARTING,
+    ONBOARDING_CHAT_VALIDATION_AUTH_REQUIRED,
+    ONBOARDING_CHAT_VALIDATION_PAIRING_REQUIRED,
+    ONBOARDING_CHAT_VALIDATION_PROVIDER_MISSING,
+    ONBOARDING_CHAT_VALIDATION_MODEL_MISSING,
+    ONBOARDING_CHAT_VALIDATION_CHAT_UNCONFIGURED,
+    ONBOARDING_CHAT_VALIDATION_UNKNOWN,
+} OnboardingChatValidationStatus;
+
+OnboardingChatValidationStatus onboarding_chat_validation_status(AppState state,
+                                                                 const ChatGateInfo *gate,
+                                                                 const SystemdState *sys);
+const char* onboarding_chat_validation_title(OnboardingChatValidationStatus status);
+

--- a/apps/linux/src/onboarding_cli_detect.c
+++ b/apps/linux/src/onboarding_cli_detect.c
@@ -1,0 +1,22 @@
+/*
+ * onboarding_cli_detect.c
+ *
+ * Detects whether the OpenClaw CLI is directly available on PATH.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "onboarding_cli_detect.h"
+
+static OnboardingCliFindProgramFunc test_find_program = NULL;
+
+void onboarding_cli_detect_set_test_hook(OnboardingCliFindProgramFunc find_program) {
+    test_find_program = find_program;
+}
+
+gboolean onboarding_cli_is_present(void) {
+    OnboardingCliFindProgramFunc find_program = test_find_program ? test_find_program : g_find_program_in_path;
+    g_autofree gchar *path = find_program("openclaw");
+    return path != NULL;
+}
+

--- a/apps/linux/src/onboarding_cli_detect.h
+++ b/apps/linux/src/onboarding_cli_detect.h
@@ -1,0 +1,17 @@
+/*
+ * onboarding_cli_detect.h
+ *
+ * Small probe surface for detecting the OpenClaw CLI during Linux onboarding.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#pragma once
+
+#include <glib.h>
+
+typedef gchar* (*OnboardingCliFindProgramFunc)(const gchar *program);
+
+gboolean onboarding_cli_is_present(void);
+void onboarding_cli_detect_set_test_hook(OnboardingCliFindProgramFunc find_program);
+

--- a/apps/linux/src/onboarding_view.c
+++ b/apps/linux/src/onboarding_view.c
@@ -18,6 +18,12 @@
 #include "gateway_client.h"
 #include "gateway_config.h"
 #include "gateway_remote_config.h"
+#include "gateway_rpc.h"
+#include "onboarding_bootstrap.h"
+#include "onboarding_bootstrap_resolver.h"
+#include "onboarding_chat_validation.h"
+#include "onboarding_cli_detect.h"
+#include "onboarding_wizard.h"
 #include "product_coordinator.h"
 #include "product_state.h"
 #include "readiness.h"
@@ -25,6 +31,9 @@
 #include "remote_probe.h"
 #include "runtime_paths.h"
 #include "state.h"
+#include "chat_window.h"
+
+extern void systemd_start_gateway(void);
 
 static OnboardingViewCallbacks onboarding_view_callbacks = {0};
 static GtkWidget *onboard_gateway_explanation_label = NULL;
@@ -39,6 +48,21 @@ static GtkWidget *onboard_gateway_next_action_value = NULL;
 static GtkWidget *onboard_whats_next_guidance_label = NULL;
 static GtkWidget *onboard_whats_next_dashboard_button = NULL;
 static GtkWidget *onboard_environment_checks_box = NULL;
+static GtkWidget *onboard_cli_install_status_label = NULL;
+static GtkWidget *onboard_chat_validation_status_label = NULL;
+static GtkWidget *onboard_bootstrap_setup_status_label = NULL;
+static GtkWidget *onboard_bootstrap_setup_output_label = NULL;
+static GtkWidget *onboard_bootstrap_install_status_label = NULL;
+static GtkWidget *onboard_bootstrap_install_output_label = NULL;
+static GtkWidget *onboard_start_gateway_status_label = NULL;
+static GtkWidget *onboard_wizard_status_label = NULL;
+static GtkWidget *onboard_wizard_step_box = NULL;
+static GtkWidget *onboard_wizard_answer_widget = NULL;
+static GPtrArray *onboard_wizard_multiselect_checks = NULL;
+static OnboardingBootstrapRun *onboard_bootstrap_setup_run = NULL;
+static OnboardingBootstrapRun *onboard_bootstrap_install_run = NULL;
+static OnboardingWizardModel *onboard_wizard_model = NULL;
+static OnboardingRoute onboard_view_current_route = ONBOARDING_SHOW_SHORTENED;
 
 /* ── Remote-mode subflow state (lives across rebuilds) ── */
 static gboolean g_onboard_chose_remote = FALSE;
@@ -84,6 +108,40 @@ static void on_back_clicked(GtkButton *button, gpointer user_data) {
                                GTK_WIDGET(adw_carousel_get_nth_page(ADW_CAROUSEL(carousel), pos - 1)),
                                TRUE);
     }
+}
+
+static void onboard_scroll_to_next(GtkWidget *carousel) {
+    if (!carousel || !ADW_IS_CAROUSEL(carousel)) return;
+    double n_pages = adw_carousel_get_n_pages(ADW_CAROUSEL(carousel));
+    double pos = adw_carousel_get_position(ADW_CAROUSEL(carousel));
+    if (pos + 1 < n_pages) {
+        GtkWidget *target = GTK_WIDGET(adw_carousel_get_nth_page(ADW_CAROUSEL(carousel), pos + 1));
+        if (target) {
+            adw_carousel_scroll_to(ADW_CAROUSEL(carousel), target, TRUE);
+        }
+    }
+}
+
+static GtkWidget* onboarding_page_box(gboolean center) {
+    GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
+    gtk_widget_set_margin_start(page, 40);
+    gtk_widget_set_margin_end(page, 40);
+    gtk_widget_set_margin_top(page, 40);
+    gtk_widget_set_margin_bottom(page, 40);
+    if (center) {
+        gtk_widget_set_valign(page, GTK_ALIGN_CENTER);
+    }
+    return page;
+}
+
+static GtkWidget* onboarding_wrapped_label(const gchar *text, const gchar *css_class) {
+    GtkWidget *label = gtk_label_new(text);
+    if (css_class) {
+        gtk_widget_add_css_class(label, css_class);
+    }
+    gtk_label_set_wrap(GTK_LABEL(label), TRUE);
+    gtk_label_set_xalign(GTK_LABEL(label), 0.0);
+    return label;
 }
 
 static void onboarding_render_environment_checks(GtkWidget *container) {
@@ -478,18 +536,10 @@ static void on_onboard_remote_apply_clicked(GtkButton *button, gpointer user_dat
     gateway_client_refresh();
     onboard_remote_set_status("✅ Saved. You can advance to the final step.");
 
-    /* Auto-advance to whats_next page if we have a carousel reference. */
+    /* Auto-advance to the next onboarding step if we have a carousel reference. */
     if (onboard_remote_carousel_ref &&
         ADW_IS_CAROUSEL(onboard_remote_carousel_ref)) {
-        guint n_pages = (guint)adw_carousel_get_n_pages(ADW_CAROUSEL(onboard_remote_carousel_ref));
-        if (n_pages > 0) {
-            GtkWidget *target = GTK_WIDGET(adw_carousel_get_nth_page(
-                ADW_CAROUSEL(onboard_remote_carousel_ref), n_pages - 1));
-            if (target) {
-                adw_carousel_scroll_to(ADW_CAROUSEL(onboard_remote_carousel_ref),
-                                       target, TRUE);
-            }
-        }
+        onboard_scroll_to_next(onboard_remote_carousel_ref);
     }
 }
 
@@ -522,6 +572,16 @@ static void on_onboard_choose_remote_clicked(GtkButton *button, gpointer user_da
         GtkWidget *target = GTK_WIDGET(adw_carousel_get_nth_page(ADW_CAROUSEL(carousel), 2));
         if (target) adw_carousel_scroll_to(ADW_CAROUSEL(carousel), target, TRUE);
     }
+}
+
+static void on_onboard_configure_later_clicked(GtkButton *button, gpointer user_data) {
+    (void)button;
+    GtkWidget *carousel = GTK_WIDGET(user_data);
+    g_onboard_chose_remote = FALSE;
+    (void)product_coordinator_request_set_connection_mode(PRODUCT_CONNECTION_MODE_UNSPECIFIED);
+    onboarding_view_rebuild_pages(carousel, ONBOARDING_SHOW_FULL,
+                                  &onboarding_view_callbacks);
+    onboard_scroll_to_next(carousel);
 }
 
 static GtkWidget* build_mode_choice_page(GtkWidget *carousel) {
@@ -560,6 +620,11 @@ static GtkWidget* build_mode_choice_page(GtkWidget *carousel) {
     g_signal_connect(remote_btn, "clicked",
                      G_CALLBACK(on_onboard_choose_remote_clicked), carousel);
     gtk_box_append(GTK_BOX(btn_row), remote_btn);
+
+    GtkWidget *later_btn = gtk_button_new_with_label("Configure Later");
+    g_signal_connect(later_btn, "clicked",
+                     G_CALLBACK(on_onboard_configure_later_clicked), carousel);
+    gtk_box_append(GTK_BOX(btn_row), later_btn);
 
     gtk_box_append(GTK_BOX(page), btn_row);
 
@@ -799,6 +864,303 @@ static void onboarding_update_whats_next_content(const ReadinessInfo *readiness,
     }
 }
 
+static void onboarding_update_chat_validation_content(void) {
+    if (!onboard_chat_validation_status_label) return;
+    AppState current = state_get_current();
+    const DesktopReadinessSnapshot *snapshot = state_get_readiness_snapshot();
+    ChatGateInfo gate = {0};
+    readiness_describe_chat_gate(snapshot, &gate);
+    OnboardingChatValidationStatus status =
+        onboarding_chat_validation_status(current, &gate, state_get_systemd());
+    const gchar *title = onboarding_chat_validation_title(status);
+    const gchar *detail = gate.status ? gate.status : (gate.next_action ? gate.next_action : "");
+    g_autofree gchar *text = g_strdup_printf("%s\n%s", title, detail);
+    gtk_label_set_text(GTK_LABEL(onboard_chat_validation_status_label), text);
+}
+
+static void on_open_chat_clicked(GtkButton *button, gpointer user_data) {
+    (void)button;
+    (void)user_data;
+    chat_window_show();
+}
+
+static void on_cli_recheck_clicked(GtkButton *button, gpointer user_data) {
+    (void)button;
+    GtkWidget *carousel = GTK_WIDGET(user_data);
+    OnboardingBootstrapResolution resolution = {0};
+    gboolean available = onboarding_bootstrap_resolve_commands(&resolution);
+    if (!available) {
+        if (onboard_cli_install_status_label) {
+            gtk_label_set_text(GTK_LABEL(onboard_cli_install_status_label),
+                               resolution.missing_reason ? resolution.missing_reason : "The OpenClaw CLI is still unavailable.");
+        }
+        onboarding_bootstrap_resolution_clear(&resolution);
+        return;
+    }
+
+    onboarding_bootstrap_resolution_clear(&resolution);
+    onboarding_view_rebuild_pages(carousel,
+                                  onboard_view_current_route,
+                                  &onboarding_view_callbacks);
+    if (ADW_IS_CAROUSEL(carousel) &&
+        adw_carousel_get_n_pages(ADW_CAROUSEL(carousel)) > 2.0) {
+        GtkWidget *target = GTK_WIDGET(adw_carousel_get_nth_page(ADW_CAROUSEL(carousel), 2));
+        if (target) {
+            adw_carousel_scroll_to(ADW_CAROUSEL(carousel), target, TRUE);
+        }
+    }
+}
+
+static void bootstrap_event_to_labels(const OnboardingBootstrapEvent *event,
+                                      GtkWidget *status_label,
+                                      GtkWidget *output_label,
+                                      gboolean refresh_on_done) {
+    if (!event) return;
+    if (status_label) {
+        const gchar *text = event->message ? event->message : "";
+        if (event->kind == ONBOARDING_BOOTSTRAP_EVENT_STARTED) text = "Running…";
+        if (event->kind == ONBOARDING_BOOTSTRAP_EVENT_DONE) text = "Completed.";
+        if (event->kind == ONBOARDING_BOOTSTRAP_EVENT_CANCELLED) text = "Cancelled.";
+        gtk_label_set_text(GTK_LABEL(status_label), text);
+    }
+    if (output_label && event->output && event->output[0] != '\0') {
+        gtk_label_set_text(GTK_LABEL(output_label), event->output);
+    }
+    if (refresh_on_done && event->kind == ONBOARDING_BOOTSTRAP_EVENT_DONE) {
+        gateway_client_refresh();
+    }
+}
+
+static void setup_bootstrap_event_cb(const OnboardingBootstrapEvent *event, gpointer user_data) {
+    (void)user_data;
+    bootstrap_event_to_labels(event,
+                              onboard_bootstrap_setup_status_label,
+                              onboard_bootstrap_setup_output_label,
+                              FALSE);
+}
+
+static void install_bootstrap_event_cb(const OnboardingBootstrapEvent *event, gpointer user_data) {
+    (void)user_data;
+    bootstrap_event_to_labels(event,
+                              onboard_bootstrap_install_status_label,
+                              onboard_bootstrap_install_output_label,
+                              TRUE);
+}
+
+static void on_bootstrap_setup_clicked(GtkButton *button, gpointer user_data) {
+    (void)button;
+    (void)user_data;
+    if (onboard_bootstrap_setup_run) {
+        onboarding_bootstrap_run_cancel(onboard_bootstrap_setup_run);
+        onboarding_bootstrap_run_free(onboard_bootstrap_setup_run);
+        onboard_bootstrap_setup_run = NULL;
+    }
+    onboard_bootstrap_setup_run =
+        onboarding_bootstrap_run_step(ONBOARDING_BOOTSTRAP_STEP_SETUP,
+                                      setup_bootstrap_event_cb,
+                                      NULL);
+}
+
+static void on_bootstrap_install_clicked(GtkButton *button, gpointer user_data) {
+    (void)button;
+    (void)user_data;
+    if (onboard_bootstrap_install_run) {
+        onboarding_bootstrap_run_cancel(onboard_bootstrap_install_run);
+        onboarding_bootstrap_run_free(onboard_bootstrap_install_run);
+        onboard_bootstrap_install_run = NULL;
+    }
+    onboard_bootstrap_install_run =
+        onboarding_bootstrap_run_step(ONBOARDING_BOOTSTRAP_STEP_GATEWAY_INSTALL,
+                                      install_bootstrap_event_cb,
+                                      NULL);
+}
+
+static void on_start_gateway_clicked(GtkButton *button, gpointer user_data) {
+    (void)button;
+    (void)user_data;
+    systemd_start_gateway();
+    gateway_client_refresh();
+    if (onboard_start_gateway_status_label) {
+        gtk_label_set_text(GTK_LABEL(onboard_start_gateway_status_label),
+                           "Start requested. Waiting for the gateway to become reachable…");
+    }
+}
+
+static const gchar* wizard_step_string(JsonObject *step, const gchar *member) {
+    if (!step || !json_object_has_member(step, member)) return NULL;
+    JsonNode *node = json_object_get_member(step, member);
+    return node && JSON_NODE_HOLDS_VALUE(node) ? json_node_get_string(node) : NULL;
+}
+
+static void clear_wizard_step_box(void) {
+    if (!onboard_wizard_step_box) return;
+    GtkWidget *child = NULL;
+    while ((child = gtk_widget_get_first_child(onboard_wizard_step_box)) != NULL) {
+        gtk_box_remove(GTK_BOX(onboard_wizard_step_box), child);
+    }
+    onboard_wizard_answer_widget = NULL;
+    g_clear_pointer(&onboard_wizard_multiselect_checks, g_ptr_array_unref);
+}
+
+static void onboarding_wizard_render(void) {
+    if (!onboard_wizard_status_label || !onboard_wizard_step_box || !onboard_wizard_model) return;
+
+    OnboardingWizardStatus status = onboarding_wizard_get_status(onboard_wizard_model);
+    const gchar *error = onboarding_wizard_get_error(onboard_wizard_model);
+    const gchar *status_text = "Ready to start the setup wizard.";
+    if (onboarding_wizard_is_busy(onboard_wizard_model)) status_text = "Contacting gateway…";
+    else if (status == ONBOARDING_WIZARD_STATUS_RUNNING) status_text = "Wizard running.";
+    else if (status == ONBOARDING_WIZARD_STATUS_DONE) status_text = "Wizard completed.";
+    else if (status == ONBOARDING_WIZARD_STATUS_CANCELLED) status_text = "Wizard cancelled.";
+    else if (status == ONBOARDING_WIZARD_STATUS_ERROR) status_text = error ? error : "Wizard failed.";
+    gtk_label_set_text(GTK_LABEL(onboard_wizard_status_label), status_text);
+
+    clear_wizard_step_box();
+    JsonObject *step = onboarding_wizard_get_step(onboard_wizard_model);
+    if (!step) return;
+
+    const gchar *title = wizard_step_string(step, "title");
+    const gchar *message = wizard_step_string(step, "message");
+    const gchar *type = wizard_step_string(step, "type");
+    if (title) {
+        GtkWidget *title_label = onboarding_wrapped_label(title, "heading");
+        gtk_box_append(GTK_BOX(onboard_wizard_step_box), title_label);
+    }
+    if (message) {
+        GtkWidget *message_label = onboarding_wrapped_label(message, "dim-label");
+        gtk_box_append(GTK_BOX(onboard_wizard_step_box), message_label);
+    }
+
+    if (g_strcmp0(type, "text") == 0) {
+        GtkWidget *entry = adw_entry_row_new();
+        const gchar *placeholder = wizard_step_string(step, "placeholder");
+        adw_preferences_row_set_title(ADW_PREFERENCES_ROW(entry), placeholder ? placeholder : "Answer");
+        gtk_box_append(GTK_BOX(onboard_wizard_step_box), entry);
+        onboard_wizard_answer_widget = entry;
+    } else if (g_strcmp0(type, "confirm") == 0) {
+        GtkWidget *check = gtk_check_button_new_with_label("Confirm");
+        gtk_box_append(GTK_BOX(onboard_wizard_step_box), check);
+        onboard_wizard_answer_widget = check;
+    } else if ((g_strcmp0(type, "select") == 0 || g_strcmp0(type, "multiselect") == 0) &&
+               json_object_has_member(step, "options")) {
+        JsonNode *options_node = json_object_get_member(step, "options");
+        if (options_node && JSON_NODE_HOLDS_ARRAY(options_node)) {
+            JsonArray *options = json_node_get_array(options_node);
+            guint len = json_array_get_length(options);
+            if (g_strcmp0(type, "multiselect") == 0) {
+                onboard_wizard_multiselect_checks = g_ptr_array_new();
+                for (guint i = 0; i < len; i++) {
+                    JsonObject *option = json_array_get_object_element(options, i);
+                    const gchar *label = wizard_step_string(option, "label");
+                    GtkWidget *check = gtk_check_button_new_with_label(label ? label : "Option");
+                    gtk_box_append(GTK_BOX(onboard_wizard_step_box), check);
+                    g_ptr_array_add(onboard_wizard_multiselect_checks, check);
+                }
+            } else {
+                GtkStringList *model = gtk_string_list_new(NULL);
+                for (guint i = 0; i < len; i++) {
+                    JsonObject *option = json_array_get_object_element(options, i);
+                    const gchar *label = wizard_step_string(option, "label");
+                    gtk_string_list_append(model, label ? label : "Option");
+                }
+                GtkWidget *combo = adw_combo_row_new();
+                adw_preferences_row_set_title(ADW_PREFERENCES_ROW(combo), "Choose an option");
+                adw_combo_row_set_model(ADW_COMBO_ROW(combo), G_LIST_MODEL(model));
+                g_object_unref(model);
+                gtk_box_append(GTK_BOX(onboard_wizard_step_box), combo);
+                onboard_wizard_answer_widget = combo;
+            }
+        }
+    }
+}
+
+static void wizard_changed_cb(OnboardingWizardModel *model, gpointer user_data) {
+    (void)model;
+    (void)user_data;
+    onboarding_wizard_render();
+}
+
+static JsonNode* wizard_build_answer_value(void) {
+    JsonObject *step = onboard_wizard_model ? onboarding_wizard_get_step(onboard_wizard_model) : NULL;
+    const gchar *type = wizard_step_string(step, "type");
+    if (g_strcmp0(type, "text") == 0 && onboard_wizard_answer_widget) {
+        const gchar *text = gtk_editable_get_text(GTK_EDITABLE(onboard_wizard_answer_widget));
+        JsonNode *node = json_node_new(JSON_NODE_VALUE);
+        json_node_set_string(node, text ? text : "");
+        return node;
+    }
+    if (g_strcmp0(type, "confirm") == 0 && onboard_wizard_answer_widget) {
+        JsonNode *node = json_node_new(JSON_NODE_VALUE);
+        json_node_set_boolean(node, gtk_check_button_get_active(GTK_CHECK_BUTTON(onboard_wizard_answer_widget)));
+        return node;
+    }
+    if (g_strcmp0(type, "select") == 0 && onboard_wizard_answer_widget &&
+        step && json_object_has_member(step, "options")) {
+        JsonArray *options = json_node_get_array(json_object_get_member(step, "options"));
+        guint selected = adw_combo_row_get_selected(ADW_COMBO_ROW(onboard_wizard_answer_widget));
+        if (selected < json_array_get_length(options)) {
+            JsonObject *option = json_array_get_object_element(options, selected);
+            if (json_object_has_member(option, "value")) {
+                return json_node_copy(json_object_get_member(option, "value"));
+            }
+        }
+    }
+    if (g_strcmp0(type, "multiselect") == 0 && onboard_wizard_multiselect_checks &&
+        step && json_object_has_member(step, "options")) {
+        JsonArray *options = json_node_get_array(json_object_get_member(step, "options"));
+        JsonBuilder *builder = json_builder_new();
+        json_builder_begin_array(builder);
+        for (guint i = 0; i < onboard_wizard_multiselect_checks->len && i < json_array_get_length(options); i++) {
+            GtkWidget *check = g_ptr_array_index(onboard_wizard_multiselect_checks, i);
+            if (!gtk_check_button_get_active(GTK_CHECK_BUTTON(check))) {
+                continue;
+            }
+            JsonObject *option = json_array_get_object_element(options, i);
+            if (json_object_has_member(option, "value")) {
+                json_builder_add_value(builder, json_node_copy(json_object_get_member(option, "value")));
+            }
+        }
+        json_builder_end_array(builder);
+        JsonNode *node = json_builder_get_root(builder);
+        g_object_unref(builder);
+        return node;
+    }
+    return NULL;
+}
+
+static void on_wizard_start_clicked(GtkButton *button, gpointer user_data) {
+    (void)button;
+    (void)user_data;
+    if (!onboard_wizard_model) {
+        onboard_wizard_model = onboarding_wizard_model_new(wizard_changed_cb, NULL);
+    }
+    if (!gateway_rpc_is_ready()) {
+        if (onboard_wizard_status_label) {
+            gtk_label_set_text(GTK_LABEL(onboard_wizard_status_label),
+                               "Gateway RPC is not ready yet. Start the gateway and wait for authentication before running the wizard.");
+        }
+        return;
+    }
+    onboarding_wizard_start(onboard_wizard_model, "local");
+}
+
+static void on_wizard_continue_clicked(GtkButton *button, gpointer user_data) {
+    (void)button;
+    (void)user_data;
+    if (!onboard_wizard_model) return;
+    JsonNode *value = wizard_build_answer_value();
+    onboarding_wizard_submit(onboard_wizard_model, value);
+    if (value) json_node_unref(value);
+}
+
+static void on_wizard_cancel_clicked(GtkButton *button, gpointer user_data) {
+    (void)button;
+    (void)user_data;
+    if (onboard_wizard_model) {
+        onboarding_wizard_cancel(onboard_wizard_model);
+    }
+}
+
 void onboarding_view_refresh_live_content(void) {
     AppState current = state_get_current();
     ReadinessInfo readiness;
@@ -811,9 +1173,157 @@ void onboarding_view_refresh_live_content(void) {
 
     onboarding_update_gateway_content(current, &readiness, &progress, &gate);
     onboarding_update_whats_next_content(&readiness, &gate);
+    onboarding_update_chat_validation_content();
     onboarding_refresh_environment_content();
 }
 
+static GtkWidget* build_cli_install_page(GtkWidget *carousel) {
+    GtkWidget *page = onboarding_page_box(TRUE);
+    GtkWidget *title = gtk_label_new("Install the OpenClaw CLI");
+    gtk_widget_add_css_class(title, "title-2");
+    gtk_box_append(GTK_BOX(page), title);
+    gtk_box_append(GTK_BOX(page), onboarding_wrapped_label(
+        "The companion needs the openclaw CLI to bootstrap a local gateway. Install it, then come back and continue.",
+        NULL));
+    GtkWidget *command = onboarding_wrapped_label(
+        "curl -fsSL https://openclaw.ai/install-cli.sh | sh",
+        "accent");
+    gtk_label_set_selectable(GTK_LABEL(command), TRUE);
+    gtk_box_append(GTK_BOX(page), command);
+    onboard_cli_install_status_label = onboarding_wrapped_label(
+        "Click Recheck after installing the CLI. If you are running from a development checkout, the app will also accept node plus openclaw.mjs.",
+        "dim-label");
+    gtk_box_append(GTK_BOX(page), onboard_cli_install_status_label);
+
+    GtkWidget *btn_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_halign(btn_row, GTK_ALIGN_CENTER);
+    GtkWidget *back_btn = gtk_button_new_with_label("Back");
+    g_signal_connect(back_btn, "clicked", G_CALLBACK(on_back_clicked), carousel);
+    gtk_box_append(GTK_BOX(btn_row), back_btn);
+    GtkWidget *next_btn = gtk_button_new_with_label("Recheck / Continue");
+    gtk_widget_add_css_class(next_btn, "suggested-action");
+    g_signal_connect(next_btn, "clicked", G_CALLBACK(on_cli_recheck_clicked), carousel);
+    gtk_box_append(GTK_BOX(btn_row), next_btn);
+    gtk_box_append(GTK_BOX(page), btn_row);
+    return page;
+}
+
+static GtkWidget* build_bootstrap_page(GtkWidget *carousel,
+                                       const gchar *title,
+                                       const gchar *body,
+                                       const gchar *button_label,
+                                       GCallback click_cb,
+                                       GtkWidget **out_status,
+                                       GtkWidget **out_output) {
+    GtkWidget *page = onboarding_page_box(TRUE);
+    GtkWidget *title_label = gtk_label_new(title);
+    gtk_widget_add_css_class(title_label, "title-2");
+    gtk_box_append(GTK_BOX(page), title_label);
+    gtk_box_append(GTK_BOX(page), onboarding_wrapped_label(body, NULL));
+    GtkWidget *status = onboarding_wrapped_label("Ready.", "accent");
+    GtkWidget *output = onboarding_wrapped_label("", "dim-label");
+    gtk_label_set_selectable(GTK_LABEL(output), TRUE);
+    gtk_box_append(GTK_BOX(page), status);
+    gtk_box_append(GTK_BOX(page), output);
+    if (out_status) *out_status = status;
+    if (out_output) *out_output = output;
+
+    GtkWidget *btn_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_halign(btn_row, GTK_ALIGN_CENTER);
+    GtkWidget *back_btn = gtk_button_new_with_label("Back");
+    g_signal_connect(back_btn, "clicked", G_CALLBACK(on_back_clicked), carousel);
+    gtk_box_append(GTK_BOX(btn_row), back_btn);
+    GtkWidget *run_btn = gtk_button_new_with_label(button_label);
+    gtk_widget_add_css_class(run_btn, "suggested-action");
+    g_signal_connect(run_btn, "clicked", click_cb, NULL);
+    gtk_box_append(GTK_BOX(btn_row), run_btn);
+    GtkWidget *next_btn = gtk_button_new_with_label("Next");
+    g_signal_connect(next_btn, "clicked", G_CALLBACK(on_next_clicked), carousel);
+    gtk_box_append(GTK_BOX(btn_row), next_btn);
+    gtk_box_append(GTK_BOX(page), btn_row);
+    return page;
+}
+
+static GtkWidget* build_start_gateway_page(GtkWidget *carousel) {
+    return build_bootstrap_page(carousel,
+                                "Start Gateway",
+                                "The service is installed. Start it, then wait for the companion to refresh its gateway connection before continuing to the setup wizard.",
+                                "Start Gateway",
+                                G_CALLBACK(on_start_gateway_clicked),
+                                &onboard_start_gateway_status_label,
+                                NULL);
+}
+
+static GtkWidget* build_setup_wizard_page(GtkWidget *carousel) {
+    GtkWidget *page = onboarding_page_box(FALSE);
+    GtkWidget *title = gtk_label_new("Setup Wizard");
+    gtk_widget_add_css_class(title, "title-2");
+    gtk_box_append(GTK_BOX(page), title);
+    gtk_box_append(GTK_BOX(page), onboarding_wrapped_label(
+        "The wizard runs through the authenticated gateway RPC channel. It becomes available only after the local gateway is installed, started, and authenticated.",
+        NULL));
+    onboard_wizard_status_label = onboarding_wrapped_label("Ready to start the setup wizard.", "accent");
+    gtk_box_append(GTK_BOX(page), onboard_wizard_status_label);
+    onboard_wizard_step_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 8);
+    gtk_widget_set_margin_top(onboard_wizard_step_box, 8);
+    gtk_box_append(GTK_BOX(page), onboard_wizard_step_box);
+
+    if (!onboard_wizard_model) {
+        onboard_wizard_model = onboarding_wizard_model_new(wizard_changed_cb, NULL);
+    }
+    onboarding_wizard_render();
+
+    GtkWidget *btn_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_halign(btn_row, GTK_ALIGN_CENTER);
+    GtkWidget *back_btn = gtk_button_new_with_label("Back");
+    g_signal_connect(back_btn, "clicked", G_CALLBACK(on_back_clicked), carousel);
+    gtk_box_append(GTK_BOX(btn_row), back_btn);
+    GtkWidget *start_btn = gtk_button_new_with_label("Start Wizard");
+    gtk_widget_add_css_class(start_btn, "suggested-action");
+    g_signal_connect(start_btn, "clicked", G_CALLBACK(on_wizard_start_clicked), NULL);
+    gtk_box_append(GTK_BOX(btn_row), start_btn);
+    GtkWidget *continue_btn = gtk_button_new_with_label("Continue");
+    g_signal_connect(continue_btn, "clicked", G_CALLBACK(on_wizard_continue_clicked), NULL);
+    gtk_box_append(GTK_BOX(btn_row), continue_btn);
+    GtkWidget *cancel_btn = gtk_button_new_with_label("Cancel Wizard");
+    g_signal_connect(cancel_btn, "clicked", G_CALLBACK(on_wizard_cancel_clicked), NULL);
+    gtk_box_append(GTK_BOX(btn_row), cancel_btn);
+    GtkWidget *next_btn = gtk_button_new_with_label("Next");
+    g_signal_connect(next_btn, "clicked", G_CALLBACK(on_next_clicked), carousel);
+    gtk_box_append(GTK_BOX(btn_row), next_btn);
+    gtk_box_append(GTK_BOX(page), btn_row);
+    return page;
+}
+
+static GtkWidget* build_chat_validation_page(GtkWidget *carousel) {
+    GtkWidget *page = onboarding_page_box(TRUE);
+    GtkWidget *title = gtk_label_new("Validate Chat");
+    gtk_widget_add_css_class(title, "title-2");
+    gtk_box_append(GTK_BOX(page), title);
+    gtk_box_append(GTK_BOX(page), onboarding_wrapped_label(
+        "Open the native chat window when the gateway is ready. This page does not create a second chat controller; it uses the standalone chat window.",
+        NULL));
+    onboard_chat_validation_status_label = onboarding_wrapped_label("", "accent");
+    gtk_box_append(GTK_BOX(page), onboard_chat_validation_status_label);
+    onboarding_update_chat_validation_content();
+
+    GtkWidget *btn_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    gtk_widget_set_halign(btn_row, GTK_ALIGN_CENTER);
+    GtkWidget *back_btn = gtk_button_new_with_label("Back");
+    g_signal_connect(back_btn, "clicked", G_CALLBACK(on_back_clicked), carousel);
+    gtk_box_append(GTK_BOX(btn_row), back_btn);
+    GtkWidget *chat_btn = gtk_button_new_with_label("Open Chat");
+    gtk_widget_add_css_class(chat_btn, "suggested-action");
+    g_signal_connect(chat_btn, "clicked", G_CALLBACK(on_open_chat_clicked), NULL);
+    gtk_box_append(GTK_BOX(btn_row), chat_btn);
+    GtkWidget *next_btn = gtk_button_new_with_label("Next");
+    g_signal_connect(next_btn, "clicked", G_CALLBACK(on_next_clicked), carousel);
+    gtk_box_append(GTK_BOX(btn_row), next_btn);
+    gtk_box_append(GTK_BOX(page), btn_row);
+    return page;
+}
+
+static GtkWidget* build_gateway_page(GtkWidget *carousel) G_GNUC_UNUSED;
 static GtkWidget* build_gateway_page(GtkWidget *carousel) {
     GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
     gtk_widget_set_margin_start(page, 40);
@@ -937,6 +1447,7 @@ static GtkWidget* build_gateway_page(GtkWidget *carousel) {
     return page;
 }
 
+static GtkWidget* build_environment_page(GtkWidget *carousel) G_GNUC_UNUSED;
 static GtkWidget* build_environment_page(GtkWidget *carousel) {
     GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 12);
     gtk_widget_set_margin_start(page, 40);
@@ -1064,6 +1575,31 @@ void onboarding_view_reset(void) {
     onboard_whats_next_guidance_label = NULL;
     onboard_whats_next_dashboard_button = NULL;
     onboard_environment_checks_box = NULL;
+    onboard_cli_install_status_label = NULL;
+    onboard_chat_validation_status_label = NULL;
+    onboard_bootstrap_setup_status_label = NULL;
+    onboard_bootstrap_setup_output_label = NULL;
+    onboard_bootstrap_install_status_label = NULL;
+    onboard_bootstrap_install_output_label = NULL;
+    onboard_start_gateway_status_label = NULL;
+    onboard_wizard_status_label = NULL;
+    onboard_wizard_step_box = NULL;
+    onboard_wizard_answer_widget = NULL;
+    g_clear_pointer(&onboard_wizard_multiselect_checks, g_ptr_array_unref);
+    if (onboard_bootstrap_setup_run) {
+        onboarding_bootstrap_run_cancel(onboard_bootstrap_setup_run);
+        onboarding_bootstrap_run_free(onboard_bootstrap_setup_run);
+        onboard_bootstrap_setup_run = NULL;
+    }
+    if (onboard_bootstrap_install_run) {
+        onboarding_bootstrap_run_cancel(onboard_bootstrap_install_run);
+        onboarding_bootstrap_run_free(onboard_bootstrap_install_run);
+        onboard_bootstrap_install_run = NULL;
+    }
+    if (onboard_wizard_model) {
+        onboarding_wizard_model_free(onboard_wizard_model);
+        onboard_wizard_model = NULL;
+    }
 
     /*
      * Remote subflow widget pointers — null the references but keep
@@ -1095,34 +1631,83 @@ void onboarding_view_build_pages(GtkWidget *carousel,
     if (callbacks) {
         onboarding_view_callbacks = *callbacks;
     }
+    onboard_view_current_route = route;
 
-    GtkWidget *welcome = build_welcome_page(carousel);
-    adw_carousel_append(ADW_CAROUSEL(carousel), welcome);
-
-    if (route == ONBOARDING_SHOW_FULL) {
-        /*
-         * Connection-mode choice page. Lets the operator pick local vs.
-         * remote up front. The local branch keeps the existing local
-         * gateway + environment pages; the remote branch swaps them
-         * for the remote-setup form.
-         */
-        GtkWidget *mode_choice = build_mode_choice_page(carousel);
-        adw_carousel_append(ADW_CAROUSEL(carousel), mode_choice);
-
-        if (g_onboard_chose_remote) {
-            GtkWidget *remote_setup = build_remote_setup_page(carousel);
-            adw_carousel_append(ADW_CAROUSEL(carousel), remote_setup);
-        } else {
-            GtkWidget *gateway = build_gateway_page(carousel);
-            adw_carousel_append(ADW_CAROUSEL(carousel), gateway);
-
-            GtkWidget *environment = build_environment_page(carousel);
-            adw_carousel_append(ADW_CAROUSEL(carousel), environment);
-        }
+    ProductConnectionMode mode = product_state_get_connection_mode();
+    if (g_onboard_chose_remote) {
+        mode = PRODUCT_CONNECTION_MODE_REMOTE;
     }
 
-    GtkWidget *whats_next = build_whats_next_page(carousel);
-    adw_carousel_append(ADW_CAROUSEL(carousel), whats_next);
+    OnboardingBootstrapResolution resolution = {0};
+    gboolean bootstrap_available = onboarding_bootstrap_resolve_commands(&resolution);
+    onboarding_bootstrap_resolution_clear(&resolution);
+
+    HealthState *health = state_get_health();
+    SystemdState *sys = state_get_systemd();
+    OnboardingFlowInput input = {
+        .route = route,
+        .connection_mode = mode,
+        .app_state = state_get_current(),
+        .cli_present = bootstrap_available,
+        .sys_installed = sys ? sys->installed : FALSE,
+        .sys_active = sys ? sys->active : FALSE,
+        .has_wizard_onboard_marker = health ? health->has_wizard_onboard_marker : FALSE,
+        .wizard_should_skip = onboarding_wizard_should_skip_for_health(
+            health ? health->has_wizard_onboard_marker : FALSE),
+    };
+    OnboardingFlowPages pages;
+    onboarding_flow_pages_visible(&input, &pages);
+
+    for (guint i = 0; i < pages.count; i++) {
+        GtkWidget *page = NULL;
+        switch (pages.pages[i]) {
+        case ONBOARDING_FLOW_PAGE_WELCOME:
+            page = build_welcome_page(carousel);
+            break;
+        case ONBOARDING_FLOW_PAGE_CONNECTION:
+            page = build_mode_choice_page(carousel);
+            break;
+        case ONBOARDING_FLOW_PAGE_CLI_INSTALL:
+            page = build_cli_install_page(carousel);
+            break;
+        case ONBOARDING_FLOW_PAGE_BOOTSTRAP_SETUP:
+            page = build_bootstrap_page(carousel,
+                                        "Bootstrap OpenClaw",
+                                        "Create the baseline OpenClaw configuration and workspace by running openclaw setup.",
+                                        "Run openclaw setup",
+                                        G_CALLBACK(on_bootstrap_setup_clicked),
+                                        &onboard_bootstrap_setup_status_label,
+                                        &onboard_bootstrap_setup_output_label);
+            break;
+        case ONBOARDING_FLOW_PAGE_BOOTSTRAP_INSTALL_UNIT:
+            page = build_bootstrap_page(carousel,
+                                        "Install Gateway Service",
+                                        "Install the local gateway systemd user service by running openclaw gateway install. This also creates the gateway token used by the companion.",
+                                        "Run gateway install",
+                                        G_CALLBACK(on_bootstrap_install_clicked),
+                                        &onboard_bootstrap_install_status_label,
+                                        &onboard_bootstrap_install_output_label);
+            break;
+        case ONBOARDING_FLOW_PAGE_BOOTSTRAP_START_GATEWAY:
+            page = build_start_gateway_page(carousel);
+            break;
+        case ONBOARDING_FLOW_PAGE_SETUP_WIZARD:
+            page = build_setup_wizard_page(carousel);
+            break;
+        case ONBOARDING_FLOW_PAGE_REMOTE_SETUP:
+            page = build_remote_setup_page(carousel);
+            break;
+        case ONBOARDING_FLOW_PAGE_CHAT_VALIDATION:
+            page = build_chat_validation_page(carousel);
+            break;
+        case ONBOARDING_FLOW_PAGE_WHATS_NEXT:
+            page = build_whats_next_page(carousel);
+            break;
+        }
+        if (page) {
+            adw_carousel_append(ADW_CAROUSEL(carousel), page);
+        }
+    }
 
     onboarding_view_refresh_live_content();
 }

--- a/apps/linux/src/onboarding_wizard.c
+++ b/apps/linux/src/onboarding_wizard.c
@@ -1,0 +1,286 @@
+/*
+ * onboarding_wizard.c
+ *
+ * Client-side model for the Gateway setup wizard RPC flow.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "onboarding_wizard.h"
+
+#include "gateway_rpc.h"
+
+struct _OnboardingWizardModel {
+    gint ref_count;
+    guint generation;
+    gboolean destroyed;
+    gchar *session_id;
+    JsonNode *step;
+    OnboardingWizardStatus status;
+    gchar *error;
+    gboolean busy;
+    OnboardingWizardChangedCallback callback;
+    gpointer user_data;
+};
+
+typedef struct {
+    OnboardingWizardModel *model;
+    guint generation;
+} OnboardingWizardCallbackContext;
+
+static OnboardingWizardModel* wizard_model_ref(OnboardingWizardModel *model) {
+    g_atomic_int_inc(&model->ref_count);
+    return model;
+}
+
+static void wizard_model_unref(OnboardingWizardModel *model) {
+    if (!model || !g_atomic_int_dec_and_test(&model->ref_count)) {
+        return;
+    }
+    g_free(model->session_id);
+    g_free(model->error);
+    if (model->step) {
+        json_node_unref(model->step);
+    }
+    g_free(model);
+}
+
+static OnboardingWizardCallbackContext* wizard_callback_context_new(OnboardingWizardModel *model) {
+    OnboardingWizardCallbackContext *ctx = g_new0(OnboardingWizardCallbackContext, 1);
+    ctx->model = wizard_model_ref(model);
+    ctx->generation = model->generation;
+    return ctx;
+}
+
+static void wizard_callback_context_free(OnboardingWizardCallbackContext *ctx) {
+    if (!ctx) return;
+    wizard_model_unref(ctx->model);
+    g_free(ctx);
+}
+
+static gboolean wizard_callback_context_is_current(const OnboardingWizardCallbackContext *ctx) {
+    return ctx && ctx->model && !ctx->model->destroyed &&
+           ctx->generation == ctx->model->generation;
+}
+
+static void wizard_emit_changed(OnboardingWizardModel *model) {
+    if (model && !model->destroyed && model->callback) {
+        model->callback(model, model->user_data);
+    }
+}
+
+static void wizard_set_error(OnboardingWizardModel *model, const gchar *message) {
+    if (!model || model->destroyed) return;
+    model->status = ONBOARDING_WIZARD_STATUS_ERROR;
+    g_free(model->error);
+    model->error = g_strdup(message ? message : "Wizard request failed.");
+    model->busy = FALSE;
+    wizard_emit_changed(model);
+}
+
+static const gchar* json_string_member(JsonObject *obj, const gchar *name) {
+    if (!obj || !json_object_has_member(obj, name)) {
+        return NULL;
+    }
+    JsonNode *node = json_object_get_member(obj, name);
+    return node && JSON_NODE_HOLDS_VALUE(node) ? json_node_get_string(node) : NULL;
+}
+
+static gboolean json_bool_member(JsonObject *obj, const gchar *name) {
+    if (!obj || !json_object_has_member(obj, name)) {
+        return FALSE;
+    }
+    JsonNode *node = json_object_get_member(obj, name);
+    return node && JSON_NODE_HOLDS_VALUE(node) ? json_node_get_boolean(node) : FALSE;
+}
+
+static void wizard_apply_result(OnboardingWizardModel *model, JsonNode *payload) {
+    if (!payload || !JSON_NODE_HOLDS_OBJECT(payload)) {
+        wizard_set_error(model, "Wizard response was not an object.");
+        return;
+    }
+    JsonObject *obj = json_node_get_object(payload);
+    const gchar *session_id = json_string_member(obj, "sessionId");
+    if (session_id && session_id[0] != '\0') {
+        g_free(model->session_id);
+        model->session_id = g_strdup(session_id);
+    }
+
+    const gchar *status = json_string_member(obj, "status");
+    gboolean done = json_bool_member(obj, "done");
+    if (g_strcmp0(status, "done") == 0 || done) {
+        model->status = ONBOARDING_WIZARD_STATUS_DONE;
+        g_clear_pointer(&model->session_id, g_free);
+    } else if (g_strcmp0(status, "cancelled") == 0) {
+        model->status = ONBOARDING_WIZARD_STATUS_CANCELLED;
+        g_clear_pointer(&model->session_id, g_free);
+    } else if (g_strcmp0(status, "error") == 0) {
+        model->status = ONBOARDING_WIZARD_STATUS_ERROR;
+    } else {
+        model->status = ONBOARDING_WIZARD_STATUS_RUNNING;
+    }
+
+    g_clear_pointer(&model->error, g_free);
+    const gchar *error = json_string_member(obj, "error");
+    model->error = g_strdup(error);
+
+    if (model->step) {
+        json_node_unref(model->step);
+        model->step = NULL;
+    }
+    if (!done && json_object_has_member(obj, "step")) {
+        JsonNode *step = json_object_get_member(obj, "step");
+        if (step && JSON_NODE_HOLDS_OBJECT(step)) {
+            model->step = json_node_copy(step);
+        }
+    }
+    model->busy = FALSE;
+    wizard_emit_changed(model);
+}
+
+static void wizard_rpc_done(const GatewayRpcResponse *response, gpointer user_data) {
+    OnboardingWizardCallbackContext *ctx = user_data;
+    if (!wizard_callback_context_is_current(ctx)) {
+        wizard_callback_context_free(ctx);
+        return;
+    }
+    OnboardingWizardModel *model = ctx->model;
+    if (!response || !response->ok) {
+        wizard_set_error(model, response && response->error_msg ? response->error_msg : "Wizard RPC failed.");
+        wizard_callback_context_free(ctx);
+        return;
+    }
+    wizard_apply_result(model, response->payload);
+    wizard_callback_context_free(ctx);
+}
+
+OnboardingWizardModel* onboarding_wizard_model_new(OnboardingWizardChangedCallback callback,
+                                                   gpointer user_data) {
+    OnboardingWizardModel *model = g_new0(OnboardingWizardModel, 1);
+    model->ref_count = 1;
+    model->status = ONBOARDING_WIZARD_STATUS_IDLE;
+    model->callback = callback;
+    model->user_data = user_data;
+    return model;
+}
+
+void onboarding_wizard_model_free(OnboardingWizardModel *model) {
+    if (!model) return;
+    model->destroyed = TRUE;
+    model->generation++;
+    model->callback = NULL;
+    model->user_data = NULL;
+    wizard_model_unref(model);
+}
+
+void onboarding_wizard_start(OnboardingWizardModel *model, const gchar *mode) {
+    if (!model || model->destroyed) return;
+    JsonBuilder *builder = json_builder_new();
+    json_builder_begin_object(builder);
+    if (mode && mode[0] != '\0') {
+        json_builder_set_member_name(builder, "mode");
+        json_builder_add_string_value(builder, mode);
+    }
+    json_builder_end_object(builder);
+    g_autoptr(JsonNode) params = json_builder_get_root(builder);
+    g_object_unref(builder);
+
+    model->busy = TRUE;
+    model->status = ONBOARDING_WIZARD_STATUS_RUNNING;
+    model->generation++;
+    OnboardingWizardCallbackContext *ctx = wizard_callback_context_new(model);
+    g_autofree gchar *request_id = gateway_rpc_request("wizard.start", params, 0, wizard_rpc_done, ctx);
+    if (!request_id) {
+        wizard_callback_context_free(ctx);
+        wizard_set_error(model, "Gateway RPC is not ready yet.");
+    } else {
+        wizard_emit_changed(model);
+    }
+}
+
+void onboarding_wizard_submit(OnboardingWizardModel *model, JsonNode *value) {
+    if (!model || model->destroyed || !model->session_id || !model->step || !JSON_NODE_HOLDS_OBJECT(model->step)) {
+        wizard_set_error(model, "Wizard step is not ready.");
+        return;
+    }
+    JsonObject *step = json_node_get_object(model->step);
+    const gchar *step_id = json_string_member(step, "id");
+
+    JsonBuilder *builder = json_builder_new();
+    json_builder_begin_object(builder);
+    json_builder_set_member_name(builder, "sessionId");
+    json_builder_add_string_value(builder, model->session_id);
+    json_builder_set_member_name(builder, "answer");
+    json_builder_begin_object(builder);
+    json_builder_set_member_name(builder, "stepId");
+    json_builder_add_string_value(builder, step_id ? step_id : "");
+    if (value) {
+        json_builder_set_member_name(builder, "value");
+        json_builder_add_value(builder, json_node_copy(value));
+    }
+    json_builder_end_object(builder);
+    json_builder_end_object(builder);
+    g_autoptr(JsonNode) params = json_builder_get_root(builder);
+    g_object_unref(builder);
+
+    model->busy = TRUE;
+    model->generation++;
+    OnboardingWizardCallbackContext *ctx = wizard_callback_context_new(model);
+    g_autofree gchar *request_id = gateway_rpc_request("wizard.next", params, 0, wizard_rpc_done, ctx);
+    if (!request_id) {
+        wizard_callback_context_free(ctx);
+        wizard_set_error(model, "Gateway RPC is not ready yet.");
+    } else {
+        wizard_emit_changed(model);
+    }
+}
+
+void onboarding_wizard_cancel(OnboardingWizardModel *model) {
+    if (!model || model->destroyed || !model->session_id) return;
+    JsonBuilder *builder = json_builder_new();
+    json_builder_begin_object(builder);
+    json_builder_set_member_name(builder, "sessionId");
+    json_builder_add_string_value(builder, model->session_id);
+    json_builder_end_object(builder);
+    g_autoptr(JsonNode) params = json_builder_get_root(builder);
+    g_object_unref(builder);
+
+    model->busy = TRUE;
+    model->generation++;
+    OnboardingWizardCallbackContext *ctx = wizard_callback_context_new(model);
+    g_autofree gchar *request_id = gateway_rpc_request("wizard.cancel", params, 0, wizard_rpc_done, ctx);
+    if (!request_id) {
+        wizard_callback_context_free(ctx);
+        wizard_set_error(model, "Gateway RPC is not ready yet.");
+    } else {
+        wizard_emit_changed(model);
+    }
+}
+
+OnboardingWizardStatus onboarding_wizard_get_status(const OnboardingWizardModel *model) {
+    return model ? model->status : ONBOARDING_WIZARD_STATUS_ERROR;
+}
+
+const gchar* onboarding_wizard_get_error(const OnboardingWizardModel *model) {
+    return model ? model->error : NULL;
+}
+
+const gchar* onboarding_wizard_get_session_id(const OnboardingWizardModel *model) {
+    return model ? model->session_id : NULL;
+}
+
+JsonObject* onboarding_wizard_get_step(const OnboardingWizardModel *model) {
+    if (!model || !model->step || !JSON_NODE_HOLDS_OBJECT(model->step)) {
+        return NULL;
+    }
+    return json_node_get_object(model->step);
+}
+
+gboolean onboarding_wizard_is_busy(const OnboardingWizardModel *model) {
+    return model ? model->busy : FALSE;
+}
+
+gboolean onboarding_wizard_should_skip_for_health(gboolean has_wizard_onboard_marker) {
+    return has_wizard_onboard_marker;
+}
+

--- a/apps/linux/src/onboarding_wizard.h
+++ b/apps/linux/src/onboarding_wizard.h
@@ -1,0 +1,41 @@
+/*
+ * onboarding_wizard.h
+ *
+ * RPC-backed setup-wizard model for Linux onboarding.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#pragma once
+
+#include <glib.h>
+#include <json-glib/json-glib.h>
+
+typedef enum {
+    ONBOARDING_WIZARD_STATUS_IDLE,
+    ONBOARDING_WIZARD_STATUS_RUNNING,
+    ONBOARDING_WIZARD_STATUS_DONE,
+    ONBOARDING_WIZARD_STATUS_CANCELLED,
+    ONBOARDING_WIZARD_STATUS_ERROR,
+} OnboardingWizardStatus;
+
+typedef struct _OnboardingWizardModel OnboardingWizardModel;
+
+typedef void (*OnboardingWizardChangedCallback)(OnboardingWizardModel *model,
+                                                gpointer user_data);
+
+OnboardingWizardModel* onboarding_wizard_model_new(OnboardingWizardChangedCallback callback,
+                                                   gpointer user_data);
+void onboarding_wizard_model_free(OnboardingWizardModel *model);
+void onboarding_wizard_start(OnboardingWizardModel *model, const gchar *mode);
+void onboarding_wizard_submit(OnboardingWizardModel *model, JsonNode *value);
+void onboarding_wizard_cancel(OnboardingWizardModel *model);
+
+OnboardingWizardStatus onboarding_wizard_get_status(const OnboardingWizardModel *model);
+const gchar* onboarding_wizard_get_error(const OnboardingWizardModel *model);
+const gchar* onboarding_wizard_get_session_id(const OnboardingWizardModel *model);
+JsonObject* onboarding_wizard_get_step(const OnboardingWizardModel *model);
+gboolean onboarding_wizard_is_busy(const OnboardingWizardModel *model);
+
+gboolean onboarding_wizard_should_skip_for_health(gboolean has_wizard_onboard_marker);
+

--- a/apps/linux/src/readiness.c
+++ b/apps/linux/src/readiness.c
@@ -68,7 +68,7 @@ void readiness_describe_chat_gate(const DesktopReadinessSnapshot *snapshot,
         break;
     case CHAT_BLOCK_NO_CONFIG:
         out->status = "No OpenClaw config detected.";
-        out->next_action = "Run 'openclaw onboard --install-daemon' to bootstrap OpenClaw.";
+        out->next_action = "Open the companion onboarding flow to run setup and install the gateway service.";
         break;
     case CHAT_BLOCK_CONFIG_INVALID:
         out->status = "Gateway configuration is invalid.";
@@ -130,19 +130,19 @@ void readiness_evaluate(AppState state, const HealthState *health,
     case STATE_NEEDS_SETUP:
         out->classification = "Setup Required";
         out->missing = "No OpenClaw configuration or state directory detected.";
-        out->next_action = "Run 'openclaw onboard --install-daemon' to set up OpenClaw.";
+        out->next_action = "Use onboarding to run 'openclaw setup', then install and start the gateway service.";
         break;
 
     case STATE_NEEDS_GATEWAY_INSTALL:
         out->classification = "Gateway Service Missing";
         out->missing = "The expected user systemd service path is not active and the unit file is missing.";
-        out->next_action = "The gateway service is not installed. Run 'openclaw onboard --install-daemon' to set up OpenClaw.";
+        out->next_action = "Use onboarding to run 'openclaw gateway install', then start the gateway service.";
         break;
 
     case STATE_NEEDS_ONBOARDING:
         out->classification = "Bootstrap Incomplete";
         out->missing = "OpenClaw bootstrap is incomplete. The onboarding wizard has not been run.";
-        out->next_action = "Run 'openclaw onboard --install-daemon' to complete setup.";
+        out->next_action = "Use onboarding to run the setup wizard after the gateway is reachable.";
         break;
 
     case STATE_USER_SYSTEMD_UNAVAILABLE:

--- a/apps/linux/tests/test_display_model.c
+++ b/apps/linux/tests/test_display_model.c
@@ -202,7 +202,7 @@ static void test_dashboard_needs_setup(void) {
     g_assert_cmpstr(dm.headline, ==, "Setup Required");
     g_assert_cmpint(dm.headline_color, ==, STATUS_COLOR_RED);
     assert_contains(dm.guidance_text, "No OpenClaw configuration", "needs_setup.guidance");
-    assert_contains(dm.next_action, "openclaw onboard --install-daemon", "needs_setup.next_action");
+    assert_contains(dm.next_action, "openclaw setup", "needs_setup.next_action");
 }
 
 static void test_dashboard_needs_install(void) {
@@ -217,7 +217,7 @@ static void test_dashboard_needs_install(void) {
     g_assert_cmpstr(dm.headline, ==, "Gateway Service Missing");
     g_assert_cmpint(dm.headline_color, ==, STATUS_COLOR_RED);
     assert_contains(dm.guidance_text, "expected user systemd service", "needs_install.guidance");
-    assert_contains(dm.next_action, "onboard --install-daemon", "needs_install.next_action");
+    assert_contains(dm.next_action, "openclaw gateway install", "needs_install.next_action");
 }
 
 static void test_dashboard_needs_onboarding(void) {
@@ -231,7 +231,7 @@ static void test_dashboard_needs_onboarding(void) {
 
     g_assert_cmpstr(dm.headline, ==, "Bootstrap Incomplete");
     g_assert_cmpint(dm.headline_color, ==, STATUS_COLOR_ORANGE);
-    assert_contains(dm.next_action, "openclaw onboard --install-daemon", "needs_onboarding.next_action");
+    assert_contains(dm.next_action, "setup wizard", "needs_onboarding.next_action");
 }
 
 static void test_dashboard_starting(void) {
@@ -648,6 +648,89 @@ static void test_onboarding_config_invalid(void) {
     g_assert_cmpint(r, ==, ONBOARDING_SHOW_FULL);
 }
 
+static void assert_flow_page(const OnboardingFlowPages *pages,
+                             guint index,
+                             OnboardingFlowPage expected) {
+    g_assert_nonnull(pages);
+    g_assert_cmpuint(index, <, pages->count);
+    g_assert_cmpint(pages->pages[index], ==, expected);
+}
+
+static void test_onboarding_flow_local_fresh_order(void) {
+    OnboardingFlowInput input = {
+        .route = ONBOARDING_SHOW_FULL,
+        .connection_mode = PRODUCT_CONNECTION_MODE_LOCAL,
+        .app_state = STATE_NEEDS_SETUP,
+        .cli_present = TRUE,
+        .sys_installed = FALSE,
+        .sys_active = FALSE,
+        .has_wizard_onboard_marker = FALSE,
+        .wizard_should_skip = FALSE,
+    };
+    OnboardingFlowPages pages;
+    onboarding_flow_pages_visible(&input, &pages);
+    g_assert_cmpuint(pages.count, ==, 8);
+    assert_flow_page(&pages, 0, ONBOARDING_FLOW_PAGE_WELCOME);
+    assert_flow_page(&pages, 1, ONBOARDING_FLOW_PAGE_CONNECTION);
+    assert_flow_page(&pages, 2, ONBOARDING_FLOW_PAGE_BOOTSTRAP_SETUP);
+    assert_flow_page(&pages, 3, ONBOARDING_FLOW_PAGE_BOOTSTRAP_INSTALL_UNIT);
+    assert_flow_page(&pages, 4, ONBOARDING_FLOW_PAGE_BOOTSTRAP_START_GATEWAY);
+    assert_flow_page(&pages, 5, ONBOARDING_FLOW_PAGE_SETUP_WIZARD);
+    assert_flow_page(&pages, 6, ONBOARDING_FLOW_PAGE_CHAT_VALIDATION);
+    assert_flow_page(&pages, 7, ONBOARDING_FLOW_PAGE_WHATS_NEXT);
+}
+
+static void test_onboarding_flow_remote_skips_local_bootstrap(void) {
+    OnboardingFlowInput input = {
+        .route = ONBOARDING_SHOW_FULL,
+        .connection_mode = PRODUCT_CONNECTION_MODE_REMOTE,
+        .app_state = STATE_NEEDS_SETUP,
+        .cli_present = FALSE,
+        .sys_installed = FALSE,
+        .sys_active = FALSE,
+        .has_wizard_onboard_marker = FALSE,
+    };
+    OnboardingFlowPages pages;
+    onboarding_flow_pages_visible(&input, &pages);
+    g_assert_cmpuint(pages.count, ==, 5);
+    assert_flow_page(&pages, 2, ONBOARDING_FLOW_PAGE_REMOTE_SETUP);
+    assert_flow_page(&pages, 3, ONBOARDING_FLOW_PAGE_CHAT_VALIDATION);
+    assert_flow_page(&pages, 4, ONBOARDING_FLOW_PAGE_WHATS_NEXT);
+}
+
+static void test_onboarding_flow_configure_later_skips_setup(void) {
+    OnboardingFlowInput input = {
+        .route = ONBOARDING_SHOW_FULL,
+        .connection_mode = PRODUCT_CONNECTION_MODE_UNSPECIFIED,
+        .app_state = STATE_NEEDS_SETUP,
+        .cli_present = FALSE,
+        .sys_installed = FALSE,
+        .sys_active = FALSE,
+        .has_wizard_onboard_marker = FALSE,
+    };
+    OnboardingFlowPages pages;
+    onboarding_flow_pages_visible(&input, &pages);
+    g_assert_cmpuint(pages.count, ==, 4);
+    assert_flow_page(&pages, 2, ONBOARDING_FLOW_PAGE_CHAT_VALIDATION);
+    assert_flow_page(&pages, 3, ONBOARDING_FLOW_PAGE_WHATS_NEXT);
+}
+
+static void test_onboarding_flow_local_missing_cli_first(void) {
+    OnboardingFlowInput input = {
+        .route = ONBOARDING_SHOW_FULL,
+        .connection_mode = PRODUCT_CONNECTION_MODE_LOCAL,
+        .app_state = STATE_NEEDS_GATEWAY_INSTALL,
+        .cli_present = FALSE,
+        .sys_installed = FALSE,
+        .sys_active = FALSE,
+        .has_wizard_onboard_marker = FALSE,
+    };
+    OnboardingFlowPages pages;
+    onboarding_flow_pages_visible(&input, &pages);
+    g_assert_cmpuint(pages.count, ==, 3);
+    assert_flow_page(&pages, 2, ONBOARDING_FLOW_PAGE_CLI_INSTALL);
+}
+
 /* ══════════════════════════════════════════════════════════════════
  * HTTP probe label tests
  * ══════════════════════════════════════════════════════════════════ */
@@ -934,6 +1017,14 @@ int main(int argc, char **argv) {
                     test_onboarding_degraded);
     g_test_add_func("/display_model/onboarding/config_invalid",
                     test_onboarding_config_invalid);
+    g_test_add_func("/display_model/onboarding_flow/local_fresh_order",
+                    test_onboarding_flow_local_fresh_order);
+    g_test_add_func("/display_model/onboarding_flow/remote_skips_local_bootstrap",
+                    test_onboarding_flow_remote_skips_local_bootstrap);
+    g_test_add_func("/display_model/onboarding_flow/configure_later_skips_setup",
+                    test_onboarding_flow_configure_later_skips_setup);
+    g_test_add_func("/display_model/onboarding_flow/local_missing_cli_first",
+                    test_onboarding_flow_local_missing_cli_first);
 
     /* HTTP probe labels */
     g_test_add_func("/display_model/probe_labels", test_probe_labels);

--- a/apps/linux/tests/test_onboarding_bootstrap.c
+++ b/apps/linux/tests/test_onboarding_bootstrap.c
@@ -1,0 +1,222 @@
+/*
+ * test_onboarding_bootstrap.c
+ *
+ * Headless lifecycle tests for Linux onboarding bootstrap subprocess runs.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "../src/onboarding_bootstrap.h"
+#include "../src/onboarding_bootstrap_resolver.h"
+
+#include <glib.h>
+
+typedef struct {
+    OnboardingBootstrapEventKind kind;
+    gchar *output;
+    gchar *message;
+} CapturedEvent;
+
+typedef struct {
+    OnboardingBootstrapTestSpawnResult result;
+    gchar **last_argv;
+} SpawnScript;
+
+static CapturedEvent events[16];
+static guint event_count = 0;
+static gchar *fake_openclaw = NULL;
+
+static gchar* test_find_program(const gchar *program) {
+    if (g_strcmp0(program, "openclaw") == 0 && fake_openclaw) {
+        return g_strdup(fake_openclaw);
+    }
+    return NULL;
+}
+
+static void clear_events(void) {
+    for (guint i = 0; i < G_N_ELEMENTS(events); i++) {
+        g_clear_pointer(&events[i].output, g_free);
+        g_clear_pointer(&events[i].message, g_free);
+    }
+    event_count = 0;
+}
+
+static void reset_harness(void) {
+    clear_events();
+    g_clear_pointer(&fake_openclaw, g_free);
+    fake_openclaw = g_strdup("/usr/local/bin/openclaw");
+    onboarding_bootstrap_resolver_set_test_hooks(test_find_program, NULL, NULL);
+    onboarding_bootstrap_set_spawner_for_test(NULL, NULL);
+}
+
+static gboolean test_spawner(const gchar * const *argv,
+                             OnboardingBootstrapTestSpawnResult *out,
+                             gpointer user_data) {
+    SpawnScript *script = user_data;
+    g_clear_pointer(&script->last_argv, g_strfreev);
+    script->last_argv = g_strdupv((gchar **)argv);
+    *out = script->result;
+    return TRUE;
+}
+
+static void capture_event(const OnboardingBootstrapEvent *event, gpointer user_data) {
+    (void)user_data;
+    g_assert_cmpuint(event_count, <, G_N_ELEMENTS(events));
+    events[event_count].kind = event->kind;
+    events[event_count].output = g_strdup(event->output);
+    events[event_count].message = g_strdup(event->message);
+    event_count++;
+}
+
+static void assert_event_kind(guint index, OnboardingBootstrapEventKind kind) {
+    g_assert_cmpuint(index, <, event_count);
+    g_assert_cmpint(events[index].kind, ==, kind);
+}
+
+static void test_spawn_failure(void) {
+    reset_harness();
+    SpawnScript script = {
+        .result = {
+            .spawn_ok = FALSE,
+            .spawn_error = "spawn failed",
+        },
+    };
+    onboarding_bootstrap_set_spawner_for_test(test_spawner, &script);
+    OnboardingBootstrapRun *run =
+        onboarding_bootstrap_run_step(ONBOARDING_BOOTSTRAP_STEP_SETUP, capture_event, NULL);
+    g_assert_null(run);
+    g_assert_cmpuint(event_count, ==, 1);
+    assert_event_kind(0, ONBOARDING_BOOTSTRAP_EVENT_ERROR);
+    g_assert_cmpstr(events[0].message, ==, "spawn failed");
+    g_strfreev(script.last_argv);
+}
+
+static void test_setup_happy_path(void) {
+    reset_harness();
+    const gchar *stdout_lines[] = { "setup line", NULL };
+    SpawnScript script = {
+        .result = {
+            .spawn_ok = TRUE,
+            .stdout_lines = stdout_lines,
+            .wait_ok = TRUE,
+            .exit_code = 0,
+            .complete_immediately = TRUE,
+        },
+    };
+    onboarding_bootstrap_set_spawner_for_test(test_spawner, &script);
+    OnboardingBootstrapRun *run =
+        onboarding_bootstrap_run_step(ONBOARDING_BOOTSTRAP_STEP_SETUP, capture_event, NULL);
+    g_assert_nonnull(run);
+    g_assert_cmpstr(script.last_argv[0], ==, "/usr/local/bin/openclaw");
+    g_assert_cmpstr(script.last_argv[1], ==, "setup");
+    g_assert_cmpuint(event_count, ==, 3);
+    assert_event_kind(0, ONBOARDING_BOOTSTRAP_EVENT_STARTED);
+    assert_event_kind(1, ONBOARDING_BOOTSTRAP_EVENT_OUTPUT);
+    g_assert_cmpstr(events[1].output, ==, "setup line");
+    assert_event_kind(2, ONBOARDING_BOOTSTRAP_EVENT_DONE);
+    onboarding_bootstrap_run_free(run);
+    g_strfreev(script.last_argv);
+}
+
+static void test_gateway_install_happy_path(void) {
+    reset_harness();
+    const gchar *stdout_lines[] = { "install line", NULL };
+    SpawnScript script = {
+        .result = {
+            .spawn_ok = TRUE,
+            .stdout_lines = stdout_lines,
+            .wait_ok = TRUE,
+            .exit_code = 0,
+            .complete_immediately = TRUE,
+        },
+    };
+    onboarding_bootstrap_set_spawner_for_test(test_spawner, &script);
+    OnboardingBootstrapRun *run =
+        onboarding_bootstrap_run_step(ONBOARDING_BOOTSTRAP_STEP_GATEWAY_INSTALL, capture_event, NULL);
+    g_assert_nonnull(run);
+    g_assert_cmpstr(script.last_argv[0], ==, "/usr/local/bin/openclaw");
+    g_assert_cmpstr(script.last_argv[1], ==, "gateway");
+    g_assert_cmpstr(script.last_argv[2], ==, "install");
+    g_assert_cmpuint(event_count, ==, 3);
+    assert_event_kind(2, ONBOARDING_BOOTSTRAP_EVENT_DONE);
+    onboarding_bootstrap_run_free(run);
+    g_strfreev(script.last_argv);
+}
+
+static void test_cancel_before_completion(void) {
+    reset_harness();
+    SpawnScript script = {
+        .result = {
+            .spawn_ok = TRUE,
+            .wait_ok = FALSE,
+            .exit_code = -1,
+        },
+    };
+    onboarding_bootstrap_set_spawner_for_test(test_spawner, &script);
+    OnboardingBootstrapRun *run =
+        onboarding_bootstrap_run_step(ONBOARDING_BOOTSTRAP_STEP_SETUP, capture_event, NULL);
+    onboarding_bootstrap_run_cancel(run);
+    onboarding_bootstrap_test_complete_pending();
+    g_assert_cmpuint(event_count, ==, 2);
+    assert_event_kind(0, ONBOARDING_BOOTSTRAP_EVENT_STARTED);
+    assert_event_kind(1, ONBOARDING_BOOTSTRAP_EVENT_CANCELLED);
+    onboarding_bootstrap_run_free(run);
+    g_strfreev(script.last_argv);
+}
+
+static void test_free_after_cancel_suppresses_future_events(void) {
+    reset_harness();
+    const gchar *stdout_lines[] = { "late output", NULL };
+    SpawnScript script = {
+        .result = {
+            .spawn_ok = TRUE,
+            .stdout_lines = stdout_lines,
+            .wait_ok = TRUE,
+            .exit_code = 0,
+        },
+    };
+    onboarding_bootstrap_set_spawner_for_test(test_spawner, &script);
+    OnboardingBootstrapRun *run =
+        onboarding_bootstrap_run_step(ONBOARDING_BOOTSTRAP_STEP_SETUP, capture_event, NULL);
+    onboarding_bootstrap_run_cancel(run);
+    onboarding_bootstrap_run_free(run);
+    onboarding_bootstrap_test_complete_pending();
+    g_assert_cmpuint(event_count, ==, 1);
+    assert_event_kind(0, ONBOARDING_BOOTSTRAP_EVENT_STARTED);
+    g_strfreev(script.last_argv);
+}
+
+static void test_timeout_emits_error(void) {
+    reset_harness();
+    SpawnScript script = {
+        .result = {
+            .spawn_ok = TRUE,
+            .wait_ok = FALSE,
+            .exit_code = -1,
+        },
+    };
+    onboarding_bootstrap_set_spawner_for_test(test_spawner, &script);
+    OnboardingBootstrapRun *run =
+        onboarding_bootstrap_run_step(ONBOARDING_BOOTSTRAP_STEP_SETUP, capture_event, NULL);
+    onboarding_bootstrap_test_timeout_pending();
+    g_assert_true(onboarding_bootstrap_test_force_exit_was_scheduled());
+    g_assert_cmpuint(event_count, ==, 2);
+    assert_event_kind(0, ONBOARDING_BOOTSTRAP_EVENT_STARTED);
+    assert_event_kind(1, ONBOARDING_BOOTSTRAP_EVENT_ERROR);
+    g_assert_nonnull(g_strstr_len(events[1].message, -1, "timed out"));
+    onboarding_bootstrap_run_free(run);
+    g_strfreev(script.last_argv);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/onboarding/bootstrap/spawn_failure", test_spawn_failure);
+    g_test_add_func("/onboarding/bootstrap/setup_happy_path", test_setup_happy_path);
+    g_test_add_func("/onboarding/bootstrap/gateway_install_happy_path", test_gateway_install_happy_path);
+    g_test_add_func("/onboarding/bootstrap/cancel_before_completion", test_cancel_before_completion);
+    g_test_add_func("/onboarding/bootstrap/free_after_cancel_suppresses_future_events",
+                    test_free_after_cancel_suppresses_future_events);
+    g_test_add_func("/onboarding/bootstrap/timeout_emits_error", test_timeout_emits_error);
+    return g_test_run();
+}
+

--- a/apps/linux/tests/test_onboarding_bootstrap_resolver.c
+++ b/apps/linux/tests/test_onboarding_bootstrap_resolver.c
@@ -1,0 +1,183 @@
+/*
+ * test_onboarding_bootstrap_resolver.c
+ *
+ * Headless coverage for deterministic Linux onboarding bootstrap command
+ * resolution.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "../src/onboarding_bootstrap_resolver.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+
+static gchar *fake_openclaw = NULL;
+static gchar *fake_node = NULL;
+static gchar *fake_executable_path = NULL;
+static gchar *fake_current_dir = NULL;
+
+static gchar* test_find_program(const gchar *program) {
+    if (g_strcmp0(program, "openclaw") == 0 && fake_openclaw) {
+        return g_strdup(fake_openclaw);
+    }
+    if (g_strcmp0(program, "node") == 0 && fake_node) {
+        return g_strdup(fake_node);
+    }
+    return NULL;
+}
+
+static gchar* test_executable_path(void) {
+    return fake_executable_path ? g_strdup(fake_executable_path) : NULL;
+}
+
+static gchar* test_current_dir(void) {
+    return fake_current_dir ? g_strdup(fake_current_dir) : NULL;
+}
+
+static void reset_hooks(void) {
+    g_clear_pointer(&fake_openclaw, g_free);
+    g_clear_pointer(&fake_node, g_free);
+    g_clear_pointer(&fake_executable_path, g_free);
+    g_clear_pointer(&fake_current_dir, g_free);
+    onboarding_bootstrap_resolver_set_test_hooks(test_find_program,
+                                                 test_executable_path,
+                                                 test_current_dir);
+}
+
+static gchar* make_repo_tree(void) {
+    g_autofree gchar *root = g_dir_make_tmp("openclaw-bootstrap-resolver-XXXXXX", NULL);
+    g_assert_nonnull(root);
+    g_autofree gchar *openclaw_mjs = g_build_filename(root, "openclaw.mjs", NULL);
+    g_autofree gchar *package_json = g_build_filename(root, "package.json", NULL);
+    g_assert_true(g_file_set_contents(openclaw_mjs, "#!/usr/bin/env node\n", -1, NULL));
+    g_assert_true(g_file_set_contents(package_json, "{\"name\":\"openclaw\"}\n", -1, NULL));
+
+    g_autofree gchar *apps = g_build_filename(root, "apps", NULL);
+    g_autofree gchar *linux_dir = g_build_filename(apps, "linux", NULL);
+    g_autofree gchar *build = g_build_filename(linux_dir, "build", NULL);
+    g_assert_cmpint(g_mkdir(apps, 0700), ==, 0);
+    g_assert_cmpint(g_mkdir(linux_dir, 0700), ==, 0);
+    g_assert_cmpint(g_mkdir(build, 0700), ==, 0);
+    return g_steal_pointer(&root);
+}
+
+static void remove_repo_tree(const gchar *root) {
+    if (!root) return;
+    g_autofree gchar *openclaw_mjs = g_build_filename(root, "openclaw.mjs", NULL);
+    g_autofree gchar *package_json = g_build_filename(root, "package.json", NULL);
+    g_autofree gchar *build = g_build_filename(root, "apps", "linux", "build", NULL);
+    g_autofree gchar *linux_dir = g_build_filename(root, "apps", "linux", NULL);
+    g_autofree gchar *apps = g_build_filename(root, "apps", NULL);
+    g_remove(openclaw_mjs);
+    g_remove(package_json);
+    g_rmdir(build);
+    g_rmdir(linux_dir);
+    g_rmdir(apps);
+    g_rmdir(root);
+}
+
+static void assert_no_shell(const OnboardingBootstrapResolution *res) {
+    g_assert_false(res->uses_shell);
+    g_assert_nonnull(res->setup_argv);
+    g_assert_nonnull(res->gateway_install_argv);
+    for (gchar **it = res->setup_argv; it && *it; it++) {
+        g_assert_cmpstr(*it, !=, "sh");
+        g_assert_cmpstr(*it, !=, "-c");
+    }
+    for (gchar **it = res->gateway_install_argv; it && *it; it++) {
+        g_assert_cmpstr(*it, !=, "sh");
+        g_assert_cmpstr(*it, !=, "-c");
+    }
+}
+
+static void test_finds_openclaw_on_path(void) {
+    reset_hooks();
+    fake_openclaw = g_strdup("/usr/local/bin/openclaw");
+
+    OnboardingBootstrapResolution res = {0};
+    g_assert_true(onboarding_bootstrap_resolve_commands(&res));
+    g_assert_cmpint(res.kind, ==, ONBOARDING_BOOTSTRAP_RESOLUTION_OPENCLAW_PATH);
+    g_assert_cmpstr(res.setup_argv[0], ==, "/usr/local/bin/openclaw");
+    g_assert_cmpstr(res.setup_argv[1], ==, "setup");
+    g_assert_cmpstr(res.gateway_install_argv[0], ==, "/usr/local/bin/openclaw");
+    g_assert_cmpstr(res.gateway_install_argv[1], ==, "gateway");
+    g_assert_cmpstr(res.gateway_install_argv[2], ==, "install");
+    assert_no_shell(&res);
+    onboarding_bootstrap_resolution_clear(&res);
+}
+
+static void test_falls_back_to_dev_tree(void) {
+    reset_hooks();
+    fake_node = g_strdup("/usr/bin/node");
+    g_autofree gchar *root = make_repo_tree();
+    fake_executable_path = g_build_filename(root, "apps", "linux", "build", "openclaw-linux", NULL);
+
+    OnboardingBootstrapResolution res = {0};
+    g_assert_true(onboarding_bootstrap_resolve_commands(&res));
+    g_assert_cmpint(res.kind, ==, ONBOARDING_BOOTSTRAP_RESOLUTION_DEV_TREE);
+    g_assert_cmpstr(res.repo_root, ==, root);
+    g_assert_cmpstr(res.setup_argv[0], ==, "/usr/bin/node");
+    g_assert_true(g_str_has_suffix(res.setup_argv[1], "openclaw.mjs"));
+    g_assert_cmpstr(res.setup_argv[2], ==, "setup");
+    g_assert_cmpstr(res.gateway_install_argv[2], ==, "gateway");
+    g_assert_cmpstr(res.gateway_install_argv[3], ==, "install");
+    assert_no_shell(&res);
+    onboarding_bootstrap_resolution_clear(&res);
+    remove_repo_tree(root);
+}
+
+static void test_walks_up_from_apps_linux_build(void) {
+    reset_hooks();
+    fake_node = g_strdup("/usr/bin/node");
+    g_autofree gchar *root = make_repo_tree();
+    fake_current_dir = g_build_filename(root, "apps", "linux", "build", NULL);
+
+    OnboardingBootstrapResolution res = {0};
+    g_assert_true(onboarding_bootstrap_resolve_commands(&res));
+    g_assert_cmpint(res.kind, ==, ONBOARDING_BOOTSTRAP_RESOLUTION_DEV_TREE);
+    g_assert_cmpstr(res.repo_root, ==, root);
+    assert_no_shell(&res);
+    onboarding_bootstrap_resolution_clear(&res);
+    remove_repo_tree(root);
+}
+
+static void test_missing_node_fails(void) {
+    reset_hooks();
+    g_autofree gchar *root = make_repo_tree();
+    fake_current_dir = g_build_filename(root, "apps", "linux", "build", NULL);
+
+    OnboardingBootstrapResolution res = {0};
+    g_assert_false(onboarding_bootstrap_resolve_commands(&res));
+    g_assert_cmpint(res.kind, ==, ONBOARDING_BOOTSTRAP_RESOLUTION_MISSING);
+    g_assert_nonnull(res.missing_reason);
+    g_assert_null(res.setup_argv);
+    onboarding_bootstrap_resolution_clear(&res);
+    remove_repo_tree(root);
+}
+
+static void test_missing_openclaw_mjs_fails(void) {
+    reset_hooks();
+    fake_node = g_strdup("/usr/bin/node");
+    g_autofree gchar *root = g_dir_make_tmp("openclaw-bootstrap-resolver-empty-XXXXXX", NULL);
+    g_assert_nonnull(root);
+    fake_current_dir = g_strdup(root);
+
+    OnboardingBootstrapResolution res = {0};
+    g_assert_false(onboarding_bootstrap_resolve_commands(&res));
+    g_assert_cmpint(res.kind, ==, ONBOARDING_BOOTSTRAP_RESOLUTION_MISSING);
+    g_assert_nonnull(res.missing_reason);
+    onboarding_bootstrap_resolution_clear(&res);
+    g_rmdir(root);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/onboarding/bootstrap_resolver/openclaw_path", test_finds_openclaw_on_path);
+    g_test_add_func("/onboarding/bootstrap_resolver/dev_tree", test_falls_back_to_dev_tree);
+    g_test_add_func("/onboarding/bootstrap_resolver/apps_linux_build", test_walks_up_from_apps_linux_build);
+    g_test_add_func("/onboarding/bootstrap_resolver/missing_node", test_missing_node_fails);
+    g_test_add_func("/onboarding/bootstrap_resolver/missing_openclaw_mjs", test_missing_openclaw_mjs_fails);
+    return g_test_run();
+}
+

--- a/apps/linux/tests/test_onboarding_chat_validation.c
+++ b/apps/linux/tests/test_onboarding_chat_validation.c
@@ -1,0 +1,53 @@
+/*
+ * test_onboarding_chat_validation.c
+ *
+ * Headless tests for Linux onboarding chat-readiness mapping.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "../src/onboarding_chat_validation.h"
+
+#include <glib.h>
+
+static void test_ready(void) {
+    ChatGateInfo gate = { .ready = TRUE };
+    g_assert_cmpint(onboarding_chat_validation_status(STATE_RUNNING, &gate, NULL),
+                    ==, ONBOARDING_CHAT_VALIDATION_READY);
+}
+
+static void test_provider_missing(void) {
+    ChatGateInfo gate = { .ready = FALSE, .reason = CHAT_BLOCK_PROVIDER_MISSING };
+    g_assert_cmpint(onboarding_chat_validation_status(STATE_RUNNING, &gate, NULL),
+                    ==, ONBOARDING_CHAT_VALIDATION_PROVIDER_MISSING);
+}
+
+static void test_model_missing(void) {
+    ChatGateInfo gate = { .ready = FALSE, .reason = CHAT_BLOCK_SELECTED_MODEL_UNRESOLVED };
+    g_assert_cmpint(onboarding_chat_validation_status(STATE_RUNNING, &gate, NULL),
+                    ==, ONBOARDING_CHAT_VALIDATION_MODEL_MISSING);
+}
+
+static void test_chat_unconfigured(void) {
+    ChatGateInfo gate = { .ready = FALSE, .reason = CHAT_BLOCK_BOOTSTRAP_INCOMPLETE };
+    g_assert_cmpint(onboarding_chat_validation_status(STATE_NEEDS_ONBOARDING, &gate, NULL),
+                    ==, ONBOARDING_CHAT_VALIDATION_CHAT_UNCONFIGURED);
+}
+
+static void test_starting(void) {
+    ChatGateInfo gate = { .ready = FALSE, .reason = CHAT_BLOCK_GATEWAY_UNREACHABLE };
+    SystemdState sys = { .activating = TRUE };
+    g_assert_cmpint(onboarding_chat_validation_status(STATE_STARTING, &gate, &sys),
+                    ==, ONBOARDING_CHAT_VALIDATION_GATEWAY_STARTING);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/onboarding/chat_validation/ready", test_ready);
+    g_test_add_func("/onboarding/chat_validation/provider_missing", test_provider_missing);
+    g_test_add_func("/onboarding/chat_validation/model_missing", test_model_missing);
+    g_test_add_func("/onboarding/chat_validation/chat_unconfigured", test_chat_unconfigured);
+    g_test_add_func("/onboarding/chat_validation/starting", test_starting);
+    return g_test_run();
+}
+

--- a/apps/linux/tests/test_onboarding_cli_detect.c
+++ b/apps/linux/tests/test_onboarding_cli_detect.c
@@ -1,0 +1,41 @@
+/*
+ * test_onboarding_cli_detect.c
+ *
+ * Headless tests for Linux onboarding CLI detection.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "../src/onboarding_cli_detect.h"
+
+#include <glib.h>
+
+static gchar *fake_openclaw = NULL;
+
+static gchar* fake_find_program(const gchar *program) {
+    if (g_strcmp0(program, "openclaw") == 0 && fake_openclaw) {
+        return g_strdup(fake_openclaw);
+    }
+    return NULL;
+}
+
+static void test_cli_present(void) {
+    onboarding_cli_detect_set_test_hook(fake_find_program);
+    fake_openclaw = g_strdup("/usr/local/bin/openclaw");
+    g_assert_true(onboarding_cli_is_present());
+    g_clear_pointer(&fake_openclaw, g_free);
+}
+
+static void test_cli_missing(void) {
+    onboarding_cli_detect_set_test_hook(fake_find_program);
+    g_clear_pointer(&fake_openclaw, g_free);
+    g_assert_false(onboarding_cli_is_present());
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/onboarding/cli_detect/present", test_cli_present);
+    g_test_add_func("/onboarding/cli_detect/missing", test_cli_missing);
+    return g_test_run();
+}
+

--- a/apps/linux/tests/test_onboarding_wizard_model.c
+++ b/apps/linux/tests/test_onboarding_wizard_model.c
@@ -1,0 +1,230 @@
+/*
+ * test_onboarding_wizard_model.c
+ *
+ * Headless coverage for the Linux onboarding wizard RPC model.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "../src/onboarding_wizard.h"
+#include "../src/gateway_rpc.h"
+
+#include <glib.h>
+
+typedef struct {
+    gchar *method;
+    JsonNode *params;
+    GatewayRpcCallback callback;
+    gpointer user_data;
+} CapturedRequest;
+
+static CapturedRequest captured[8];
+static guint captured_count = 0;
+static gboolean rpc_return_null = FALSE;
+static guint change_count = 0;
+
+static void clear_captured(void) {
+    for (guint i = 0; i < G_N_ELEMENTS(captured); i++) {
+        g_clear_pointer(&captured[i].method, g_free);
+        if (captured[i].params) {
+            json_node_unref(captured[i].params);
+            captured[i].params = NULL;
+        }
+        captured[i].callback = NULL;
+        captured[i].user_data = NULL;
+    }
+    captured_count = 0;
+    rpc_return_null = FALSE;
+    change_count = 0;
+}
+
+gchar* gateway_rpc_request(const gchar *method,
+                           JsonNode *params_json,
+                           guint timeout_ms,
+                           GatewayRpcCallback callback,
+                           gpointer user_data) {
+    (void)timeout_ms;
+    if (rpc_return_null) {
+        return NULL;
+    }
+    g_assert_cmpuint(captured_count, <, G_N_ELEMENTS(captured));
+    CapturedRequest *req = &captured[captured_count++];
+    req->method = g_strdup(method);
+    req->params = params_json ? json_node_copy(params_json) : NULL;
+    req->callback = callback;
+    req->user_data = user_data;
+    return g_strdup_printf("req-%u", captured_count);
+}
+
+static void on_wizard_changed(OnboardingWizardModel *model, gpointer user_data) {
+    (void)model;
+    (void)user_data;
+    change_count++;
+}
+
+static const gchar* object_string(JsonObject *obj, const gchar *member) {
+    JsonNode *node = json_object_get_member(obj, member);
+    return node && JSON_NODE_HOLDS_VALUE(node) ? json_node_get_string(node) : NULL;
+}
+
+static JsonNode* wizard_result_node(const gchar *session_id,
+                                    const gchar *step_id,
+                                    gboolean done) {
+    JsonBuilder *builder = json_builder_new();
+    json_builder_begin_object(builder);
+    if (session_id) {
+        json_builder_set_member_name(builder, "sessionId");
+        json_builder_add_string_value(builder, session_id);
+    }
+    json_builder_set_member_name(builder, "done");
+    json_builder_add_boolean_value(builder, done);
+    json_builder_set_member_name(builder, "status");
+    json_builder_add_string_value(builder, done ? "done" : "running");
+    if (step_id) {
+        json_builder_set_member_name(builder, "step");
+        json_builder_begin_object(builder);
+        json_builder_set_member_name(builder, "id");
+        json_builder_add_string_value(builder, step_id);
+        json_builder_set_member_name(builder, "type");
+        json_builder_add_string_value(builder, "text");
+        json_builder_set_member_name(builder, "title");
+        json_builder_add_string_value(builder, "Step");
+        json_builder_end_object(builder);
+    }
+    json_builder_end_object(builder);
+    JsonNode *node = json_builder_get_root(builder);
+    g_object_unref(builder);
+    return node;
+}
+
+static void deliver_success(guint index, JsonNode *payload) {
+    GatewayRpcResponse response = {
+        .ok = TRUE,
+        .payload = payload,
+    };
+    captured[index].callback(&response, captured[index].user_data);
+}
+
+static void test_start_happy_path(void) {
+    clear_captured();
+    OnboardingWizardModel *model = onboarding_wizard_model_new(on_wizard_changed, NULL);
+
+    onboarding_wizard_start(model, "local");
+    g_assert_cmpuint(captured_count, ==, 1);
+    g_assert_cmpstr(captured[0].method, ==, "wizard.start");
+    JsonObject *params = json_node_get_object(captured[0].params);
+    g_assert_cmpstr(object_string(params, "mode"), ==, "local");
+
+    g_autoptr(JsonNode) result = wizard_result_node("session-1", "step-1", FALSE);
+    deliver_success(0, result);
+    g_assert_cmpstr(onboarding_wizard_get_session_id(model), ==, "session-1");
+    JsonObject *step = onboarding_wizard_get_step(model);
+    g_assert_nonnull(step);
+    g_assert_cmpstr(object_string(step, "id"), ==, "step-1");
+    g_assert_cmpint(onboarding_wizard_get_status(model), ==, ONBOARDING_WIZARD_STATUS_RUNNING);
+    g_assert_cmpuint(change_count, ==, 2);
+
+    onboarding_wizard_model_free(model);
+    clear_captured();
+}
+
+static void test_next_happy_path(void) {
+    clear_captured();
+    OnboardingWizardModel *model = onboarding_wizard_model_new(on_wizard_changed, NULL);
+    onboarding_wizard_start(model, "local");
+    g_autoptr(JsonNode) start_result = wizard_result_node("session-1", "step-1", FALSE);
+    deliver_success(0, start_result);
+
+    g_autoptr(JsonNode) value = json_node_new(JSON_NODE_VALUE);
+    json_node_set_string(value, "answer");
+    onboarding_wizard_submit(model, value);
+
+    g_assert_cmpuint(captured_count, ==, 2);
+    g_assert_cmpstr(captured[1].method, ==, "wizard.next");
+    JsonObject *params = json_node_get_object(captured[1].params);
+    g_assert_cmpstr(object_string(params, "sessionId"), ==, "session-1");
+    JsonObject *answer = json_object_get_object_member(params, "answer");
+    g_assert_cmpstr(object_string(answer, "stepId"), ==, "step-1");
+    g_assert_cmpstr(object_string(answer, "value"), ==, "answer");
+
+    onboarding_wizard_model_free(model);
+    clear_captured();
+}
+
+static void test_cancel_happy_path(void) {
+    clear_captured();
+    OnboardingWizardModel *model = onboarding_wizard_model_new(on_wizard_changed, NULL);
+    onboarding_wizard_start(model, "local");
+    g_autoptr(JsonNode) start_result = wizard_result_node("session-1", "step-1", FALSE);
+    deliver_success(0, start_result);
+
+    onboarding_wizard_cancel(model);
+    g_assert_cmpuint(captured_count, ==, 2);
+    g_assert_cmpstr(captured[1].method, ==, "wizard.cancel");
+    JsonObject *params = json_node_get_object(captured[1].params);
+    g_assert_cmpstr(object_string(params, "sessionId"), ==, "session-1");
+
+    onboarding_wizard_model_free(model);
+    clear_captured();
+}
+
+static void test_rpc_not_ready_sets_error(void) {
+    clear_captured();
+    rpc_return_null = TRUE;
+    OnboardingWizardModel *model = onboarding_wizard_model_new(on_wizard_changed, NULL);
+    onboarding_wizard_start(model, "local");
+
+    g_assert_cmpint(onboarding_wizard_get_status(model), ==, ONBOARDING_WIZARD_STATUS_ERROR);
+    g_assert_cmpstr(onboarding_wizard_get_error(model), ==, "Gateway RPC is not ready yet.");
+    g_assert_cmpuint(change_count, ==, 1);
+
+    onboarding_wizard_model_free(model);
+    clear_captured();
+}
+
+static void test_model_free_before_callback(void) {
+    clear_captured();
+    OnboardingWizardModel *model = onboarding_wizard_model_new(on_wizard_changed, NULL);
+    onboarding_wizard_start(model, "local");
+    g_assert_cmpuint(change_count, ==, 1);
+    onboarding_wizard_model_free(model);
+
+    g_autoptr(JsonNode) result = wizard_result_node("late", "late-step", FALSE);
+    deliver_success(0, result);
+    g_assert_cmpuint(change_count, ==, 1);
+    clear_captured();
+}
+
+static void test_stale_generation_ignored(void) {
+    clear_captured();
+    OnboardingWizardModel *model = onboarding_wizard_model_new(on_wizard_changed, NULL);
+    onboarding_wizard_start(model, "local");
+    onboarding_wizard_start(model, "local");
+    g_assert_cmpuint(captured_count, ==, 2);
+    g_assert_cmpuint(change_count, ==, 2);
+
+    g_autoptr(JsonNode) stale = wizard_result_node("session-a", "step-a", FALSE);
+    deliver_success(0, stale);
+    g_assert_null(onboarding_wizard_get_session_id(model));
+    g_assert_cmpuint(change_count, ==, 2);
+
+    g_autoptr(JsonNode) current = wizard_result_node("session-b", "step-b", FALSE);
+    deliver_success(1, current);
+    g_assert_cmpstr(onboarding_wizard_get_session_id(model), ==, "session-b");
+    g_assert_cmpuint(change_count, ==, 3);
+
+    onboarding_wizard_model_free(model);
+    clear_captured();
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func("/onboarding/wizard/start_happy_path", test_start_happy_path);
+    g_test_add_func("/onboarding/wizard/next_happy_path", test_next_happy_path);
+    g_test_add_func("/onboarding/wizard/cancel_happy_path", test_cancel_happy_path);
+    g_test_add_func("/onboarding/wizard/rpc_not_ready", test_rpc_not_ready_sets_error);
+    g_test_add_func("/onboarding/wizard/model_free_before_callback", test_model_free_before_callback);
+    g_test_add_func("/onboarding/wizard/stale_generation_ignored", test_stale_generation_ignored);
+    return g_test_run();
+}
+

--- a/apps/linux/tests/test_readiness.c
+++ b/apps/linux/tests/test_readiness.c
@@ -46,7 +46,7 @@ static void test_presenter_needs_setup(void) {
     g_assert_cmpstr(ri.classification, ==, "Setup Required");
     g_assert_nonnull(ri.missing);
     g_assert_nonnull(ri.next_action);
-    assert_contains(ri.next_action, "openclaw onboard --install-daemon", "needs_setup.next_action");
+    assert_contains(ri.next_action, "openclaw setup", "needs_setup.next_action");
 }
 
 /* ── STATE_NEEDS_GATEWAY_INSTALL ── */
@@ -57,7 +57,7 @@ static void test_presenter_needs_gateway_install(void) {
 
     g_assert_cmpstr(ri.classification, ==, "Gateway Service Missing");
     g_assert_true(g_str_has_prefix(ri.missing, "The expected user systemd service path is not active"));
-    assert_contains(ri.next_action, "onboard --install-daemon", "needs_gateway_install.next_action");
+    assert_contains(ri.next_action, "openclaw gateway install", "needs_gateway_install.next_action");
 }
 
 /* ── STATE_NEEDS_ONBOARDING ── */
@@ -72,7 +72,7 @@ static void test_presenter_needs_onboarding(void) {
     g_assert_cmpstr(ri.classification, ==, "Bootstrap Incomplete");
     g_assert_nonnull(ri.missing);
     g_assert_nonnull(ri.next_action);
-    assert_contains(ri.next_action, "openclaw onboard --install-daemon", "needs_onboarding.next_action");
+    assert_contains(ri.next_action, "setup wizard", "needs_onboarding.next_action");
 }
 
 /* ── STATE_USER_SYSTEMD_UNAVAILABLE ── */


### PR DESCRIPTION
Expand Linux onboarding from a mostly informational flow into a state-aware setup flow for local bootstrap, remote setup, wizard execution, and chat validation.

Add a pure onboarding page-sequence model so visible pages are derived from connection mode, CLI availability, systemd state, and wizard completion state. Local onboarding now cascades through CLI availability, `openclaw setup`, `openclaw gateway install`, gateway start, setup wizard, chat validation, and final guidance.

Add deterministic bootstrap command resolution from either the installed `openclaw` CLI or a development checkout via `node <repo-root>/openclaw.mjs`. Add an async bootstrap runner with event streaming, cancellation, timeout handling, force-exit fallback, and callback suppression.

Add onboarding-specific CLI detection, chat-readiness mapping, and a wizard RPC model for `wizard.start`, `wizard.next`, and `wizard.cancel`. Update readiness guidance to point users at the guided onboarding flow instead of `openclaw onboard --install-daemon`, and add focused headless tests for the new onboarding components.