### PR TITLE
feat(linux): expand tray menu and shared debug actions (#122)

### DIFF
--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -75,6 +75,10 @@ sources = [
   'src/runtime_mode.c',
   'src/readiness.c',
   'src/notify.c',
+  'src/debug_actions.c',
+  'src/app_restart.c',
+  'src/exec_approval_tray_model.c',
+  'src/tray_protocol.c',
   'src/diagnostics.c',
   'src/display_model.c',
   'src/runtime_paths.c',
@@ -136,7 +140,9 @@ endforeach
 # Tray helper (GTK3 + Ayatana AppIndicator)
 # Installed as a private implementation detail into libexec
 helper_sources = [
-  'src/tray_helper.c'
+  'src/tray_helper.c',
+  'src/tray_helper_protocol.c',
+  'src/tray_protocol.c',
 ]
 
 executable('openclaw-tray-helper',
@@ -270,12 +276,54 @@ test('shell_sections_display', test_shell_sections_display_exe)
 
 test_section_debug_exe = executable('test_section_debug',
   ['tests/test_section_debug.c', 'src/section_debug.c', 'src/runtime_reveal.c',
+   'src/debug_actions.c',
    'src/connection_mode_resolver.c', 'src/remote_endpoint.c',
    'src/remote_tunnel.c', 'src/remote_tunnel_command.c',
    'src/remote_port_check.c',
    'src/gateway_remote_config.c', 'src/product_state.c', 'src/log.c'],
   dependencies : [glib_dep, gio_dep, gtk4_dep, adwaita_dep, json_glib_dep])
 test('section_debug', test_section_debug_exe)
+
+# Pure-C regression for the shared debug-action registry. Headless: the
+# registry never imports GTK, and the test stubs out cross-module entry
+# points (gateway_client_refresh, systemd_restart_gateway, etc.) plus
+# the reveal-URI builders so the registry can be exercised end-to-end
+# without standing up runtime_reveal.c's dependency tree.
+test_debug_actions_exe = executable('test_debug_actions',
+  ['tests/test_debug_actions.c', 'src/debug_actions.c'],
+  dependencies : [glib_dep])
+test('debug_actions', test_debug_actions_exe)
+
+# Pure-C regression for the host↔helper line protocol formatter and
+# parser. No GTK; only glib is needed.
+test_tray_protocol_exe = executable('test_tray_protocol',
+  ['tests/test_tray_protocol.c', 'src/tray_protocol.c'],
+  dependencies : [glib_dep])
+test('tray_protocol', test_tray_protocol_exe)
+
+# Pure-C regression for the helper-side parser/applier. Capture
+# callbacks stand in for the GTK widget mutations so the suite stays
+# headless.
+test_tray_helper_protocol_exe = executable('test_tray_helper_protocol',
+  ['tests/test_tray_helper_protocol.c',
+   'src/tray_helper_protocol.c', 'src/tray_protocol.c'],
+  dependencies : [glib_dep])
+test('tray_helper_protocol', test_tray_helper_protocol_exe)
+
+# Hermetic regression for the Restart App argv builder. The actual
+# spawn path is intentionally NOT exercised — see test source for the
+# rationale.
+test_app_restart_exe = executable('test_app_restart',
+  ['tests/test_app_restart.c', 'src/app_restart.c'],
+  dependencies : [glib_dep, gio_dep])
+test('app_restart', test_app_restart_exe)
+
+# Pure-C regression for the OcExecQuickMode <-> wire token mapping.
+test_exec_approval_tray_model_exe = executable('test_exec_approval_tray_model',
+  ['tests/test_exec_approval_tray_model.c',
+   'src/exec_approval_tray_model.c'],
+  dependencies : [glib_dep])
+test('exec_approval_tray_model', test_exec_approval_tray_model_exe)
 
 # Real-controller contract audit (Tranche E.3). Links the production
 # section_*.c translation units through app_core_sources so every

--- a/apps/linux/src/app_restart.c
+++ b/apps/linux/src/app_restart.c
@@ -1,0 +1,75 @@
+/*
+ * app_restart.c
+ *
+ * Implementation of the Restart App helper. See app_restart.h.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "app_restart.h"
+
+#include <gio/gio.h>
+#include <glib.h>
+
+/*
+ * The relaunch shell snippet. Using `exec "$1"` keeps argv[0] set to
+ * the original self_exe path (better for any internal lookups that
+ * read /proc/self/exe). A short sleep gives the current GApplication
+ * time to release its session-bus name before the relaunch.
+ */
+#define APP_RESTART_SHELL_SNIPPET "sleep 0.2; exec \"$1\""
+
+gchar** app_restart_build_argv_for_test(const gchar *self_exe) {
+    if (!self_exe || self_exe[0] == '\0') return NULL;
+
+    /* argv layout (NULL-terminated, suitable for g_spawn_async +
+     * G_SPAWN_SEARCH_PATH):
+     *
+     *   [0] /bin/sh
+     *   [1] -c
+     *   [2] sleep 0.2; exec "$1"
+     *   [3] sh                           ← shell argv[0] / "$0"
+     *   [4] <self_exe>                   ← becomes "$1"
+     *   [5] NULL
+     */
+    gchar **argv = g_new0(gchar *, 6);
+    argv[0] = g_strdup("/bin/sh");
+    argv[1] = g_strdup("-c");
+    argv[2] = g_strdup(APP_RESTART_SHELL_SNIPPET);
+    argv[3] = g_strdup("sh");
+    argv[4] = g_strdup(self_exe);
+    argv[5] = NULL;
+    return argv;
+}
+
+gboolean app_restart_request(void) {
+    g_autofree gchar *self_exe = g_file_read_link("/proc/self/exe", NULL);
+    if (!self_exe || self_exe[0] == '\0') {
+        g_warning("app_restart_request: failed to resolve /proc/self/exe");
+        return FALSE;
+    }
+
+    g_auto(GStrv) argv = app_restart_build_argv_for_test(self_exe);
+    if (!argv) return FALSE;
+
+    g_autoptr(GError) error = NULL;
+    gboolean ok = g_spawn_async(NULL,                         /* working dir */
+                                argv,
+                                NULL,                         /* envp */
+                                G_SPAWN_SEARCH_PATH,
+                                NULL,                         /* child setup */
+                                NULL,
+                                NULL,                         /* child pid */
+                                &error);
+    if (!ok) {
+        g_warning("app_restart_request: g_spawn_async failed: %s",
+                  error ? error->message : "(unknown)");
+        return FALSE;
+    }
+
+    GApplication *app = g_application_get_default();
+    if (app && g_application_get_is_registered(app)) {
+        g_application_quit(app);
+    }
+    return TRUE;
+}

--- a/apps/linux/src/app_restart.h
+++ b/apps/linux/src/app_restart.h
@@ -1,0 +1,43 @@
+/*
+ * app_restart.h
+ *
+ * Implements the `Restart App` debug action: spawn a tiny detached
+ * shell that waits 200 ms (so the current process can exit cleanly)
+ * and then re-execs the companion at the same `/proc/self/exe` path,
+ * then quits the current GApplication.
+ *
+ * The wait avoids racing the systemd / DBus session for the singleton
+ * lock when a primary GApplication instance is in the middle of
+ * shutting down.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_APP_RESTART_H
+#define OPENCLAW_LINUX_APP_RESTART_H
+
+#include <glib.h>
+
+/*
+ * Build the argv vector that `app_restart_request()` would pass to
+ * `g_spawn_async`. Exposed as a separate function so the (deterministic,
+ * hermetic) argv-builder logic can be unit tested without a fork or
+ * spawn. Returns NULL when `self_exe` is NULL or empty. The returned
+ * vector is suitable for `g_strfreev`.
+ */
+gchar** app_restart_build_argv_for_test(const gchar *self_exe);
+
+/*
+ * Resolve the current process's executable path, spawn the detached
+ * relaunch shell, and request the running GApplication to quit (when
+ * one is registered). Non-blocking — does not wait for the relaunched
+ * child.
+ *
+ * Returns TRUE only when the spawn succeeded. Returns FALSE if the
+ * self path could not be resolved or the spawn failed; in that case
+ * the GApplication is NOT asked to quit, so the user is not stranded
+ * with a closed app.
+ */
+gboolean app_restart_request(void);
+
+#endif /* OPENCLAW_LINUX_APP_RESTART_H */

--- a/apps/linux/src/debug_actions.c
+++ b/apps/linux/src/debug_actions.c
@@ -1,0 +1,314 @@
+/*
+ * debug_actions.c
+ *
+ * Implementation of the shared debug-action registry. Side effects that
+ * intrinsically need GTK (clipboard writes, URI launches that must go
+ * through GAppInfo) are routed through hook seams installed at startup.
+ *
+ * Cross-module dependencies are imported via forward declarations so
+ * the registry's translation unit does not transitively pull GTK in;
+ * tests can link this file alongside their own stubs and remain
+ * headless.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "debug_actions.h"
+
+#include <glib.h>
+#include <string.h>
+
+#include "app_restart.h"
+#include "notify.h"
+#include "runtime_reveal.h"
+
+/* ── Forward declarations of cross-module entry points ──────────────
+ *
+ * Defined in:
+ *   gateway_client.c          → gateway_client_refresh
+ *   systemd.c                 → systemd_restart_gateway
+ *   state.c                   → systemd_get_canonical_unit_name
+ *   product_coordinator.c     → product_coordinator_request_rerun_onboarding
+ *   debug_actions_show_section() — thin wrapper installed by the host
+ *     application (see oc_debug_actions_set_show_section); tests can
+ *     install their own capture wrapper. We deliberately avoid
+ *     including app_window.h here so the registry stays GTK-free.
+ */
+extern void gateway_client_refresh(void);
+extern void systemd_restart_gateway(void);
+extern const gchar* systemd_get_canonical_unit_name(void);
+extern void product_coordinator_request_rerun_onboarding(void);
+
+/* ── Registry table ─────────────────────────────────────────────── */
+
+static const OcDebugActionSpec g_debug_actions[] = {
+    [OC_DEBUG_ACTION_TRIGGER_HEALTH_REFRESH] = {
+        .id                 = OC_DEBUG_ACTION_TRIGGER_HEALTH_REFRESH,
+        .tray_action_string = "TRIGGER_HEALTH_REFRESH",
+        .tray_menu_label    = NULL,                       /* not surfaced in tray (REFRESH covers it) */
+        .debug_page_label   = "Trigger Health Refresh",
+    },
+    [OC_DEBUG_ACTION_RESTART_GATEWAY] = {
+        .id                 = OC_DEBUG_ACTION_RESTART_GATEWAY,
+        .tray_action_string = NULL,                       /* tray's RESTART legacy action covers it */
+        .tray_menu_label    = NULL,
+        .debug_page_label   = "Restart Gateway",
+    },
+    [OC_DEBUG_ACTION_RESTART_ONBOARDING] = {
+        .id                 = OC_DEBUG_ACTION_RESTART_ONBOARDING,
+        .tray_action_string = "RESTART_ONBOARDING",
+        .tray_menu_label    = "Restart Onboarding",
+        .debug_page_label   = "Restart Onboarding",
+    },
+    [OC_DEBUG_ACTION_REVEAL_CONFIG_FOLDER] = {
+        .id                 = OC_DEBUG_ACTION_REVEAL_CONFIG_FOLDER,
+        .tray_action_string = "REVEAL_CONFIG_FOLDER",
+        .tray_menu_label    = "Reveal Config Folder",
+        .debug_page_label   = "Reveal Config Folder",
+    },
+    [OC_DEBUG_ACTION_REVEAL_STATE_FOLDER] = {
+        .id                 = OC_DEBUG_ACTION_REVEAL_STATE_FOLDER,
+        .tray_action_string = "REVEAL_STATE_FOLDER",
+        .tray_menu_label    = "Reveal State Folder",
+        .debug_page_label   = "Reveal State Folder",
+    },
+    [OC_DEBUG_ACTION_COPY_JOURNAL_COMMAND] = {
+        .id                 = OC_DEBUG_ACTION_COPY_JOURNAL_COMMAND,
+        .tray_action_string = "COPY_JOURNAL_COMMAND",
+        .tray_menu_label    = "Copy Journal Command",
+        .debug_page_label   = "Copy Journal Command",
+    },
+    [OC_DEBUG_ACTION_SEND_TEST_NOTIFICATION] = {
+        .id                 = OC_DEBUG_ACTION_SEND_TEST_NOTIFICATION,
+        .tray_action_string = "SEND_TEST_NOTIFICATION",
+        .tray_menu_label    = "Send Test Notification",
+        .debug_page_label   = "Send Test Notification",
+    },
+    [OC_DEBUG_ACTION_OPEN_LOGS] = {
+        .id                 = OC_DEBUG_ACTION_OPEN_LOGS,
+        .tray_action_string = "OPEN_LOGS",
+        .tray_menu_label    = "Open Logs",
+        .debug_page_label   = NULL,                       /* navigates away from Debug */
+    },
+    [OC_DEBUG_ACTION_OPEN_DEBUG] = {
+        .id                 = OC_DEBUG_ACTION_OPEN_DEBUG,
+        .tray_action_string = "OPEN_DEBUG",
+        .tray_menu_label    = "Open Debug",
+        .debug_page_label   = NULL,                       /* you are already here */
+    },
+    [OC_DEBUG_ACTION_RESET_REMOTE_TUNNEL] = {
+        .id                 = OC_DEBUG_ACTION_RESET_REMOTE_TUNNEL,
+        .tray_action_string = "RESET_REMOTE_TUNNEL",
+        .tray_menu_label    = "Reset Remote Tunnel",
+        .debug_page_label   = NULL,                       /* tray-only until a reset API lands */
+    },
+    [OC_DEBUG_ACTION_RESTART_APP] = {
+        .id                 = OC_DEBUG_ACTION_RESTART_APP,
+        .tray_action_string = "RESTART_APP",
+        .tray_menu_label    = "Restart App",
+        .debug_page_label   = "Restart App",
+    },
+};
+
+G_STATIC_ASSERT(G_N_ELEMENTS(g_debug_actions) == OC_DEBUG_ACTION_COUNT);
+
+/* ── Hook seams ────────────────────────────────────────────────── */
+
+typedef struct {
+    OcDebugUriLauncherFn     uri_launcher;
+    gpointer                 uri_launcher_data;
+    OcDebugClipboardWriterFn clipboard_writer;
+    gpointer                 clipboard_writer_data;
+} OcDebugHooks;
+
+static OcDebugHooks g_hooks = {0};
+
+void oc_debug_actions_set_uri_launcher(OcDebugUriLauncherFn fn, gpointer user_data) {
+    g_hooks.uri_launcher = fn;
+    g_hooks.uri_launcher_data = user_data;
+}
+
+void oc_debug_actions_set_clipboard_writer(OcDebugClipboardWriterFn fn, gpointer user_data) {
+    g_hooks.clipboard_writer = fn;
+    g_hooks.clipboard_writer_data = user_data;
+}
+
+/* ── Show-section hook (Open Logs / Open Debug) ───────────────────
+ *
+ * The registry must not import app_window.h (it would pull GTK in),
+ * so the host installs a thin show-section adapter here. Default is
+ * a no-op so headless tests do not crash if a dispatch fires before
+ * the host hook has been installed.
+ */
+static OcDebugShowSectionFn g_show_section_fn = NULL;
+static gpointer             g_show_section_data = NULL;
+
+void oc_debug_actions_set_show_section_handler(OcDebugShowSectionFn fn, gpointer user_data) {
+    g_show_section_fn = fn;
+    g_show_section_data = user_data;
+}
+
+/* ── Test capture state ─────────────────────────────────────────── */
+
+static gchar               *g_test_last_uri = NULL;
+static gchar               *g_test_last_clipboard = NULL;
+static gboolean             g_test_section_requested = FALSE;
+static OcDebugSectionTarget g_test_last_section_target = OC_DEBUG_SECTION_TARGET_LOGS;
+
+static void capture_uri(const char *uri) {
+    g_free(g_test_last_uri);
+    g_test_last_uri = uri ? g_strdup(uri) : NULL;
+}
+
+static void capture_clipboard(const char *text) {
+    g_free(g_test_last_clipboard);
+    g_test_last_clipboard = text ? g_strdup(text) : NULL;
+}
+
+const char* oc_debug_actions_test_last_uri(void) {
+    return g_test_last_uri;
+}
+
+const char* oc_debug_actions_test_last_clipboard_text(void) {
+    return g_test_last_clipboard;
+}
+
+OcDebugSectionTarget oc_debug_actions_test_last_section_target(void) {
+    return g_test_last_section_target;
+}
+
+gboolean oc_debug_actions_test_section_was_requested(void) {
+    return g_test_section_requested;
+}
+
+void oc_debug_actions_test_reset(void) {
+    g_clear_pointer(&g_test_last_uri, g_free);
+    g_clear_pointer(&g_test_last_clipboard, g_free);
+    g_test_section_requested = FALSE;
+    g_test_last_section_target = OC_DEBUG_SECTION_TARGET_LOGS;
+    g_hooks.uri_launcher = NULL;
+    g_hooks.uri_launcher_data = NULL;
+    g_hooks.clipboard_writer = NULL;
+    g_hooks.clipboard_writer_data = NULL;
+    g_show_section_fn = NULL;
+    g_show_section_data = NULL;
+}
+
+static void show_section(OcDebugSectionTarget target) {
+    g_test_section_requested = TRUE;
+    g_test_last_section_target = target;
+    if (g_show_section_fn) {
+        g_show_section_fn(target, g_show_section_data);
+    }
+}
+
+/* ── Internal helpers ─────────────────────────────────────────── */
+
+static void launch_uri(const char *uri) {
+    if (!uri || !uri[0]) return;
+    capture_uri(uri);
+    if (g_hooks.uri_launcher) {
+        g_hooks.uri_launcher(uri, g_hooks.uri_launcher_data);
+    }
+}
+
+static void write_clipboard(const char *text) {
+    if (!text) return;
+    capture_clipboard(text);
+    if (g_hooks.clipboard_writer) {
+        g_hooks.clipboard_writer(text, g_hooks.clipboard_writer_data);
+    }
+}
+
+/* ── Public API ──────────────────────────────────────────────── */
+
+const OcDebugActionSpec* oc_debug_action_get(OcDebugAction id) {
+    if ((guint)id >= (guint)OC_DEBUG_ACTION_COUNT) return NULL;
+    return &g_debug_actions[id];
+}
+
+guint oc_debug_action_count(void) {
+    return (guint)OC_DEBUG_ACTION_COUNT;
+}
+
+gboolean oc_debug_action_from_tray_string(const char *s, OcDebugAction *out) {
+    if (!s) return FALSE;
+    for (guint i = 0; i < (guint)OC_DEBUG_ACTION_COUNT; i++) {
+        const char *ts = g_debug_actions[i].tray_action_string;
+        if (ts && strcmp(ts, s) == 0) {
+            if (out) *out = (OcDebugAction)i;
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+gboolean oc_debug_action_dispatch(OcDebugAction id) {
+    if ((guint)id >= (guint)OC_DEBUG_ACTION_COUNT) return FALSE;
+
+    switch (id) {
+    case OC_DEBUG_ACTION_TRIGGER_HEALTH_REFRESH:
+        gateway_client_refresh();
+        return TRUE;
+
+    case OC_DEBUG_ACTION_RESTART_GATEWAY:
+        systemd_restart_gateway();
+        return TRUE;
+
+    case OC_DEBUG_ACTION_RESTART_ONBOARDING:
+        product_coordinator_request_rerun_onboarding();
+        return TRUE;
+
+    case OC_DEBUG_ACTION_REVEAL_CONFIG_FOLDER: {
+        g_autofree gchar *uri = runtime_reveal_build_config_dir_uri();
+        launch_uri(uri);
+        return TRUE;
+    }
+
+    case OC_DEBUG_ACTION_REVEAL_STATE_FOLDER: {
+        g_autofree gchar *uri = runtime_reveal_build_state_dir_uri();
+        launch_uri(uri);
+        return TRUE;
+    }
+
+    case OC_DEBUG_ACTION_COPY_JOURNAL_COMMAND: {
+        const gchar *unit = systemd_get_canonical_unit_name();
+        g_autofree gchar *cmd = g_strdup_printf("journalctl --user -u %s -f",
+                                                unit ? unit : "openclaw-gateway.service");
+        write_clipboard(cmd);
+        return TRUE;
+    }
+
+    case OC_DEBUG_ACTION_SEND_TEST_NOTIFICATION:
+        (void)notify_send_test_notification();
+        return TRUE;
+
+    case OC_DEBUG_ACTION_OPEN_LOGS:
+        show_section(OC_DEBUG_SECTION_TARGET_LOGS);
+        return TRUE;
+
+    case OC_DEBUG_ACTION_OPEN_DEBUG:
+        show_section(OC_DEBUG_SECTION_TARGET_DEBUG);
+        return TRUE;
+
+    case OC_DEBUG_ACTION_RESET_REMOTE_TUNNEL:
+        /*
+         * TODO: wire to a real reset API once one exists. The closest
+         * existing primitives are `remote_tunnel_stop()` plus a
+         * coordinator-driven re-apply, but synthesising that here would
+         * duplicate the connection-mode coordinator's apply path. The
+         * tray surfaces this action only when MENU_VISIBLE is set to 1,
+         * and the host emits MENU_VISIBLE:RESET_REMOTE_TUNNEL:0 until
+         * a public reset entrypoint lands — so reaching this dispatch
+         * indicates a stale helper or test harness.
+         */
+        return FALSE;
+
+    case OC_DEBUG_ACTION_RESTART_APP:
+        return app_restart_request();
+
+    case OC_DEBUG_ACTION_COUNT:
+    default:
+        return FALSE;
+    }
+}

--- a/apps/linux/src/debug_actions.h
+++ b/apps/linux/src/debug_actions.h
@@ -1,0 +1,139 @@
+/*
+ * debug_actions.h
+ *
+ * Shared debug-action registry for the OpenClaw Linux Companion App.
+ *
+ * Single source of truth for the set of operational/debug affordances
+ * surfaced by the tray helper menu and the in-app Debug section
+ * (`section_debug.c`). Prior to this registry, the tray dispatched via
+ * an ad-hoc if/else ladder while `section_debug.c` declared its own
+ * `DebugActionSpec` tables — and any new action exposed in both
+ * surfaces had to be wired twice with no compile-time guarantee they
+ * stayed in sync.
+ *
+ * Each registered `OcDebugAction` carries:
+ *
+ *   - a `tray_action_string` used by the tray helper protocol
+ *     (the `ACTION:<NAME>` line emitted on stdout); NULL when the
+ *     action is intentionally not surfaced in the tray.
+ *   - a `tray_menu_label` used by the helper to label the menu item;
+ *     NULL when the action is not in the tray.
+ *   - a `debug_page_label` used by the Debug section to label the
+ *     button; NULL when the action is intentionally not surfaced in
+ *     the Debug section.
+ *
+ * The dispatcher is pure C / GLib + GIO: it never imports GTK. Side
+ * effects that genuinely need GTK or GDK (clipboard writes, URI
+ * launches that should funnel through the desktop default handler)
+ * are routed through hook seams installed once at startup. Tests can
+ * install capture hooks instead and assert what was requested without
+ * a display.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_DEBUG_ACTIONS_H
+#define OPENCLAW_LINUX_DEBUG_ACTIONS_H
+
+#include <glib.h>
+
+typedef enum {
+    OC_DEBUG_ACTION_TRIGGER_HEALTH_REFRESH = 0,
+    OC_DEBUG_ACTION_RESTART_GATEWAY,
+    OC_DEBUG_ACTION_RESTART_ONBOARDING,
+    OC_DEBUG_ACTION_REVEAL_CONFIG_FOLDER,
+    OC_DEBUG_ACTION_REVEAL_STATE_FOLDER,
+    OC_DEBUG_ACTION_COPY_JOURNAL_COMMAND,
+    OC_DEBUG_ACTION_SEND_TEST_NOTIFICATION,
+    OC_DEBUG_ACTION_OPEN_LOGS,
+    OC_DEBUG_ACTION_OPEN_DEBUG,
+    OC_DEBUG_ACTION_RESET_REMOTE_TUNNEL,
+    OC_DEBUG_ACTION_RESTART_APP,
+    OC_DEBUG_ACTION_COUNT,
+} OcDebugAction;
+
+typedef struct {
+    OcDebugAction id;
+    const char   *tray_action_string;
+    const char   *tray_menu_label;
+    const char   *debug_page_label;
+} OcDebugActionSpec;
+
+/* Returns the spec for `id`, or NULL when `id` is out of range. */
+const OcDebugActionSpec* oc_debug_action_get(OcDebugAction id);
+
+/* Number of entries in the registry (excludes the COUNT sentinel). */
+guint oc_debug_action_count(void);
+
+/*
+ * Look up an action by its tray action string (case-sensitive). Returns
+ * TRUE when matched and writes the id into `*out`; returns FALSE for
+ * unknown / NULL input. Safe to pass NULL for `out` (then it is purely
+ * a "do we recognize this string" probe).
+ */
+gboolean oc_debug_action_from_tray_string(const char *s, OcDebugAction *out);
+
+/*
+ * Dispatch the registered side effect for `id`. Returns TRUE when the
+ * action was recognized and executed (even if the underlying side
+ * effect was a no-op, e.g. a reveal action whose URI could not be
+ * resolved), and FALSE for unknown ids.
+ */
+gboolean oc_debug_action_dispatch(OcDebugAction id);
+
+/* ── Production hook seams ─────────────────────────────────────────
+ *
+ * The registry is pure C and intentionally does not pull GTK/GDK in.
+ * Surfaces that need GTK to materialize (clipboard, URI launch) are
+ * routed through these hooks. Production installs real hooks once at
+ * startup; tests install capture hooks (or rely on the default no-op
+ * behavior).
+ */
+
+typedef void (*OcDebugUriLauncherFn)(const char *uri, gpointer user_data);
+typedef void (*OcDebugClipboardWriterFn)(const char *text, gpointer user_data);
+
+void oc_debug_actions_set_uri_launcher(OcDebugUriLauncherFn fn, gpointer user_data);
+void oc_debug_actions_set_clipboard_writer(OcDebugClipboardWriterFn fn, gpointer user_data);
+
+/*
+ * The Open Logs / Open Debug actions navigate the main app window to
+ * a specific section. The registry must not import app_window.h (it
+ * would pull GTK in transitively), so the host installs a small
+ * adapter via this hook. Tests can install a capture hook instead.
+ */
+typedef enum {
+    OC_DEBUG_SECTION_TARGET_LOGS = 0,
+    OC_DEBUG_SECTION_TARGET_DEBUG = 1,
+} OcDebugSectionTarget;
+
+typedef void (*OcDebugShowSectionFn)(OcDebugSectionTarget target, gpointer user_data);
+
+void oc_debug_actions_set_show_section_handler(OcDebugShowSectionFn fn, gpointer user_data);
+
+OcDebugSectionTarget oc_debug_actions_test_last_section_target(void);
+gboolean             oc_debug_actions_test_section_was_requested(void);
+
+/* ── Test seams ──────────────────────────────────────────────────── */
+
+/*
+ * Returns the most-recent URI that was requested via the URI hook (or
+ * NULL if none). Pointer remains valid until the next dispatch or
+ * `oc_debug_actions_test_reset()`.
+ */
+const char* oc_debug_actions_test_last_uri(void);
+
+/*
+ * Returns the most-recent clipboard text that was requested via the
+ * clipboard hook. Same lifetime contract as `..._test_last_uri()`.
+ */
+const char* oc_debug_actions_test_last_clipboard_text(void);
+
+/*
+ * Clears captured test state and uninstalls currently registered hooks.
+ * Intended for unit tests only; production code must not call this after
+ * installing runtime hooks.
+ */
+void oc_debug_actions_test_reset(void);
+
+#endif /* OPENCLAW_LINUX_DEBUG_ACTIONS_H */

--- a/apps/linux/src/exec_approval_tray_model.c
+++ b/apps/linux/src/exec_approval_tray_model.c
@@ -1,0 +1,32 @@
+/*
+ * exec_approval_tray_model.c
+ *
+ * Implementation of the OcExecQuickMode <-> wire token mapping used by
+ * the tray protocol surface. See exec_approval_tray_model.h.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "exec_approval_tray_model.h"
+
+const char* exec_approval_tray_mode_to_string(OcExecQuickMode mode) {
+    switch (mode) {
+    case OC_EXEC_QUICK_MODE_DENY:  return "deny";
+    case OC_EXEC_QUICK_MODE_ASK:   return "ask";
+    case OC_EXEC_QUICK_MODE_ALLOW: return "allow";
+    default:                       return NULL;
+    }
+}
+
+gboolean exec_approval_tray_mode_from_string(const char *s, OcExecQuickMode *out) {
+    if (!s) return FALSE;
+
+    OcExecQuickMode mode;
+    if      (g_strcmp0(s, "deny")  == 0) mode = OC_EXEC_QUICK_MODE_DENY;
+    else if (g_strcmp0(s, "ask")   == 0) mode = OC_EXEC_QUICK_MODE_ASK;
+    else if (g_strcmp0(s, "allow") == 0) mode = OC_EXEC_QUICK_MODE_ALLOW;
+    else return FALSE;
+
+    if (out) *out = mode;
+    return TRUE;
+}

--- a/apps/linux/src/exec_approval_tray_model.h
+++ b/apps/linux/src/exec_approval_tray_model.h
@@ -1,0 +1,39 @@
+/*
+ * exec_approval_tray_model.h
+ *
+ * Tray-side mapping helpers between the persistent OpenClaw exec
+ * approval quick-mode enum (`OcExecQuickMode`) and the canonical wire
+ * tokens used in the tray helper protocol ("deny" / "ask" / "allow").
+ *
+ * This module is deliberately tiny and pure-C so the host (`tray.c`),
+ * the registry (`debug_actions.c`), and unit tests can all share the
+ * same string<->enum decision without re-deriving it. Centralising the
+ * mapping here means a future addition to `OcExecQuickMode` only needs
+ * one edit instead of touching every consumer.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_EXEC_APPROVAL_TRAY_MODEL_H
+#define OPENCLAW_LINUX_EXEC_APPROVAL_TRAY_MODEL_H
+
+#include <glib.h>
+
+#include "exec_approval_store.h"
+
+/*
+ * Convert an `OcExecQuickMode` into the canonical lower-case wire
+ * token. Returns NULL for values outside the known enum range. The
+ * returned pointer is to a static literal — do not free.
+ */
+const char* exec_approval_tray_mode_to_string(OcExecQuickMode mode);
+
+/*
+ * Parse a canonical wire token ("deny" / "ask" / "allow") into an
+ * `OcExecQuickMode`. Returns TRUE on match and writes the enum into
+ * `*out` (when non-NULL); returns FALSE for unknown / NULL input and
+ * leaves `*out` untouched.
+ */
+gboolean exec_approval_tray_mode_from_string(const char *s, OcExecQuickMode *out);
+
+#endif /* OPENCLAW_LINUX_EXEC_APPROVAL_TRAY_MODEL_H */

--- a/apps/linux/src/notify.c
+++ b/apps/linux/src/notify.c
@@ -14,11 +14,34 @@
 #include <gio/gio.h>
 #include <glib.h>
 #include <gtk/gtk.h>
+#include "notify.h"
 #include "state.h"
 #include "log.h"
 
 void notify_init(void) {
     // Basic init, application holds notification scope
+}
+
+gboolean notify_send_test_notification(void) {
+    GApplication *app = g_application_get_default();
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_NOTIFY,
+                 "notify_send_test_notification entry app=%p registered=%d",
+                 (void *)app,
+                 app ? g_application_get_is_registered(app) : 0);
+
+    if (!app || !g_application_get_is_registered(app)) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_NOTIFY,
+                     "notify_send_test_notification skip (not registered)");
+        return FALSE;
+    }
+
+    g_autoptr(GNotification) notification = g_notification_new("OpenClaw");
+    g_notification_set_body(notification,
+                            "This is a test notification from the "
+                            "OpenClaw Linux companion.");
+    g_application_send_notification(app, "openclaw-test", notification);
+    return TRUE;
 }
 
 void notify_on_transition(AppState old_state, AppState new_state) {

--- a/apps/linux/src/notify.h
+++ b/apps/linux/src/notify.h
@@ -1,0 +1,35 @@
+/*
+ * notify.h
+ *
+ * Public surface for the desktop notification manager.
+ *
+ * The companion fans out notifications through GApplication so the
+ * helper TU never needs to link libnotify directly. All entry points
+ * are safe to call before the app is registered with the session bus —
+ * they no-op rather than crashing.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_NOTIFY_H
+#define OPENCLAW_LINUX_NOTIFY_H
+
+#include <glib.h>
+
+#include "state.h"
+
+void notify_init(void);
+
+/* Lifecycle/health-driven notifications dispatched from state.c. */
+void notify_on_transition(AppState old_state, AppState new_state);
+void notify_on_gateway_connection_transition(gboolean connected);
+
+/*
+ * Dispatch a manual "test" notification. Used by the Debug section
+ * button and the tray "Send Test Notification" entry. Returns TRUE if
+ * the notification was posted, FALSE if the GApplication has not yet
+ * registered (caller is in pre-startup) — both outcomes are safe.
+ */
+gboolean notify_send_test_notification(void);
+
+#endif /* OPENCLAW_LINUX_NOTIFY_H */

--- a/apps/linux/src/section_debug.c
+++ b/apps/linux/src/section_debug.c
@@ -13,6 +13,7 @@
 
 #include <adwaita.h>
 
+#include "debug_actions.h"
 #include "gateway_client.h"
 #include "product_coordinator.h"
 #include "runtime_reveal.h"
@@ -22,8 +23,6 @@
 #include "remote_endpoint.h"
 #include "remote_tunnel.h"
 #include "product_state.h"
-
-extern void systemd_restart_gateway(void);
 
 static void debug_refresh_remote_mode(void);
 static void on_remote_state_changed(gpointer user_data);
@@ -42,97 +41,75 @@ static GtkWidget *dbg_remote_tunnel_detail_label = NULL;
 static guint      dbg_endpoint_sub = 0;
 static guint      dbg_tunnel_sub   = 0;
 
-typedef struct {
-    const gchar *label;
-    GCallback callback;
-} DebugActionSpec;
+/*
+ * Per-row layout for Debug-section action buttons. Each row is a flat
+ * list of registry ids; the registry owns the label and the dispatch.
+ */
+static const OcDebugAction debug_row1_actions[] = {
+    OC_DEBUG_ACTION_TRIGGER_HEALTH_REFRESH,
+    OC_DEBUG_ACTION_RESTART_GATEWAY,
+};
 
-static void on_dbg_refresh_health(GtkButton *button, gpointer user_data) {
-    (void)button;
-    (void)user_data;
-    gateway_client_refresh();
-}
+static const OcDebugAction debug_row2_actions[] = {
+    OC_DEBUG_ACTION_REVEAL_CONFIG_FOLDER,
+    OC_DEBUG_ACTION_REVEAL_STATE_FOLDER,
+};
 
-static void on_dbg_restart_gw(GtkButton *button, gpointer user_data) {
-    (void)button;
-    (void)user_data;
-    systemd_restart_gateway();
-}
-
-static void on_dbg_rerun_onboarding(GtkButton *button, gpointer user_data) {
-    (void)button;
-    (void)user_data;
-    product_coordinator_request_rerun_onboarding();
-}
-
-static void on_dbg_reveal_config(GtkButton *button, gpointer user_data) {
-    (void)button;
-    (void)user_data;
-
-    g_autofree gchar *uri = section_debug_test_build_reveal_config_uri();
-    if (uri) {
-        g_app_info_launch_default_for_uri(uri, NULL, NULL);
-    }
-}
+static const OcDebugAction debug_standalone_actions[] = {
+    OC_DEBUG_ACTION_RESTART_ONBOARDING,
+    OC_DEBUG_ACTION_COPY_JOURNAL_COMMAND,
+    OC_DEBUG_ACTION_SEND_TEST_NOTIFICATION,
+    OC_DEBUG_ACTION_RESTART_APP,
+};
 
 gchar* section_debug_test_build_reveal_config_uri(void) {
     return runtime_reveal_build_config_dir_uri();
 }
 
-static void on_dbg_copy_journal_cmd(GtkButton *button, gpointer user_data) {
+static void on_dbg_action_clicked(GtkButton *button, gpointer user_data) {
     (void)button;
-    (void)user_data;
-
-    const gchar *unit = systemd_get_canonical_unit_name();
-    g_autofree gchar *cmd = g_strdup_printf("journalctl --user -u %s -f",
-                                            unit ? unit : "openclaw-gateway.service");
-    GdkClipboard *clipboard = gdk_display_get_clipboard(gdk_display_get_default());
-    gdk_clipboard_set_text(clipboard, cmd);
+    OcDebugAction id = (OcDebugAction)GPOINTER_TO_INT(user_data);
+    (void)oc_debug_action_dispatch(id);
 }
 
-static const DebugActionSpec debug_row1_actions[] = {
-    { "Trigger Health Refresh", G_CALLBACK(on_dbg_refresh_health) },
-    { "Restart Gateway", G_CALLBACK(on_dbg_restart_gw) },
-};
+static GtkWidget* debug_build_action_button_for(OcDebugAction id) {
+    const OcDebugActionSpec *spec = oc_debug_action_get(id);
+    const gchar *label = (spec && spec->debug_page_label) ? spec->debug_page_label : "(action)";
+    GtkWidget *button = gtk_button_new_with_label(label);
+    g_signal_connect(button, "clicked", G_CALLBACK(on_dbg_action_clicked),
+                     GINT_TO_POINTER((gint)id));
+    return button;
+}
 
-static const DebugActionSpec debug_row2_actions[] = {
-    { "Reveal Config Folder", G_CALLBACK(on_dbg_reveal_config) },
-};
-
-static const DebugActionSpec debug_standalone_actions[] = {
-    { "Restart Onboarding", G_CALLBACK(on_dbg_rerun_onboarding) },
-};
-
-static GtkWidget* debug_build_action_row(const DebugActionSpec *actions, gsize action_count) {
+static GtkWidget* debug_build_action_row(const OcDebugAction *actions, gsize action_count) {
     GtkWidget *row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
     gtk_widget_set_margin_top(row, 4);
 
     for (gsize i = 0; i < action_count; i++) {
-        GtkWidget *button = gtk_button_new_with_label(actions[i].label);
-        g_signal_connect(button, "clicked", actions[i].callback, NULL);
+        GtkWidget *button = debug_build_action_button_for(actions[i]);
         gtk_box_append(GTK_BOX(row), button);
     }
 
     return row;
 }
 
-static GtkWidget* debug_build_action_button(const DebugActionSpec *action) {
-    GtkWidget *button = gtk_button_new_with_label(action->label);
+static GtkWidget* debug_build_standalone_action_button(OcDebugAction id) {
+    GtkWidget *button = debug_build_action_button_for(id);
     gtk_widget_set_halign(button, GTK_ALIGN_START);
     gtk_widget_set_margin_top(button, 4);
-    g_signal_connect(button, "clicked", action->callback, NULL);
     return button;
 }
 
-static gboolean debug_action_specs_contain(const DebugActionSpec *actions,
-                                            gsize action_count,
-                                            const gchar *label) {
+static gboolean debug_actions_array_contains_label(const OcDebugAction *actions,
+                                                    gsize action_count,
+                                                    const gchar *label) {
     for (gsize i = 0; i < action_count; i++) {
-        if (g_strcmp0(actions[i].label, label) == 0) {
+        const OcDebugActionSpec *spec = oc_debug_action_get(actions[i]);
+        if (spec && spec->debug_page_label &&
+            g_strcmp0(spec->debug_page_label, label) == 0) {
             return TRUE;
         }
     }
-
     return FALSE;
 }
 
@@ -198,12 +175,6 @@ static GtkWidget* debug_build(void) {
     gtk_label_set_wrap(GTK_LABEL(dbg_journal_label), TRUE);
     gtk_box_append(GTK_BOX(page), dbg_journal_label);
 
-    GtkWidget *copy_journal_btn = gtk_button_new_with_label("Copy Journal Command");
-    gtk_widget_set_halign(copy_journal_btn, GTK_ALIGN_START);
-    gtk_widget_set_margin_top(copy_journal_btn, 4);
-    g_signal_connect(copy_journal_btn, "clicked", G_CALLBACK(on_dbg_copy_journal_cmd), NULL);
-    gtk_box_append(GTK_BOX(page), copy_journal_btn);
-
     GtkWidget *actions_heading = gtk_label_new("Actions");
     gtk_widget_add_css_class(actions_heading, "heading");
     gtk_label_set_xalign(GTK_LABEL(actions_heading), 0.0);
@@ -218,8 +189,10 @@ static GtkWidget* debug_build(void) {
                                               G_N_ELEMENTS(debug_row2_actions));
     gtk_box_append(GTK_BOX(page), row2);
 
-    GtkWidget *onboard_btn = debug_build_action_button(&debug_standalone_actions[0]);
-    gtk_box_append(GTK_BOX(page), onboard_btn);
+    for (gsize i = 0; i < G_N_ELEMENTS(debug_standalone_actions); i++) {
+        GtkWidget *btn = debug_build_standalone_action_button(debug_standalone_actions[i]);
+        gtk_box_append(GTK_BOX(page), btn);
+    }
 
     gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(scrolled), page);
 
@@ -377,13 +350,13 @@ const SectionController* section_debug_get(void) {
 }
 
 gboolean section_debug_test_has_action_label(const gchar *label) {
-    return debug_action_specs_contain(debug_row1_actions,
-                                       G_N_ELEMENTS(debug_row1_actions),
-                                       label)
-        || debug_action_specs_contain(debug_row2_actions,
-                                       G_N_ELEMENTS(debug_row2_actions),
-                                       label)
-        || debug_action_specs_contain(debug_standalone_actions,
-                                       G_N_ELEMENTS(debug_standalone_actions),
-                                       label);
+    return debug_actions_array_contains_label(debug_row1_actions,
+                                               G_N_ELEMENTS(debug_row1_actions),
+                                               label)
+        || debug_actions_array_contains_label(debug_row2_actions,
+                                               G_N_ELEMENTS(debug_row2_actions),
+                                               label)
+        || debug_actions_array_contains_label(debug_standalone_actions,
+                                               G_N_ELEMENTS(debug_standalone_actions),
+                                               label);
 }

--- a/apps/linux/src/tray.c
+++ b/apps/linux/src/tray.c
@@ -13,17 +13,25 @@
 
 #include <glib.h>
 #include <gio/gio.h>
+#include <gtk/gtk.h>
 #include <stdio.h>
 #include <string.h>
 #include "state.h"
 #include "log.h"
 #include "chat_window.h"
+#include "debug_actions.h"
+#include "exec_approval_prompter.h"
+#include "exec_approval_store.h"
+#include "exec_approval_tray_model.h"
 #include "gateway_client.h"
 #include "gateway_config.h"
 #include "display_model.h"
 #include "onboarding.h"
 #include "product_coordinator.h"
+#include "product_state.h"
+#include "shell_sections.h"
 #include "test_seams.h"
+#include "tray_protocol.h"
 
 static GSubprocess *helper_process = NULL;
 static GOutputStream *helper_stdin = NULL;
@@ -56,6 +64,51 @@ extern void systemd_restart_gateway(void);
 extern void gateway_client_refresh(void);
 
 static void handle_helper_action(const gchar *action);
+
+/* ── Debug-action registry hooks (production wiring) ──────────────
+ *
+ * The shared registry (`debug_actions.c`) intentionally avoids GTK
+ * imports so it can link into headless tests. Side effects that need
+ * GTK/GDK at runtime — clipboard writes for the "Copy Journal Command"
+ * action, and URI launches for the "Reveal …" actions — are delegated
+ * to these callbacks. Hooks are installed once during `tray_init` and
+ * never removed.
+ */
+static void tray_debug_uri_launcher(const char *uri, gpointer user_data) {
+    (void)user_data;
+    if (!uri || !uri[0]) return;
+    g_app_info_launch_default_for_uri(uri, NULL, NULL);
+}
+
+static void tray_debug_clipboard_writer(const char *text, gpointer user_data) {
+    (void)user_data;
+    if (!text) return;
+    GdkDisplay *display = gdk_display_get_default();
+    if (!display) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY,
+                     "tray_debug_clipboard_writer skipped (no default display)");
+        return;
+    }
+    GdkClipboard *clipboard = gdk_display_get_clipboard(display);
+    if (!clipboard) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY,
+                     "tray_debug_clipboard_writer skipped (no clipboard)");
+        return;
+    }
+    gdk_clipboard_set_text(clipboard, text);
+}
+
+static void tray_debug_show_section(OcDebugSectionTarget target, gpointer user_data) {
+    (void)user_data;
+    switch (target) {
+    case OC_DEBUG_SECTION_TARGET_LOGS:
+        product_coordinator_request_show_section(SECTION_LOGS);
+        break;
+    case OC_DEBUG_SECTION_TARGET_DEBUG:
+        product_coordinator_request_show_section(SECTION_DEBUG);
+        break;
+    }
+}
 
 static void handle_open_settings_request(void) {
     TrayUiAction action = tray_ui_dispatch_decide(TRAY_UI_REQUEST_SETTINGS, onboarding_is_visible());
@@ -113,6 +166,33 @@ static void handle_helper_action(const gchar *action) {
     } else if (g_strcmp0(action, "QUIT") == 0) {
         GApplication *app = g_application_get_default();
         if (app) g_application_quit(app);
+    } else if (g_str_has_prefix(action, "EXEC_APPROVAL_SET:")) {
+        /* Tranche D Full: tray-driven quick-mode change. The protocol
+         * parser validates the body shape and the exec_approval_tray_model
+         * helper performs the enum mapping; both are shared with the
+         * unit-test surface so this dispatcher stays trivial. */
+        char *mode_str = NULL;
+        if (tray_protocol_parse_exec_approval_action(action, &mode_str)) {
+            OcExecQuickMode mode;
+            if (exec_approval_tray_mode_from_string(mode_str, &mode)) {
+                (void)exec_approval_store_set_quick_mode(mode);
+            }
+        }
+        g_free(mode_str);
+    } else {
+        /* All remaining tray actions belong to the shared debug-action
+         * registry. Unknown actions are silently ignored — the helper
+         * protocol is one-way with no error channel, and a noisy
+         * g_warning here would just spam the journal if a stale helper
+         * sends a string we don't recognize.
+         */
+        OcDebugAction id;
+        if (oc_debug_action_from_tray_string(action, &id)) {
+            (void)oc_debug_action_dispatch(id);
+        } else {
+            OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY,
+                         "handle_helper_action unknown action='%s'", action);
+        }
     }
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "handle_helper_action exit seq=%u action='%s'", seq, action);
 }
@@ -195,6 +275,14 @@ static void on_helper_exited(GObject *source_object, GAsyncResult *res, gpointer
 void tray_init(void) {
     g_autoptr(GError) error = NULL;
     g_autofree gchar *helper_path = NULL;
+
+    /* Install debug-action registry hooks once. The registry default is a
+     * no-op, so installing here means tray clicks for new debug-class
+     * actions come fully alive only after tray_init() runs. Tests link
+     * the registry without these hooks and capture intent instead. */
+    oc_debug_actions_set_uri_launcher(tray_debug_uri_launcher, NULL);
+    oc_debug_actions_set_clipboard_writer(tray_debug_clipboard_writer, NULL);
+    oc_debug_actions_set_show_section_handler(tray_debug_show_section, NULL);
     
     // 1. Try build-tree sibling path first
     g_autofree gchar *exe_path = g_file_read_link("/proc/self/exe", NULL);
@@ -370,11 +458,82 @@ void tray_update_from_state(const AppState state) {
 
     /* A6: Send runtime mode label if available.
      * tray_helper.c supports RUNTIME:<label> for the runtime menu item.
+     *
+     * Append the effective connection mode as a human-readable suffix
+     * (e.g. "Expected Service Healthy · Local") so the operator can see
+     * at a glance whether the companion is talking to a local or remote
+     * gateway. This stays within the existing RUNTIME line — no new
+     * protocol surface — to keep the tray helper backwards compatible
+     * with older host builds.
      */
     if (tdm.runtime_label) {
-        g_autofree gchar *runtime_line = g_strdup_printf("RUNTIME:%s\n", tdm.runtime_label);
+        ProductConnectionMode mode = product_state_get_effective_connection_mode();
+        const gchar *mode_suffix = NULL;
+        switch (mode) {
+        case PRODUCT_CONNECTION_MODE_REMOTE: mode_suffix = "Remote"; break;
+        case PRODUCT_CONNECTION_MODE_LOCAL:  mode_suffix = "Local";  break;
+        case PRODUCT_CONNECTION_MODE_UNSPECIFIED:
+        default:                             mode_suffix = NULL;     break;
+        }
+        g_autofree gchar *runtime_line = mode_suffix
+            ? g_strdup_printf("RUNTIME:%s \u00B7 %s\n", tdm.runtime_label, mode_suffix)
+            : g_strdup_printf("RUNTIME:%s\n", tdm.runtime_label);
         send_line_to_helper(runtime_line, NULL);
     }
+
+    /* ── Tranche D Full host → helper state lines ──
+     *
+     * MENU_VISIBLE:
+     *   - OPEN_DEBUG: visible only when SECTION_DEBUG is embedded
+     *     (i.e. OPENCLAW_DEBUG_PANE is set on the host process).
+     *   - EXEC_APPROVAL: visible when the exec approval store yields a
+     *     known enum value — `OcExecQuickMode` only has three values, so
+     *     this is effectively always TRUE on a healthy host.
+     *   - APPROVALS_PENDING: visible iff pending count > 0.
+     *   - RESET_REMOTE_TUNNEL: hidden until a real reset API exists; the
+     *     registry's dispatch returns FALSE for this id and the host
+     *     therefore must keep the tray entry hidden. See the TODO in
+     *     debug_actions.c.
+     *   - RESTART_APP: app_restart_request() is built into every Linux
+     *     companion build, so this is always visible.
+     *
+     * RADIO:EXEC_APPROVAL:<mode> — current quick-mode default. Sending
+     * this on every refresh keeps the tray in sync with any
+     * settings-pane edits.
+     *
+     * APPROVALS:<n> — pending exec approval count (queued + presenting).
+     */
+    OcExecQuickMode quick_mode = exec_approval_store_get_quick_mode();
+    const char *mode_token = exec_approval_tray_mode_to_string(quick_mode);
+    gboolean exec_approval_ready = (mode_token != NULL);
+    guint pending = exec_approval_prompter_pending_count();
+
+    g_autofree gchar *menu_open_debug =
+        tray_protocol_format_menu_visible("OPEN_DEBUG",
+                                          shell_sections_is_embedded(SECTION_DEBUG));
+    g_autofree gchar *menu_exec_approval =
+        tray_protocol_format_menu_visible("EXEC_APPROVAL", exec_approval_ready);
+    g_autofree gchar *menu_approvals_pending =
+        tray_protocol_format_menu_visible("APPROVALS_PENDING", pending > 0);
+    g_autofree gchar *menu_reset_tunnel =
+        tray_protocol_format_menu_visible("RESET_REMOTE_TUNNEL", FALSE);
+    g_autofree gchar *menu_restart_app =
+        tray_protocol_format_menu_visible("RESTART_APP", TRUE);
+
+    if (menu_open_debug)        send_line_to_helper(menu_open_debug, NULL);
+    if (menu_exec_approval)     send_line_to_helper(menu_exec_approval, NULL);
+    if (menu_approvals_pending) send_line_to_helper(menu_approvals_pending, NULL);
+    if (menu_reset_tunnel)      send_line_to_helper(menu_reset_tunnel, NULL);
+    if (menu_restart_app)       send_line_to_helper(menu_restart_app, NULL);
+
+    if (mode_token) {
+        g_autofree gchar *radio_line =
+            tray_protocol_format_radio_exec_approval(mode_token);
+        if (radio_line) send_line_to_helper(radio_line, NULL);
+    }
+
+    g_autofree gchar *approvals_line = tray_protocol_format_approvals(pending);
+    if (approvals_line) send_line_to_helper(approvals_line, NULL);
 
     OC_LOG_DEBUG(OPENCLAW_LOG_CAT_TRAY, "tray_update_from_state exit");
 }

--- a/apps/linux/src/tray_helper.c
+++ b/apps/linux/src/tray_helper.c
@@ -37,11 +37,34 @@
 #include <string.h>
 #include <gio/gio.h>
 
+#include "tray_helper_protocol.h"
+
 static AppIndicator *indicator = NULL;
+
+/* Tray helpers must not echo an ACTION line back to the host while
+ * applying a host-driven RADIO update — otherwise the host would see
+ * its own broadcast bounce back as a user click. The radio item
+ * activate handler short-circuits when this guard is TRUE. */
+static gboolean updating_from_host = FALSE;
 
 /* Status context (disabled labels) */
 static GtkWidget *status_item = NULL;
 static GtkWidget *runtime_item = NULL;
+
+/* Exec Approvals submenu (Tranche D Full).
+ * Default selected mode is "ask" until the host sends RADIO. */
+static GtkWidget *exec_approval_parent_item = NULL;
+static GtkWidget *exec_approval_deny_item   = NULL;
+static GtkWidget *exec_approval_ask_item    = NULL;
+static GtkWidget *exec_approval_allow_item  = NULL;
+
+/* Pending exec approvals indicator (insensitive label).
+ * Hidden when count == 0. */
+static GtkWidget *approvals_pending_item = NULL;
+
+/* Operational items that the host can show/hide via MENU_VISIBLE. */
+static GtkWidget *reset_remote_tunnel_item = NULL;
+static GtkWidget *restart_app_item = NULL;
 
 /* Navigation actions */
 static GtkWidget *open_main_item = NULL;
@@ -57,6 +80,18 @@ static GtkWidget *refresh_item = NULL;
 /* App navigation */
 static GtkWidget *settings_item = NULL;
 static GtkWidget *diagnostics_item = NULL;
+static GtkWidget *logs_item = NULL;
+static GtkWidget *debug_item = NULL;
+
+/* Operational/debug parity items (Tranche D Core).
+ * All flat — no submenus, no checks, no radios. Each one emits a fixed
+ * ACTION:<NAME> line that the host process routes through the shared
+ * debug-action registry (`oc_debug_action_from_tray_string`). */
+static GtkWidget *restart_onboarding_item = NULL;
+static GtkWidget *reveal_config_item = NULL;
+static GtkWidget *reveal_state_item = NULL;
+static GtkWidget *copy_journal_item = NULL;
+static GtkWidget *send_test_notification_item = NULL;
 
 static void send_action(const char *action) {
     g_print("ACTION:%s\n", action);
@@ -72,11 +107,113 @@ static void on_restart_clicked(GtkMenuItem *item, gpointer data) { (void)item; (
 static void on_refresh_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("REFRESH"); }
 static void on_settings_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("OPEN_SETTINGS"); }
 static void on_diagnostics_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("OPEN_DIAGNOSTICS"); }
+static void on_logs_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("OPEN_LOGS"); }
+static void on_debug_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("OPEN_DEBUG"); }
+static void on_restart_onboarding_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("RESTART_ONBOARDING"); }
+static void on_reveal_config_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("REVEAL_CONFIG_FOLDER"); }
+static void on_reveal_state_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("REVEAL_STATE_FOLDER"); }
+static void on_copy_journal_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("COPY_JOURNAL_COMMAND"); }
+static void on_send_test_notification_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("SEND_TEST_NOTIFICATION"); }
+static void on_reset_remote_tunnel_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("RESET_REMOTE_TUNNEL"); }
+static void on_restart_app_clicked(GtkMenuItem *item, gpointer data) { (void)item; (void)data; send_action("RESTART_APP"); }
+
+/*
+ * Radio activate handler (Exec Approvals submenu).
+ *
+ * Each radio item carries its mode token in `g_object_set_data(item,
+ * "exec-approval-mode", "deny|ask|allow")` so a single callback can
+ * service all three. Suppresses re-emission while applying a host
+ * RADIO update via the `updating_from_host` guard.
+ */
+static void on_exec_approval_radio_activate(GtkRadioMenuItem *item, gpointer data) {
+    (void)data;
+    if (updating_from_host) return;
+    if (!gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(item))) return;
+
+    const char *mode = g_object_get_data(G_OBJECT(item), "exec-approval-mode");
+    if (!mode) return;
+
+    g_autofree gchar *line = g_strdup_printf("EXEC_APPROVAL_SET:%s", mode);
+    send_action(line);
+}
+
 static void on_quit_clicked(GtkMenuItem *item, gpointer data) { 
     (void)item; (void)data;
     send_action("QUIT"); 
     gtk_main_quit();
 }
+
+/* ── tray_helper_protocol callback adapters ─────────────────────
+ *
+ * The pure parser in tray_helper_protocol.c is GTK-free; these thin
+ * adapters translate its callback contract into widget mutations.
+ */
+
+static GtkWidget* widget_for_menu_key(TrayHelperMenuKey key) {
+    switch (key) {
+    case TRAY_HELPER_MENU_KEY_OPEN_DEBUG:          return debug_item;
+    case TRAY_HELPER_MENU_KEY_EXEC_APPROVAL:       return exec_approval_parent_item;
+    case TRAY_HELPER_MENU_KEY_APPROVALS_PENDING:   return approvals_pending_item;
+    case TRAY_HELPER_MENU_KEY_RESET_REMOTE_TUNNEL: return reset_remote_tunnel_item;
+    case TRAY_HELPER_MENU_KEY_RESTART_APP:         return restart_app_item;
+    case TRAY_HELPER_MENU_KEY_UNKNOWN:
+    default:                                       return NULL;
+    }
+}
+
+static void helper_set_menu_visible(TrayHelperMenuKey key, gboolean visible, gpointer ud) {
+    (void)ud;
+    GtkWidget *w = widget_for_menu_key(key);
+    if (!w) return;
+    /* Both the visible flag and the "no-show-all" flag must agree —
+     * otherwise a future gtk_widget_show_all() on the menu would un-hide
+     * everything we just hid. */
+    gtk_widget_set_no_show_all(w, !visible);
+    if (visible) gtk_widget_show(w);
+    else         gtk_widget_hide(w);
+}
+
+static void helper_set_radio_exec_approval(const char *mode, gpointer ud) {
+    (void)ud;
+    GtkWidget *target = NULL;
+    if      (g_strcmp0(mode, "deny")  == 0) target = exec_approval_deny_item;
+    else if (g_strcmp0(mode, "ask")   == 0) target = exec_approval_ask_item;
+    else if (g_strcmp0(mode, "allow") == 0) target = exec_approval_allow_item;
+    if (!target) return;
+
+    /* Set the active item under the host-update guard so the activate
+     * handler does not echo an EXEC_APPROVAL_SET back out. */
+    updating_from_host = TRUE;
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(target), TRUE);
+    updating_from_host = FALSE;
+}
+
+static void helper_set_approvals_count(guint count, gpointer ud) {
+    (void)ud;
+    if (!approvals_pending_item) return;
+
+    g_autofree gchar *label = tray_helper_protocol_format_approvals_label(count);
+    gtk_menu_item_set_label(GTK_MENU_ITEM(approvals_pending_item), label);
+
+    /* The pending-approvals label is also gated by an explicit
+     * MENU_VISIBLE:APPROVALS_PENDING line from the host (so the host
+     * controls visibility based on its own readiness signals). The
+     * spec, however, also says "If n == 0: hide pending approvals
+     * item" purely from the count. Apply that policy here as a
+     * defensive default — if the host disagrees, its later
+     * MENU_VISIBLE will overwrite this state. */
+    gboolean visible = (count > 0);
+    gtk_widget_set_no_show_all(approvals_pending_item, !visible);
+    if (visible) gtk_widget_show(approvals_pending_item);
+    else         gtk_widget_hide(approvals_pending_item);
+}
+
+static const TrayHelperProtocolHandlers helper_protocol_handlers = {
+    .set_menu_visible        = helper_set_menu_visible,
+    .set_radio_exec_approval = helper_set_radio_exec_approval,
+    .set_approvals_count     = helper_set_approvals_count,
+    .user_data               = NULL,
+};
 
 static gboolean handle_stdin(GIOChannel *source, GIOCondition condition, gpointer data) {
     (void)data;
@@ -120,6 +257,12 @@ static gboolean handle_stdin(GIOChannel *source, GIOCondition condition, gpointe
                 }
             }
             g_strfreev(parts);
+        } else {
+            /* Tranche D Full host→helper extensions: MENU_VISIBLE,
+             * RADIO:EXEC_APPROVAL, APPROVALS. The pure parser handles
+             * recognition + dispatch; lines it doesn't recognise are
+             * silently dropped. */
+            (void)tray_helper_protocol_apply_line(&helper_protocol_handlers, line);
         }
         g_free(line);
     } else if (status == G_IO_STATUS_EOF) {
@@ -213,6 +356,104 @@ int main(int argc, char **argv) {
     diagnostics_item = gtk_menu_item_new_with_label("Diagnostics");
     g_signal_connect(diagnostics_item, "activate", G_CALLBACK(on_diagnostics_clicked), NULL);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), diagnostics_item);
+
+    logs_item = gtk_menu_item_new_with_label("Logs");
+    g_signal_connect(logs_item, "activate", G_CALLBACK(on_logs_clicked), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), logs_item);
+
+    debug_item = gtk_menu_item_new_with_label("Debug");
+    g_signal_connect(debug_item, "activate", G_CALLBACK(on_debug_clicked), NULL);
+    /* Hidden until the host sends MENU_VISIBLE:OPEN_DEBUG:1. SECTION_DEBUG
+     * is gated by OPENCLAW_DEBUG_PANE on the host side. */
+    gtk_widget_set_no_show_all(debug_item, TRUE);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), debug_item);
+
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+
+    /* ── Operational / debug parity actions (flat) ── */
+    restart_onboarding_item = gtk_menu_item_new_with_label("Restart Onboarding");
+    g_signal_connect(restart_onboarding_item, "activate", G_CALLBACK(on_restart_onboarding_clicked), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), restart_onboarding_item);
+
+    reveal_config_item = gtk_menu_item_new_with_label("Reveal Config Folder");
+    g_signal_connect(reveal_config_item, "activate", G_CALLBACK(on_reveal_config_clicked), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), reveal_config_item);
+
+    reveal_state_item = gtk_menu_item_new_with_label("Reveal State Folder");
+    g_signal_connect(reveal_state_item, "activate", G_CALLBACK(on_reveal_state_clicked), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), reveal_state_item);
+
+    copy_journal_item = gtk_menu_item_new_with_label("Copy Journal Command");
+    g_signal_connect(copy_journal_item, "activate", G_CALLBACK(on_copy_journal_clicked), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), copy_journal_item);
+
+    send_test_notification_item = gtk_menu_item_new_with_label("Send Test Notification");
+    g_signal_connect(send_test_notification_item, "activate", G_CALLBACK(on_send_test_notification_clicked), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), send_test_notification_item);
+
+    /* ── Reset Remote Tunnel (initially hidden — host emits
+     *    MENU_VISIBLE:RESET_REMOTE_TUNNEL:1 only when applicable) ── */
+    reset_remote_tunnel_item = gtk_menu_item_new_with_label("Reset Remote Tunnel");
+    g_signal_connect(reset_remote_tunnel_item, "activate", G_CALLBACK(on_reset_remote_tunnel_clicked), NULL);
+    gtk_widget_set_no_show_all(reset_remote_tunnel_item, TRUE);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), reset_remote_tunnel_item);
+
+    /* ── Restart App (visible by default; host can toggle via
+     *    MENU_VISIBLE:RESTART_APP) ── */
+    restart_app_item = gtk_menu_item_new_with_label("Restart App");
+    g_signal_connect(restart_app_item, "activate", G_CALLBACK(on_restart_app_clicked), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), restart_app_item);
+
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+
+    /* ── Exec Approvals (Tranche D Full) ──
+     *
+     * Pending-counter item (insensitive, hidden until the host sends
+     * APPROVALS:n with n > 0) followed by a radio submenu for the
+     * quick-mode default. The host owns the source of truth: it emits
+     * RADIO:EXEC_APPROVAL:<mode> on every refresh, which selects the
+     * matching radio item under the `updating_from_host` guard so no
+     * EXEC_APPROVAL_SET is echoed back.
+     */
+    approvals_pending_item = gtk_menu_item_new_with_label("Exec Approvals: 0 pending");
+    gtk_widget_set_sensitive(approvals_pending_item, FALSE);
+    gtk_widget_set_no_show_all(approvals_pending_item, TRUE);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), approvals_pending_item);
+
+    exec_approval_parent_item = gtk_menu_item_new_with_label("Exec Approvals");
+    gtk_widget_set_no_show_all(exec_approval_parent_item, TRUE);
+    GtkWidget *exec_approval_submenu = gtk_menu_new();
+    gtk_menu_item_set_submenu(GTK_MENU_ITEM(exec_approval_parent_item), exec_approval_submenu);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), exec_approval_parent_item);
+
+    /* Three radio items in a single GtkRadioMenuItem group. The "ask"
+     * default is selected before any host message arrives so the
+     * widget always has a selected state. */
+    exec_approval_deny_item = gtk_radio_menu_item_new_with_label(NULL, "Deny");
+    g_object_set_data(G_OBJECT(exec_approval_deny_item), "exec-approval-mode", "deny");
+    g_signal_connect(exec_approval_deny_item, "activate",
+                     G_CALLBACK(on_exec_approval_radio_activate), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(exec_approval_submenu), exec_approval_deny_item);
+
+    GSList *radio_group = gtk_radio_menu_item_get_group(GTK_RADIO_MENU_ITEM(exec_approval_deny_item));
+    exec_approval_ask_item = gtk_radio_menu_item_new_with_label(radio_group, "Ask");
+    g_object_set_data(G_OBJECT(exec_approval_ask_item), "exec-approval-mode", "ask");
+    g_signal_connect(exec_approval_ask_item, "activate",
+                     G_CALLBACK(on_exec_approval_radio_activate), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(exec_approval_submenu), exec_approval_ask_item);
+
+    radio_group = gtk_radio_menu_item_get_group(GTK_RADIO_MENU_ITEM(exec_approval_ask_item));
+    exec_approval_allow_item = gtk_radio_menu_item_new_with_label(radio_group, "Allow");
+    g_object_set_data(G_OBJECT(exec_approval_allow_item), "exec-approval-mode", "allow");
+    g_signal_connect(exec_approval_allow_item, "activate",
+                     G_CALLBACK(on_exec_approval_radio_activate), NULL);
+    gtk_menu_shell_append(GTK_MENU_SHELL(exec_approval_submenu), exec_approval_allow_item);
+
+    /* Default selection = ask. The submenu always stays initialised
+     * regardless of host readiness. */
+    updating_from_host = TRUE;
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(exec_approval_ask_item), TRUE);
+    updating_from_host = FALSE;
 
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 

--- a/apps/linux/src/tray_helper_protocol.c
+++ b/apps/linux/src/tray_helper_protocol.c
@@ -1,0 +1,104 @@
+/*
+ * tray_helper_protocol.c
+ *
+ * Pure-C parser/applier for the host→helper line shapes introduced in
+ * Tranche D Full. See tray_helper_protocol.h.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "tray_helper_protocol.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "tray_protocol.h"
+
+TrayHelperMenuKey tray_helper_protocol_menu_key_from_string(const char *s) {
+    if (!s) return TRAY_HELPER_MENU_KEY_UNKNOWN;
+    if (g_strcmp0(s, "OPEN_DEBUG")          == 0) return TRAY_HELPER_MENU_KEY_OPEN_DEBUG;
+    if (g_strcmp0(s, "EXEC_APPROVAL")       == 0) return TRAY_HELPER_MENU_KEY_EXEC_APPROVAL;
+    if (g_strcmp0(s, "APPROVALS_PENDING")   == 0) return TRAY_HELPER_MENU_KEY_APPROVALS_PENDING;
+    if (g_strcmp0(s, "RESET_REMOTE_TUNNEL") == 0) return TRAY_HELPER_MENU_KEY_RESET_REMOTE_TUNNEL;
+    if (g_strcmp0(s, "RESTART_APP")         == 0) return TRAY_HELPER_MENU_KEY_RESTART_APP;
+    return TRAY_HELPER_MENU_KEY_UNKNOWN;
+}
+
+gchar* tray_helper_protocol_format_approvals_label(guint count) {
+    /* Tranche D Full keeps the label deterministic and language-stable.
+     * Singular/plural variants are explicit so a translation pass can
+     * later override them without restructuring the call site. */
+    if (count == 0u) return g_strdup("Exec Approvals: 0 pending");
+    if (count == 1u) return g_strdup("Exec Approvals: 1 pending");
+    return g_strdup_printf("Exec Approvals: %u pending", count);
+}
+
+static gboolean apply_menu_visible(const TrayHelperProtocolHandlers *handlers,
+                                    const char *body) {
+    /* body shape: "<ACTION>:0|1" */
+    if (!body) return FALSE;
+    const char *colon = strchr(body, ':');
+    if (!colon || colon == body) return FALSE;
+
+    g_autofree gchar *action = g_strndup(body, (gsize)(colon - body));
+    const char *flag = colon + 1;
+    if (flag[0] == '\0' || flag[1] != '\0') return FALSE;
+    if (flag[0] != '0' && flag[0] != '1') return FALSE;
+
+    TrayHelperMenuKey key = tray_helper_protocol_menu_key_from_string(action);
+    if (key == TRAY_HELPER_MENU_KEY_UNKNOWN) {
+        /* Unknown keys are recognised by shape but silently dropped, per
+         * spec ("Unknown keys are ignored"). Treat as not-applied. */
+        return FALSE;
+    }
+
+    if (handlers && handlers->set_menu_visible) {
+        handlers->set_menu_visible(key, flag[0] == '1', handlers->user_data);
+    }
+    return TRUE;
+}
+
+static gboolean apply_radio_exec_approval(const TrayHelperProtocolHandlers *handlers,
+                                           const char *body) {
+    /* body shape: "<mode>" — only deny/ask/allow are valid. */
+    if (!tray_protocol_exec_approval_mode_is_valid(body)) return FALSE;
+    if (handlers && handlers->set_radio_exec_approval) {
+        handlers->set_radio_exec_approval(body, handlers->user_data);
+    }
+    return TRUE;
+}
+
+static gboolean apply_approvals(const TrayHelperProtocolHandlers *handlers,
+                                 const char *body) {
+    if (!body || body[0] == '\0') return FALSE;
+    /* Reject negative numbers and anything that isn't pure digits. */
+    for (const char *p = body; *p; p++) {
+        if (*p < '0' || *p > '9') return FALSE;
+    }
+    char *endp = NULL;
+    unsigned long parsed = strtoul(body, &endp, 10);
+    if (!endp || *endp != '\0') return FALSE;
+    if (parsed > G_MAXUINT) return FALSE;
+
+    if (handlers && handlers->set_approvals_count) {
+        handlers->set_approvals_count((guint)parsed, handlers->user_data);
+    }
+    return TRUE;
+}
+
+gboolean tray_helper_protocol_apply_line(const TrayHelperProtocolHandlers *handlers,
+                                          const char *line) {
+    if (!line) return FALSE;
+
+    if (g_str_has_prefix(line, "MENU_VISIBLE:")) {
+        return apply_menu_visible(handlers, line + sizeof("MENU_VISIBLE:") - 1);
+    }
+    if (g_str_has_prefix(line, "RADIO:EXEC_APPROVAL:")) {
+        return apply_radio_exec_approval(handlers, line + sizeof("RADIO:EXEC_APPROVAL:") - 1);
+    }
+    if (g_str_has_prefix(line, "APPROVALS:")) {
+        return apply_approvals(handlers, line + sizeof("APPROVALS:") - 1);
+    }
+
+    return FALSE;
+}

--- a/apps/linux/src/tray_helper_protocol.h
+++ b/apps/linux/src/tray_helper_protocol.h
@@ -1,0 +1,95 @@
+/*
+ * tray_helper_protocol.h
+ *
+ * Pure-C parser/applier for the host→tray-helper line protocol that
+ * runs inside `openclaw-tray-helper` (GTK3). The helper reads each
+ * line from stdin, classifies it, and applies the resulting state
+ * change to its menu widgets.
+ *
+ * To keep the GTK-bound widget code testable, the parser is split off
+ * into this module. Instead of taking GTK widgets directly, it takes a
+ * struct of callback function pointers — the helper installs real
+ * callbacks that mutate widgets, and unit tests install capture
+ * callbacks that record what was requested.
+ *
+ * The four protocol shapes handled here are:
+ *
+ *   MENU_VISIBLE:<ACTION>:0|1
+ *   RADIO:EXEC_APPROVAL:<deny|ask|allow>
+ *   APPROVALS:<n>
+ *
+ * Lines that do not match any of these prefixes are ignored — the
+ * helper keeps its own handlers for `STATE:`, `RUNTIME:`, and
+ * `SENSITIVE:` lines, which predate this module.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_TRAY_HELPER_PROTOCOL_H
+#define OPENCLAW_LINUX_TRAY_HELPER_PROTOCOL_H
+
+#include <glib.h>
+
+/* Stable identifiers for the menu items the helper can show/hide via
+ * MENU_VISIBLE. Keeping them in a single enum lets the test harness
+ * assert against named keys rather than free-form strings. */
+typedef enum {
+    TRAY_HELPER_MENU_KEY_UNKNOWN = 0,
+    TRAY_HELPER_MENU_KEY_OPEN_DEBUG,
+    TRAY_HELPER_MENU_KEY_EXEC_APPROVAL,
+    TRAY_HELPER_MENU_KEY_APPROVALS_PENDING,
+    TRAY_HELPER_MENU_KEY_RESET_REMOTE_TUNNEL,
+    TRAY_HELPER_MENU_KEY_RESTART_APP,
+} TrayHelperMenuKey;
+
+typedef struct {
+    /* Show/hide the named menu item. Helper owns the actual widget. */
+    void (*set_menu_visible)(TrayHelperMenuKey key, gboolean visible, gpointer user_data);
+
+    /* Select the radio item matching `mode` ("deny"/"ask"/"allow").
+     * Helper is responsible for using its `updating_from_host` guard
+     * so the resulting GtkRadioMenuItem::toggled does not re-emit an
+     * ACTION line. */
+    void (*set_radio_exec_approval)(const char *mode, gpointer user_data);
+
+    /* Update the pending-approvals counter. Helper computes the
+     * displayed label and visibility from the count. */
+    void (*set_approvals_count)(guint count, gpointer user_data);
+
+    gpointer user_data;
+} TrayHelperProtocolHandlers;
+
+/*
+ * Convert an ASCII action key from a MENU_VISIBLE line into a
+ * TrayHelperMenuKey. Returns TRAY_HELPER_MENU_KEY_UNKNOWN for any
+ * unrecognised string (including NULL/empty), which the apply path
+ * treats as "ignore".
+ */
+TrayHelperMenuKey tray_helper_protocol_menu_key_from_string(const char *s);
+
+/*
+ * Parse a single line and dispatch it through `handlers`. Returns
+ * TRUE iff the line was recognised and a handler was invoked (or
+ * would have been, had it been non-NULL); returns FALSE for any line
+ * that does not match a Tranche D Full host→helper shape. The line
+ * MUST be already chomped of any trailing newline.
+ *
+ * `handlers` may be NULL (the call still classifies the line and
+ * returns the recognise/ignore decision); each handler pointer in
+ * `handlers` may itself be NULL (that line is then silently dropped).
+ */
+gboolean tray_helper_protocol_apply_line(const TrayHelperProtocolHandlers *handlers,
+                                          const char *line);
+
+/*
+ * Compute the label text that the helper renders next to the
+ * pending-approvals item for a given count. Always returns a
+ * newly-allocated string; caller frees with g_free(). Pluralisation
+ * matches the Tranche D Full spec:
+ *   0  → "Exec Approvals: 0 pending"
+ *   1  → "Exec Approvals: 1 pending"
+ *   >1 → "Exec Approvals: <n> pending"
+ */
+gchar* tray_helper_protocol_format_approvals_label(guint count);
+
+#endif /* OPENCLAW_LINUX_TRAY_HELPER_PROTOCOL_H */

--- a/apps/linux/src/tray_protocol.c
+++ b/apps/linux/src/tray_protocol.c
@@ -1,0 +1,57 @@
+/*
+ * tray_protocol.c
+ *
+ * Implementation of the pure-C tray helper line protocol formatter and
+ * parser. See tray_protocol.h for the protocol grammar.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "tray_protocol.h"
+
+#include <string.h>
+
+gboolean tray_protocol_exec_approval_mode_is_valid(const char *mode) {
+    if (!mode) return FALSE;
+    return g_strcmp0(mode, "deny")  == 0
+        || g_strcmp0(mode, "ask")   == 0
+        || g_strcmp0(mode, "allow") == 0;
+}
+
+gchar* tray_protocol_format_menu_visible(const char *action, gboolean visible) {
+    if (!action || action[0] == '\0') return NULL;
+    return g_strdup_printf("MENU_VISIBLE:%s:%d\n", action, visible ? 1 : 0);
+}
+
+gchar* tray_protocol_format_radio_exec_approval(const char *mode) {
+    if (!tray_protocol_exec_approval_mode_is_valid(mode)) return NULL;
+    return g_strdup_printf("RADIO:EXEC_APPROVAL:%s\n", mode);
+}
+
+gchar* tray_protocol_format_approvals(guint count) {
+    return g_strdup_printf("APPROVALS:%u\n", count);
+}
+
+gboolean tray_protocol_parse_exec_approval_action(const char *action, char **out_mode) {
+    if (!action) return FALSE;
+
+    /* Action body shape: "EXEC_APPROVAL_SET:<mode>" with no trailing
+     * whitespace or extra colons. The host strips the `ACTION:` prefix
+     * before reaching this parser, so the body must start with the
+     * verb. */
+    static const char prefix[] = "EXEC_APPROVAL_SET:";
+    const gsize prefix_len = sizeof(prefix) - 1;
+
+    if (strncmp(action, prefix, prefix_len) != 0) return FALSE;
+
+    const char *mode = action + prefix_len;
+    if (mode[0] == '\0') return FALSE;
+    if (strchr(mode, ':') != NULL) return FALSE;          /* extra fields */
+    if (strchr(mode, '\n') != NULL) return FALSE;
+    if (strchr(mode, ' ') != NULL) return FALSE;
+
+    if (!tray_protocol_exec_approval_mode_is_valid(mode)) return FALSE;
+
+    if (out_mode) *out_mode = g_strdup(mode);
+    return TRUE;
+}

--- a/apps/linux/src/tray_protocol.h
+++ b/apps/linux/src/tray_protocol.h
@@ -1,0 +1,72 @@
+/*
+ * tray_protocol.h
+ *
+ * Pure-C / GLib formatter + parser for the line protocol shared between
+ * the OpenClaw Linux companion (host) and its private tray helper
+ * (`openclaw-tray-helper`).
+ *
+ * The host writes formatted lines to the helper's stdin and reads
+ * `ACTION:` / `STATE:` lines back from the helper's stdout. Tranche D
+ * Full extends that protocol with three additional host→helper line
+ * shapes:
+ *
+ *   MENU_VISIBLE:<ACTION>:0|1     — show/hide a tray menu item
+ *   RADIO:EXEC_APPROVAL:<mode>    — select the active radio item
+ *   APPROVALS:<n>                 — pending exec-approval count badge
+ *
+ * And one new helper→host action body:
+ *
+ *   EXEC_APPROVAL_SET:<deny|ask|allow>
+ *
+ * This module owns *only* string formatting and parsing. It deliberately
+ * has no GTK dependency, so both the host and the helper (and the unit
+ * tests) can link it cheaply.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_TRAY_PROTOCOL_H
+#define OPENCLAW_LINUX_TRAY_PROTOCOL_H
+
+#include <glib.h>
+
+/*
+ * Format a MENU_VISIBLE line for transmission to the tray helper. The
+ * trailing "\n" is included so the result can be passed straight to
+ * `send_line_to_helper` without further concatenation.
+ *
+ * Returns NULL when `action` is NULL or empty. The caller frees with
+ * g_free().
+ */
+gchar* tray_protocol_format_menu_visible(const char *action, gboolean visible);
+
+/*
+ * Format a RADIO:EXEC_APPROVAL line. `mode` must be one of the canonical
+ * lower-case strings: "deny", "ask", "allow". For any other input the
+ * function returns NULL.
+ */
+gchar* tray_protocol_format_radio_exec_approval(const char *mode);
+
+/*
+ * Format an APPROVALS:<count> line. Always succeeds for any guint.
+ * Caller frees with g_free().
+ */
+gchar* tray_protocol_format_approvals(guint count);
+
+/*
+ * Parse the body of an `EXEC_APPROVAL_SET:<mode>` action line (i.e. the
+ * substring AFTER `ACTION:`). On success, writes a newly-allocated copy
+ * of the mode token into `*out_mode` and returns TRUE. On any malformed
+ * input (NULL, missing prefix, missing/invalid mode token, trailing
+ * junk) returns FALSE and leaves `*out_mode` untouched. `out_mode` may
+ * be NULL — then the function is a pure validity probe.
+ */
+gboolean tray_protocol_parse_exec_approval_action(const char *action, char **out_mode);
+
+/*
+ * Lightweight check on a mode token (no allocation). TRUE iff `mode` is
+ * exactly one of "deny", "ask", "allow". NULL returns FALSE.
+ */
+gboolean tray_protocol_exec_approval_mode_is_valid(const char *mode);
+
+#endif /* OPENCLAW_LINUX_TRAY_PROTOCOL_H */

--- a/apps/linux/tests/test_app_restart.c
+++ b/apps/linux/tests/test_app_restart.c
@@ -1,0 +1,63 @@
+/*
+ * test_app_restart.c
+ *
+ * Hermetic regression for the `Restart App` argv builder. The actual
+ * spawn path is intentionally NOT exercised here — adding a process-
+ * spawning seam to the production module would create a foot-gun
+ * larger than the tested behavior. Instead this suite locks down the
+ * argv shape so a future refactor cannot silently change the relaunch
+ * contract.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include <glib.h>
+#include <string.h>
+
+#include "../src/app_restart.h"
+
+static void test_argv_builder_rejects_null_self(void) {
+    g_assert_null(app_restart_build_argv_for_test(NULL));
+    g_assert_null(app_restart_build_argv_for_test(""));
+}
+
+static void test_argv_builder_emits_sh_dash_c_form(void) {
+    g_auto(GStrv) argv = app_restart_build_argv_for_test("/usr/local/bin/openclaw-linux");
+    g_assert_nonnull(argv);
+    g_assert_cmpuint(g_strv_length(argv), ==, 5u);
+    g_assert_cmpstr(argv[0], ==, "/bin/sh");
+    g_assert_cmpstr(argv[1], ==, "-c");
+    g_assert_cmpstr(argv[3], ==, "sh");
+    g_assert_cmpstr(argv[4], ==, "/usr/local/bin/openclaw-linux");
+    g_assert_null(argv[5]);
+}
+
+static void test_argv_builder_script_contains_sleep_and_exec(void) {
+    g_auto(GStrv) argv = app_restart_build_argv_for_test("/opt/openclaw/openclaw-linux");
+    g_assert_nonnull(argv);
+    g_assert_nonnull(strstr(argv[2], "sleep "));
+    g_assert_nonnull(strstr(argv[2], "exec \"$1\""));
+}
+
+static void test_argv_builder_passes_self_path_as_dollar_one(void) {
+    /* The shell snippet uses exec "$1", so the self path MUST be
+     * argv[4] (i.e. shell positional $1, after argv[3] = "sh"/$0). */
+    g_auto(GStrv) argv = app_restart_build_argv_for_test("/tmp/my-build/openclaw-linux");
+    g_assert_nonnull(argv);
+    g_assert_cmpstr(argv[4], ==, "/tmp/my-build/openclaw-linux");
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/app_restart/argv_builder_rejects_null_self",
+                    test_argv_builder_rejects_null_self);
+    g_test_add_func("/app_restart/argv_builder_emits_sh_dash_c_form",
+                    test_argv_builder_emits_sh_dash_c_form);
+    g_test_add_func("/app_restart/argv_builder_script_contains_sleep_and_exec",
+                    test_argv_builder_script_contains_sleep_and_exec);
+    g_test_add_func("/app_restart/argv_builder_passes_self_path_as_dollar_one",
+                    test_argv_builder_passes_self_path_as_dollar_one);
+
+    return g_test_run();
+}

--- a/apps/linux/tests/test_debug_actions.c
+++ b/apps/linux/tests/test_debug_actions.c
@@ -1,0 +1,467 @@
+/*
+ * test_debug_actions.c
+ *
+ * Pure-C regression suite for the shared debug-action registry
+ * (`apps/linux/src/debug_actions.{c,h}`). The registry is the single
+ * source of truth for the operational/debug affordances surfaced by
+ * both the tray helper menu and the in-app Debug section, so the tests
+ * here lock down:
+ *
+ *   1. Spec-table integrity (count, unique tray strings, every entry's
+ *      label/action surfaces match expectations from the Tranche D
+ *      Core scope).
+ *   2. `oc_debug_action_from_tray_string` round-trips for every entry
+ *      that exposes a `tray_action_string` and rejects unknown / NULL
+ *      input cleanly.
+ *   3. `oc_debug_action_dispatch` calls through to the right cross-
+ *      module entry points (gateway_client_refresh,
+ *      systemd_restart_gateway, product_coordinator_request_rerun_*,
+ *      notify_send_test_notification) AND through to the production
+ *      hooks (URI launcher, clipboard writer, show-section handler).
+ *   4. Reveal actions feed the URI launcher, "Copy Journal Command"
+ *      formats `journalctl --user -u <unit> -f`, and "Open Logs" /
+ *      "Open Debug" route to the right show-section target.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include <glib.h>
+#include <string.h>
+
+#include "../src/debug_actions.h"
+
+/* ── Stubs for cross-module entry points ───────────────────────── */
+
+static guint stub_gateway_refresh_calls = 0;
+static guint stub_systemd_restart_calls = 0;
+static guint stub_rerun_onboarding_calls = 0;
+static guint stub_send_test_notification_calls = 0;
+static guint stub_app_restart_calls = 0;
+static gboolean stub_app_restart_result = TRUE;
+static gchar *stub_unit_name = NULL;
+
+void gateway_client_refresh(void) { stub_gateway_refresh_calls++; }
+void systemd_restart_gateway(void) { stub_systemd_restart_calls++; }
+void product_coordinator_request_rerun_onboarding(void) { stub_rerun_onboarding_calls++; }
+gboolean notify_send_test_notification(void) { stub_send_test_notification_calls++; return TRUE; }
+const gchar* systemd_get_canonical_unit_name(void) { return stub_unit_name; }
+
+/*
+ * Stub for `app_restart_request()` — production path uses g_spawn_async
+ * to detach a relaunch shell, which is unsafe to actually invoke from a
+ * unit test. The registry only sees the boolean return and the call
+ * counter. */
+gboolean app_restart_request(void) {
+    stub_app_restart_calls++;
+    return stub_app_restart_result;
+}
+
+/* runtime_reveal stubs — controlled per-test via these globals. The
+ * production module is intentionally NOT linked into this test so we
+ * can hand-feed the URIs without standing up the runtime-paths and
+ * gateway-config dependency tree. */
+static gchar *stub_config_uri = NULL;
+static gchar *stub_state_uri = NULL;
+
+gchar* runtime_reveal_build_config_dir_uri(void) {
+    return stub_config_uri ? g_strdup(stub_config_uri) : NULL;
+}
+
+gchar* runtime_reveal_build_state_dir_uri(void) {
+    return stub_state_uri ? g_strdup(stub_state_uri) : NULL;
+}
+
+/* ── Production-hook capture stubs ───────────────────────────── */
+
+static guint                hook_uri_calls = 0;
+static guint                hook_clipboard_calls = 0;
+static guint                hook_show_section_calls = 0;
+static gchar               *hook_last_uri = NULL;
+static gchar               *hook_last_clipboard = NULL;
+static OcDebugSectionTarget hook_last_section_target = OC_DEBUG_SECTION_TARGET_LOGS;
+static gpointer             hook_last_user_data = NULL;
+
+static void capture_uri_hook(const char *uri, gpointer user_data) {
+    hook_uri_calls++;
+    g_free(hook_last_uri);
+    hook_last_uri = uri ? g_strdup(uri) : NULL;
+    hook_last_user_data = user_data;
+}
+
+static void capture_clipboard_hook(const char *text, gpointer user_data) {
+    hook_clipboard_calls++;
+    g_free(hook_last_clipboard);
+    hook_last_clipboard = text ? g_strdup(text) : NULL;
+    hook_last_user_data = user_data;
+}
+
+static void capture_show_section_hook(OcDebugSectionTarget target, gpointer user_data) {
+    hook_show_section_calls++;
+    hook_last_section_target = target;
+    hook_last_user_data = user_data;
+}
+
+/* ── Per-test reset ─────────────────────────────────────────── */
+
+static void reset_all(void) {
+    stub_gateway_refresh_calls = 0;
+    stub_systemd_restart_calls = 0;
+    stub_rerun_onboarding_calls = 0;
+    stub_send_test_notification_calls = 0;
+    stub_app_restart_calls = 0;
+    stub_app_restart_result = TRUE;
+
+    g_clear_pointer(&stub_unit_name, g_free);
+    g_clear_pointer(&stub_config_uri, g_free);
+    g_clear_pointer(&stub_state_uri, g_free);
+
+    hook_uri_calls = 0;
+    hook_clipboard_calls = 0;
+    hook_show_section_calls = 0;
+    g_clear_pointer(&hook_last_uri, g_free);
+    g_clear_pointer(&hook_last_clipboard, g_free);
+    hook_last_section_target = OC_DEBUG_SECTION_TARGET_LOGS;
+    hook_last_user_data = NULL;
+
+    oc_debug_actions_test_reset();
+}
+
+/* ── Tests ──────────────────────────────────────────────────── */
+
+static void test_registry_count_matches_enum(void) {
+    g_assert_cmpuint(oc_debug_action_count(), ==, (guint)OC_DEBUG_ACTION_COUNT);
+    g_assert_cmpuint(oc_debug_action_count(), ==, 11u);
+}
+
+static void test_registry_get_returns_consistent_specs(void) {
+    for (guint i = 0; i < oc_debug_action_count(); i++) {
+        const OcDebugActionSpec *spec = oc_debug_action_get((OcDebugAction)i);
+        g_assert_nonnull(spec);
+        g_assert_cmpint((gint)spec->id, ==, (gint)i);
+    }
+    g_assert_null(oc_debug_action_get(OC_DEBUG_ACTION_COUNT));
+    g_assert_null(oc_debug_action_get((OcDebugAction)9999));
+}
+
+static void test_registry_tray_action_strings_unique(void) {
+    GHashTable *seen = g_hash_table_new(g_str_hash, g_str_equal);
+    for (guint i = 0; i < oc_debug_action_count(); i++) {
+        const OcDebugActionSpec *spec = oc_debug_action_get((OcDebugAction)i);
+        if (!spec->tray_action_string) continue;
+        if (g_hash_table_contains(seen, spec->tray_action_string)) {
+            g_test_message("duplicate tray action string '%s'", spec->tray_action_string);
+            g_assert_not_reached();
+        }
+        g_hash_table_insert(seen, (gpointer)spec->tray_action_string, GINT_TO_POINTER(1));
+    }
+    g_hash_table_destroy(seen);
+}
+
+static void test_registry_expected_labels_exist(void) {
+    /* These are the Tranche D Core public labels — the contract Codex
+     * promised to ship. Lock them in so a future rename has to come
+     * with an explicit test update. */
+    const char *expected_debug_labels[] = {
+        "Trigger Health Refresh",
+        "Restart Gateway",
+        "Restart Onboarding",
+        "Reveal Config Folder",
+        "Reveal State Folder",
+        "Copy Journal Command",
+        "Send Test Notification",
+        "Restart App",
+        NULL,
+    };
+    const char *expected_tray_actions[] = {
+        "RESTART_ONBOARDING",
+        "REVEAL_CONFIG_FOLDER",
+        "REVEAL_STATE_FOLDER",
+        "COPY_JOURNAL_COMMAND",
+        "SEND_TEST_NOTIFICATION",
+        "OPEN_LOGS",
+        "OPEN_DEBUG",
+        "RESET_REMOTE_TUNNEL",
+        "RESTART_APP",
+        NULL,
+    };
+    for (guint i = 0; expected_debug_labels[i]; i++) {
+        gboolean found = FALSE;
+        for (guint j = 0; j < oc_debug_action_count(); j++) {
+            const OcDebugActionSpec *spec = oc_debug_action_get((OcDebugAction)j);
+            if (spec->debug_page_label &&
+                g_strcmp0(spec->debug_page_label, expected_debug_labels[i]) == 0) {
+                found = TRUE; break;
+            }
+        }
+        if (!found) {
+            g_test_message("expected debug label not found: %s", expected_debug_labels[i]);
+            g_assert_not_reached();
+        }
+    }
+    for (guint i = 0; expected_tray_actions[i]; i++) {
+        OcDebugAction id;
+        if (!oc_debug_action_from_tray_string(expected_tray_actions[i], &id)) {
+            g_test_message("expected tray action not found: %s", expected_tray_actions[i]);
+            g_assert_not_reached();
+        }
+    }
+}
+
+static void test_from_tray_string_round_trip(void) {
+    for (guint i = 0; i < oc_debug_action_count(); i++) {
+        const OcDebugActionSpec *spec = oc_debug_action_get((OcDebugAction)i);
+        if (!spec->tray_action_string) continue;
+        OcDebugAction out = OC_DEBUG_ACTION_COUNT;
+        g_assert_true(oc_debug_action_from_tray_string(spec->tray_action_string, &out));
+        g_assert_cmpint((gint)out, ==, (gint)i);
+    }
+}
+
+static void test_from_tray_string_rejects_unknown(void) {
+    OcDebugAction out = OC_DEBUG_ACTION_COUNT;
+    g_assert_false(oc_debug_action_from_tray_string(NULL, NULL));
+    g_assert_false(oc_debug_action_from_tray_string(NULL, &out));
+    g_assert_false(oc_debug_action_from_tray_string("DOES_NOT_EXIST", &out));
+    g_assert_false(oc_debug_action_from_tray_string("", &out));
+    /* lower-case must NOT match an upper-case action. */
+    g_assert_false(oc_debug_action_from_tray_string("open_logs", &out));
+}
+
+static void test_from_tray_string_accepts_null_out(void) {
+    g_assert_true(oc_debug_action_from_tray_string("OPEN_LOGS", NULL));
+    g_assert_true(oc_debug_action_from_tray_string("RESTART_ONBOARDING", NULL));
+}
+
+static void test_dispatch_unknown_id(void) {
+    reset_all();
+    g_assert_false(oc_debug_action_dispatch(OC_DEBUG_ACTION_COUNT));
+    g_assert_false(oc_debug_action_dispatch((OcDebugAction)9999));
+    /* No side effects fired. */
+    g_assert_cmpuint(stub_gateway_refresh_calls, ==, 0);
+    g_assert_cmpuint(stub_systemd_restart_calls, ==, 0);
+}
+
+static void test_dispatch_trigger_health_refresh(void) {
+    reset_all();
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_TRIGGER_HEALTH_REFRESH));
+    g_assert_cmpuint(stub_gateway_refresh_calls, ==, 1);
+    g_assert_cmpuint(stub_systemd_restart_calls, ==, 0);
+}
+
+static void test_dispatch_restart_gateway(void) {
+    reset_all();
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_RESTART_GATEWAY));
+    g_assert_cmpuint(stub_systemd_restart_calls, ==, 1);
+    g_assert_cmpuint(stub_gateway_refresh_calls, ==, 0);
+}
+
+static void test_dispatch_restart_onboarding(void) {
+    reset_all();
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_RESTART_ONBOARDING));
+    g_assert_cmpuint(stub_rerun_onboarding_calls, ==, 1);
+}
+
+static void test_dispatch_send_test_notification(void) {
+    reset_all();
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_SEND_TEST_NOTIFICATION));
+    g_assert_cmpuint(stub_send_test_notification_calls, ==, 1);
+}
+
+static void test_dispatch_reveal_config_folder_invokes_uri_hook(void) {
+    reset_all();
+    stub_config_uri = g_strdup("file:///tmp/openclaw-config");
+
+    oc_debug_actions_set_uri_launcher(capture_uri_hook, GINT_TO_POINTER(0xC));
+
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_REVEAL_CONFIG_FOLDER));
+    g_assert_cmpuint(hook_uri_calls, ==, 1);
+    g_assert_cmpstr(hook_last_uri, ==, "file:///tmp/openclaw-config");
+    g_assert_cmpstr(oc_debug_actions_test_last_uri(), ==, "file:///tmp/openclaw-config");
+    g_assert_cmpint(GPOINTER_TO_INT(hook_last_user_data), ==, 0xC);
+}
+
+static void test_dispatch_reveal_state_folder_invokes_uri_hook(void) {
+    reset_all();
+    stub_state_uri = g_strdup("file:///tmp/openclaw-state");
+
+    oc_debug_actions_set_uri_launcher(capture_uri_hook, NULL);
+
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_REVEAL_STATE_FOLDER));
+    g_assert_cmpuint(hook_uri_calls, ==, 1);
+    g_assert_cmpstr(hook_last_uri, ==, "file:///tmp/openclaw-state");
+    g_assert_cmpstr(oc_debug_actions_test_last_uri(), ==, "file:///tmp/openclaw-state");
+}
+
+static void test_dispatch_reveal_skips_hook_when_uri_unresolved(void) {
+    reset_all();
+    /* Both stubs return NULL; dispatch must still succeed and must not
+     * call the hook with a NULL/empty URI. */
+    oc_debug_actions_set_uri_launcher(capture_uri_hook, NULL);
+
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_REVEAL_CONFIG_FOLDER));
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_REVEAL_STATE_FOLDER));
+    g_assert_cmpuint(hook_uri_calls, ==, 0);
+    g_assert_null(oc_debug_actions_test_last_uri());
+}
+
+static void test_dispatch_copy_journal_command_uses_canonical_unit(void) {
+    reset_all();
+    stub_unit_name = g_strdup("openclaw-gateway-special.service");
+
+    oc_debug_actions_set_clipboard_writer(capture_clipboard_hook, GINT_TO_POINTER(0xCB));
+
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_COPY_JOURNAL_COMMAND));
+    g_assert_cmpuint(hook_clipboard_calls, ==, 1);
+    g_assert_cmpstr(hook_last_clipboard,
+                    ==,
+                    "journalctl --user -u openclaw-gateway-special.service -f");
+    g_assert_cmpstr(oc_debug_actions_test_last_clipboard_text(),
+                    ==,
+                    "journalctl --user -u openclaw-gateway-special.service -f");
+    g_assert_cmpint(GPOINTER_TO_INT(hook_last_user_data), ==, 0xCB);
+}
+
+static void test_dispatch_copy_journal_command_falls_back_when_unit_unknown(void) {
+    reset_all();
+    /* stub_unit_name stays NULL — registry must fall back to default. */
+    oc_debug_actions_set_clipboard_writer(capture_clipboard_hook, NULL);
+
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_COPY_JOURNAL_COMMAND));
+    g_assert_cmpstr(hook_last_clipboard,
+                    ==,
+                    "journalctl --user -u openclaw-gateway.service -f");
+}
+
+static void test_dispatch_open_logs_routes_to_logs_target(void) {
+    reset_all();
+    oc_debug_actions_set_show_section_handler(capture_show_section_hook,
+                                              GINT_TO_POINTER(0x1065));
+
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_OPEN_LOGS));
+    g_assert_cmpuint(hook_show_section_calls, ==, 1);
+    g_assert_cmpint(hook_last_section_target, ==, OC_DEBUG_SECTION_TARGET_LOGS);
+    g_assert_true(oc_debug_actions_test_section_was_requested());
+    g_assert_cmpint(oc_debug_actions_test_last_section_target(), ==, OC_DEBUG_SECTION_TARGET_LOGS);
+}
+
+static void test_dispatch_open_debug_routes_to_debug_target(void) {
+    reset_all();
+    oc_debug_actions_set_show_section_handler(capture_show_section_hook, NULL);
+
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_OPEN_DEBUG));
+    g_assert_cmpuint(hook_show_section_calls, ==, 1);
+    g_assert_cmpint(hook_last_section_target, ==, OC_DEBUG_SECTION_TARGET_DEBUG);
+    g_assert_cmpint(oc_debug_actions_test_last_section_target(), ==, OC_DEBUG_SECTION_TARGET_DEBUG);
+}
+
+static void test_dispatch_reset_remote_tunnel_returns_false(void) {
+    /* No production reset API exists yet (see TODO in debug_actions.c).
+     * Until it does, dispatch must report FALSE so the host treats this
+     * as not-implemented. */
+    reset_all();
+    g_assert_false(oc_debug_action_dispatch(OC_DEBUG_ACTION_RESET_REMOTE_TUNNEL));
+}
+
+static void test_dispatch_restart_app_invokes_helper_when_available(void) {
+    reset_all();
+    stub_app_restart_result = TRUE;
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_RESTART_APP));
+    g_assert_cmpuint(stub_app_restart_calls, ==, 1);
+}
+
+static void test_dispatch_restart_app_propagates_failure(void) {
+    reset_all();
+    stub_app_restart_result = FALSE;
+    g_assert_false(oc_debug_action_dispatch(OC_DEBUG_ACTION_RESTART_APP));
+    g_assert_cmpuint(stub_app_restart_calls, ==, 1);
+}
+
+static void test_dispatch_show_section_safe_without_hook(void) {
+    reset_all();
+    /* No hook installed. Registry should still capture the request and
+     * not crash. */
+    g_assert_true(oc_debug_action_dispatch(OC_DEBUG_ACTION_OPEN_LOGS));
+    g_assert_cmpuint(hook_show_section_calls, ==, 0);
+    g_assert_true(oc_debug_actions_test_section_was_requested());
+}
+
+static void test_tray_dispatch_via_registry_round_trip(void) {
+    /* Simulates `tray.c::handle_helper_action` for an action that the
+     * legacy ladder no longer owns: route through the registry by
+     * string and ensure the side effect fires exactly once. */
+    reset_all();
+
+    OcDebugAction id = OC_DEBUG_ACTION_COUNT;
+    g_assert_true(oc_debug_action_from_tray_string("RESTART_ONBOARDING", &id));
+    g_assert_cmpint((gint)id, ==, (gint)OC_DEBUG_ACTION_RESTART_ONBOARDING);
+    g_assert_true(oc_debug_action_dispatch(id));
+    g_assert_cmpuint(stub_rerun_onboarding_calls, ==, 1);
+}
+
+static void test_tray_dispatch_unknown_action_is_harmless(void) {
+    reset_all();
+    OcDebugAction id = OC_DEBUG_ACTION_COUNT;
+    g_assert_false(oc_debug_action_from_tray_string("PROBABLY_NOT_A_REAL_ACTION", &id));
+    g_assert_cmpuint(stub_rerun_onboarding_calls, ==, 0);
+    g_assert_cmpuint(stub_gateway_refresh_calls, ==, 0);
+    g_assert_cmpuint(stub_systemd_restart_calls, ==, 0);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/debug_actions/registry_count_matches_enum",
+                    test_registry_count_matches_enum);
+    g_test_add_func("/debug_actions/registry_get_returns_consistent_specs",
+                    test_registry_get_returns_consistent_specs);
+    g_test_add_func("/debug_actions/registry_tray_action_strings_unique",
+                    test_registry_tray_action_strings_unique);
+    g_test_add_func("/debug_actions/registry_expected_labels_exist",
+                    test_registry_expected_labels_exist);
+    g_test_add_func("/debug_actions/from_tray_string_round_trip",
+                    test_from_tray_string_round_trip);
+    g_test_add_func("/debug_actions/from_tray_string_rejects_unknown",
+                    test_from_tray_string_rejects_unknown);
+    g_test_add_func("/debug_actions/from_tray_string_accepts_null_out",
+                    test_from_tray_string_accepts_null_out);
+    g_test_add_func("/debug_actions/dispatch_unknown_id",
+                    test_dispatch_unknown_id);
+    g_test_add_func("/debug_actions/dispatch_trigger_health_refresh",
+                    test_dispatch_trigger_health_refresh);
+    g_test_add_func("/debug_actions/dispatch_restart_gateway",
+                    test_dispatch_restart_gateway);
+    g_test_add_func("/debug_actions/dispatch_restart_onboarding",
+                    test_dispatch_restart_onboarding);
+    g_test_add_func("/debug_actions/dispatch_send_test_notification",
+                    test_dispatch_send_test_notification);
+    g_test_add_func("/debug_actions/dispatch_reveal_config_folder",
+                    test_dispatch_reveal_config_folder_invokes_uri_hook);
+    g_test_add_func("/debug_actions/dispatch_reveal_state_folder",
+                    test_dispatch_reveal_state_folder_invokes_uri_hook);
+    g_test_add_func("/debug_actions/dispatch_reveal_skips_hook_when_uri_unresolved",
+                    test_dispatch_reveal_skips_hook_when_uri_unresolved);
+    g_test_add_func("/debug_actions/dispatch_copy_journal_command",
+                    test_dispatch_copy_journal_command_uses_canonical_unit);
+    g_test_add_func("/debug_actions/dispatch_copy_journal_command_fallback",
+                    test_dispatch_copy_journal_command_falls_back_when_unit_unknown);
+    g_test_add_func("/debug_actions/dispatch_open_logs",
+                    test_dispatch_open_logs_routes_to_logs_target);
+    g_test_add_func("/debug_actions/dispatch_open_debug",
+                    test_dispatch_open_debug_routes_to_debug_target);
+    g_test_add_func("/debug_actions/dispatch_reset_remote_tunnel_returns_false",
+                    test_dispatch_reset_remote_tunnel_returns_false);
+    g_test_add_func("/debug_actions/dispatch_restart_app_invokes_helper_when_available",
+                    test_dispatch_restart_app_invokes_helper_when_available);
+    g_test_add_func("/debug_actions/dispatch_restart_app_propagates_failure",
+                    test_dispatch_restart_app_propagates_failure);
+    g_test_add_func("/debug_actions/dispatch_show_section_safe_without_hook",
+                    test_dispatch_show_section_safe_without_hook);
+    g_test_add_func("/debug_actions/tray_dispatch_via_registry_round_trip",
+                    test_tray_dispatch_via_registry_round_trip);
+    g_test_add_func("/debug_actions/tray_dispatch_unknown_action_is_harmless",
+                    test_tray_dispatch_unknown_action_is_harmless);
+
+    int rc = g_test_run();
+    reset_all();
+    return rc;
+}

--- a/apps/linux/tests/test_exec_approval_tray_model.c
+++ b/apps/linux/tests/test_exec_approval_tray_model.c
@@ -1,0 +1,82 @@
+/*
+ * test_exec_approval_tray_model.c
+ *
+ * Pure-C regression for the OcExecQuickMode <-> wire token mapping
+ * exposed by `exec_approval_tray_model.{c,h}`. Locks down the canonical
+ * lower-case "deny" / "ask" / "allow" tokens so the tray protocol stays
+ * stable across renames or refactors of the underlying enum.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include <glib.h>
+
+#include "../src/exec_approval_tray_model.h"
+
+static void test_to_string_roundtrip(void) {
+    g_assert_cmpstr(exec_approval_tray_mode_to_string(OC_EXEC_QUICK_MODE_DENY),  ==, "deny");
+    g_assert_cmpstr(exec_approval_tray_mode_to_string(OC_EXEC_QUICK_MODE_ASK),   ==, "ask");
+    g_assert_cmpstr(exec_approval_tray_mode_to_string(OC_EXEC_QUICK_MODE_ALLOW), ==, "allow");
+}
+
+static void test_to_string_unknown_returns_null(void) {
+    g_assert_null(exec_approval_tray_mode_to_string((OcExecQuickMode)999));
+    g_assert_null(exec_approval_tray_mode_to_string((OcExecQuickMode)-1));
+}
+
+static void test_from_string_known_modes(void) {
+    OcExecQuickMode out = (OcExecQuickMode)999;
+
+    g_assert_true(exec_approval_tray_mode_from_string("deny", &out));
+    g_assert_cmpint(out, ==, OC_EXEC_QUICK_MODE_DENY);
+
+    g_assert_true(exec_approval_tray_mode_from_string("ask", &out));
+    g_assert_cmpint(out, ==, OC_EXEC_QUICK_MODE_ASK);
+
+    g_assert_true(exec_approval_tray_mode_from_string("allow", &out));
+    g_assert_cmpint(out, ==, OC_EXEC_QUICK_MODE_ALLOW);
+}
+
+static void test_from_string_rejects_unknown(void) {
+    OcExecQuickMode out = OC_EXEC_QUICK_MODE_ASK;
+    g_assert_false(exec_approval_tray_mode_from_string(NULL, &out));
+    g_assert_false(exec_approval_tray_mode_from_string("", &out));
+    g_assert_false(exec_approval_tray_mode_from_string("Deny", &out));    /* case sensitive */
+    g_assert_false(exec_approval_tray_mode_from_string("ALLOW", &out));
+    g_assert_false(exec_approval_tray_mode_from_string("never", &out));
+    g_assert_false(exec_approval_tray_mode_from_string("ask ", &out));    /* trailing space */
+    /* `out` must be untouched on failure. */
+    g_assert_cmpint(out, ==, OC_EXEC_QUICK_MODE_ASK);
+}
+
+static void test_from_string_accepts_null_out(void) {
+    g_assert_true(exec_approval_tray_mode_from_string("ask", NULL));
+    g_assert_false(exec_approval_tray_mode_from_string("nope", NULL));
+}
+
+static void test_round_trip_for_each_mode(void) {
+    const OcExecQuickMode modes[] = {
+        OC_EXEC_QUICK_MODE_DENY, OC_EXEC_QUICK_MODE_ASK, OC_EXEC_QUICK_MODE_ALLOW,
+    };
+    for (gsize i = 0; i < G_N_ELEMENTS(modes); i++) {
+        const char *token = exec_approval_tray_mode_to_string(modes[i]);
+        g_assert_nonnull(token);
+        OcExecQuickMode roundtrip = (OcExecQuickMode)999;
+        g_assert_true(exec_approval_tray_mode_from_string(token, &roundtrip));
+        g_assert_cmpint(roundtrip, ==, modes[i]);
+    }
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/exec_approval_tray_model/to_string_roundtrip",         test_to_string_roundtrip);
+    g_test_add_func("/exec_approval_tray_model/to_string_unknown_returns_null",
+                    test_to_string_unknown_returns_null);
+    g_test_add_func("/exec_approval_tray_model/from_string_known_modes",     test_from_string_known_modes);
+    g_test_add_func("/exec_approval_tray_model/from_string_rejects_unknown", test_from_string_rejects_unknown);
+    g_test_add_func("/exec_approval_tray_model/from_string_accepts_null_out", test_from_string_accepts_null_out);
+    g_test_add_func("/exec_approval_tray_model/round_trip_for_each_mode",    test_round_trip_for_each_mode);
+
+    return g_test_run();
+}

--- a/apps/linux/tests/test_section_debug.c
+++ b/apps/linux/tests/test_section_debug.c
@@ -1,11 +1,14 @@
 #include <glib.h>
 
+#include "../src/debug_actions.h"
 #include "../src/section_debug.h"
 #include "../src/gateway_config.h"
 #include "../src/runtime_paths.h"
 #include "../src/state.h"
 
 void gateway_client_refresh(void) {}
+gboolean notify_send_test_notification(void) { return FALSE; }
+gboolean app_restart_request(void) { return FALSE; }
 static GatewayConfig stub_cfg = {0};
 static gchar *stub_runtime_profile = NULL;
 static gchar *stub_runtime_state_dir = NULL;
@@ -69,9 +72,35 @@ static void test_debug_actions_exclude_duplicate_diagnostics_affordance(void) {
     g_assert_true(section_debug_test_has_action_label("Trigger Health Refresh"));
     g_assert_true(section_debug_test_has_action_label("Restart Gateway"));
     g_assert_true(section_debug_test_has_action_label("Reveal Config Folder"));
+    g_assert_true(section_debug_test_has_action_label("Reveal State Folder"));
     g_assert_true(section_debug_test_has_action_label("Restart Onboarding"));
+    g_assert_true(section_debug_test_has_action_label("Copy Journal Command"));
+    g_assert_true(section_debug_test_has_action_label("Send Test Notification"));
+    g_assert_true(section_debug_test_has_action_label("Restart App"));
     g_assert_false(section_debug_test_has_action_label("Copy Diagnostics Dump"));
     g_assert_false(section_debug_test_has_action_label("Copy Diagnostics"));
+}
+
+/*
+ * Cross-check the registry against the Debug section: every registry
+ * entry that carries a `debug_page_label` MUST be reachable via
+ * section_debug_test_has_action_label. This is the structural guarantee
+ * Tranche D promises — adding a new debug-class action to the registry
+ * lights it up in the Debug section without a separate edit.
+ */
+static void test_debug_section_includes_every_registry_debug_label(void) {
+    guint n = oc_debug_action_count();
+    g_assert_cmpuint(n, ==, (guint)OC_DEBUG_ACTION_COUNT);
+    for (guint i = 0; i < n; i++) {
+        const OcDebugActionSpec *spec = oc_debug_action_get((OcDebugAction)i);
+        g_assert_nonnull(spec);
+        if (!spec->debug_page_label) continue;
+        if (!section_debug_test_has_action_label(spec->debug_page_label)) {
+            g_test_message("registry entry %u (%s) is not exposed in Debug section",
+                           i, spec->debug_page_label);
+            g_assert_not_reached();
+        }
+    }
 }
 
 static void test_debug_reveal_config_uri_uses_effective_runtime_path(void) {
@@ -109,6 +138,8 @@ int main(int argc, char **argv) {
 
     g_test_add_func("/section_debug/actions_exclude_duplicate_diagnostics_affordance",
                     test_debug_actions_exclude_duplicate_diagnostics_affordance);
+    g_test_add_func("/section_debug/includes_every_registry_debug_label",
+                    test_debug_section_includes_every_registry_debug_label);
     g_test_add_func("/section_debug/reveal_config_uri_uses_effective_runtime_path",
                     test_debug_reveal_config_uri_uses_effective_runtime_path);
     g_test_add_func("/section_debug/reveal_config_uri_returns_null_without_effective_path",

--- a/apps/linux/tests/test_tray_helper_protocol.c
+++ b/apps/linux/tests/test_tray_helper_protocol.c
@@ -1,0 +1,260 @@
+/*
+ * test_tray_helper_protocol.c
+ *
+ * Hermetic regression for the helper-side parser/applier that handles
+ * MENU_VISIBLE / RADIO:EXEC_APPROVAL / APPROVALS lines. The test
+ * installs capture callbacks instead of GTK widgets so the suite runs
+ * without a display.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include <glib.h>
+#include <string.h>
+
+#include "../src/tray_helper_protocol.h"
+
+typedef struct {
+    guint              menu_visible_calls;
+    TrayHelperMenuKey  last_menu_key;
+    gboolean           last_menu_visible;
+
+    guint              radio_calls;
+    gchar             *last_radio_mode;
+
+    guint              approvals_calls;
+    guint              last_approvals_count;
+} CaptureState;
+
+static void capture_menu_visible(TrayHelperMenuKey key, gboolean visible, gpointer ud) {
+    CaptureState *s = ud;
+    s->menu_visible_calls++;
+    s->last_menu_key = key;
+    s->last_menu_visible = visible;
+}
+
+static void capture_radio(const char *mode, gpointer ud) {
+    CaptureState *s = ud;
+    s->radio_calls++;
+    g_free(s->last_radio_mode);
+    s->last_radio_mode = g_strdup(mode);
+}
+
+static void capture_approvals(guint count, gpointer ud) {
+    CaptureState *s = ud;
+    s->approvals_calls++;
+    s->last_approvals_count = count;
+}
+
+static TrayHelperProtocolHandlers make_handlers(CaptureState *s) {
+    return (TrayHelperProtocolHandlers){
+        .set_menu_visible          = capture_menu_visible,
+        .set_radio_exec_approval   = capture_radio,
+        .set_approvals_count       = capture_approvals,
+        .user_data                 = s,
+    };
+}
+
+static void capture_state_clear(CaptureState *s) {
+    g_free(s->last_radio_mode);
+    memset(s, 0, sizeof(*s));
+}
+
+/* ── menu key parser ───────────────────────────────────────── */
+
+static void test_menu_key_from_string_known(void) {
+    g_assert_cmpint(tray_helper_protocol_menu_key_from_string("OPEN_DEBUG"),          ==, TRAY_HELPER_MENU_KEY_OPEN_DEBUG);
+    g_assert_cmpint(tray_helper_protocol_menu_key_from_string("EXEC_APPROVAL"),       ==, TRAY_HELPER_MENU_KEY_EXEC_APPROVAL);
+    g_assert_cmpint(tray_helper_protocol_menu_key_from_string("APPROVALS_PENDING"),   ==, TRAY_HELPER_MENU_KEY_APPROVALS_PENDING);
+    g_assert_cmpint(tray_helper_protocol_menu_key_from_string("RESET_REMOTE_TUNNEL"), ==, TRAY_HELPER_MENU_KEY_RESET_REMOTE_TUNNEL);
+    g_assert_cmpint(tray_helper_protocol_menu_key_from_string("RESTART_APP"),         ==, TRAY_HELPER_MENU_KEY_RESTART_APP);
+}
+
+static void test_menu_key_from_string_unknown(void) {
+    g_assert_cmpint(tray_helper_protocol_menu_key_from_string(NULL),         ==, TRAY_HELPER_MENU_KEY_UNKNOWN);
+    g_assert_cmpint(tray_helper_protocol_menu_key_from_string(""),           ==, TRAY_HELPER_MENU_KEY_UNKNOWN);
+    g_assert_cmpint(tray_helper_protocol_menu_key_from_string("open_debug"), ==, TRAY_HELPER_MENU_KEY_UNKNOWN);
+    g_assert_cmpint(tray_helper_protocol_menu_key_from_string("OTHER"),      ==, TRAY_HELPER_MENU_KEY_UNKNOWN);
+}
+
+/* ── apply_line: MENU_VISIBLE ────────────────────────────── */
+
+static void test_apply_menu_visible_show(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+    g_assert_true(tray_helper_protocol_apply_line(&h, "MENU_VISIBLE:OPEN_DEBUG:1"));
+    g_assert_cmpuint(s.menu_visible_calls, ==, 1);
+    g_assert_cmpint(s.last_menu_key, ==, TRAY_HELPER_MENU_KEY_OPEN_DEBUG);
+    g_assert_true(s.last_menu_visible);
+    capture_state_clear(&s);
+}
+
+static void test_apply_menu_visible_hide(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+    g_assert_true(tray_helper_protocol_apply_line(&h, "MENU_VISIBLE:RESET_REMOTE_TUNNEL:0"));
+    g_assert_cmpuint(s.menu_visible_calls, ==, 1);
+    g_assert_cmpint(s.last_menu_key, ==, TRAY_HELPER_MENU_KEY_RESET_REMOTE_TUNNEL);
+    g_assert_false(s.last_menu_visible);
+    capture_state_clear(&s);
+}
+
+static void test_apply_menu_visible_unknown_key_ignored(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+    g_assert_false(tray_helper_protocol_apply_line(&h, "MENU_VISIBLE:NOPE:1"));
+    g_assert_cmpuint(s.menu_visible_calls, ==, 0);
+    capture_state_clear(&s);
+}
+
+static void test_apply_menu_visible_invalid_flag(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+    g_assert_false(tray_helper_protocol_apply_line(&h, "MENU_VISIBLE:OPEN_DEBUG:2"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, "MENU_VISIBLE:OPEN_DEBUG:"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, "MENU_VISIBLE:OPEN_DEBUG:11"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, "MENU_VISIBLE::1"));
+    g_assert_cmpuint(s.menu_visible_calls, ==, 0);
+    capture_state_clear(&s);
+}
+
+/* ── apply_line: RADIO ──────────────────────────────────── */
+
+static void test_apply_radio_each_mode(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+
+    g_assert_true(tray_helper_protocol_apply_line(&h, "RADIO:EXEC_APPROVAL:deny"));
+    g_assert_cmpstr(s.last_radio_mode, ==, "deny");
+    g_assert_true(tray_helper_protocol_apply_line(&h, "RADIO:EXEC_APPROVAL:ask"));
+    g_assert_cmpstr(s.last_radio_mode, ==, "ask");
+    g_assert_true(tray_helper_protocol_apply_line(&h, "RADIO:EXEC_APPROVAL:allow"));
+    g_assert_cmpstr(s.last_radio_mode, ==, "allow");
+
+    g_assert_cmpuint(s.radio_calls, ==, 3);
+    capture_state_clear(&s);
+}
+
+static void test_apply_radio_invalid_mode_ignored(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+    g_assert_false(tray_helper_protocol_apply_line(&h, "RADIO:EXEC_APPROVAL:nope"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, "RADIO:EXEC_APPROVAL:"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, "RADIO:EXEC_APPROVAL:Ask"));
+    g_assert_cmpuint(s.radio_calls, ==, 0);
+    capture_state_clear(&s);
+}
+
+/* ── apply_line: APPROVALS ─────────────────────────────── */
+
+static void test_apply_approvals_zero(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+    g_assert_true(tray_helper_protocol_apply_line(&h, "APPROVALS:0"));
+    g_assert_cmpuint(s.approvals_calls, ==, 1);
+    g_assert_cmpuint(s.last_approvals_count, ==, 0);
+    capture_state_clear(&s);
+}
+
+static void test_apply_approvals_nonzero(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+    g_assert_true(tray_helper_protocol_apply_line(&h, "APPROVALS:7"));
+    g_assert_cmpuint(s.last_approvals_count, ==, 7);
+    capture_state_clear(&s);
+}
+
+static void test_apply_approvals_rejects_garbage(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+    g_assert_false(tray_helper_protocol_apply_line(&h, "APPROVALS:"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, "APPROVALS:abc"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, "APPROVALS:-1"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, "APPROVALS:1.5"));
+    g_assert_cmpuint(s.approvals_calls, ==, 0);
+    capture_state_clear(&s);
+}
+
+/* ── apply_line: ignored prefixes ────────────────────── */
+
+static void test_apply_unrecognised_prefix_returns_false(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+    g_assert_false(tray_helper_protocol_apply_line(&h, "STATE:Running"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, "RUNTIME:foo"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, "SENSITIVE:START:1"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, ""));
+    g_assert_false(tray_helper_protocol_apply_line(&h, NULL));
+    g_assert_cmpuint(s.menu_visible_calls + s.radio_calls + s.approvals_calls, ==, 0);
+    capture_state_clear(&s);
+}
+
+static void test_apply_with_null_handlers_still_classifies(void) {
+    /* Passing NULL handlers must not crash: the function still returns
+     * TRUE/FALSE based on whether the line shape is recognised. */
+    g_assert_true (tray_helper_protocol_apply_line(NULL, "MENU_VISIBLE:OPEN_DEBUG:1"));
+    g_assert_true (tray_helper_protocol_apply_line(NULL, "RADIO:EXEC_APPROVAL:ask"));
+    g_assert_true (tray_helper_protocol_apply_line(NULL, "APPROVALS:3"));
+    g_assert_false(tray_helper_protocol_apply_line(NULL, "STATE:foo"));
+}
+
+/* ── pending-approvals label formatter ───────────────── */
+
+static void test_format_approvals_label_zero(void) {
+    g_autofree gchar *s = tray_helper_protocol_format_approvals_label(0);
+    g_assert_cmpstr(s, ==, "Exec Approvals: 0 pending");
+}
+
+static void test_format_approvals_label_one(void) {
+    g_autofree gchar *s = tray_helper_protocol_format_approvals_label(1);
+    g_assert_cmpstr(s, ==, "Exec Approvals: 1 pending");
+}
+
+static void test_format_approvals_label_many(void) {
+    g_autofree gchar *s = tray_helper_protocol_format_approvals_label(13);
+    g_assert_cmpstr(s, ==, "Exec Approvals: 13 pending");
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/tray_helper_protocol/menu_key_from_string_known",
+                    test_menu_key_from_string_known);
+    g_test_add_func("/tray_helper_protocol/menu_key_from_string_unknown",
+                    test_menu_key_from_string_unknown);
+
+    g_test_add_func("/tray_helper_protocol/apply_menu_visible_show",
+                    test_apply_menu_visible_show);
+    g_test_add_func("/tray_helper_protocol/apply_menu_visible_hide",
+                    test_apply_menu_visible_hide);
+    g_test_add_func("/tray_helper_protocol/apply_menu_visible_unknown_key_ignored",
+                    test_apply_menu_visible_unknown_key_ignored);
+    g_test_add_func("/tray_helper_protocol/apply_menu_visible_invalid_flag",
+                    test_apply_menu_visible_invalid_flag);
+
+    g_test_add_func("/tray_helper_protocol/apply_radio_each_mode",
+                    test_apply_radio_each_mode);
+    g_test_add_func("/tray_helper_protocol/apply_radio_invalid_mode_ignored",
+                    test_apply_radio_invalid_mode_ignored);
+
+    g_test_add_func("/tray_helper_protocol/apply_approvals_zero",
+                    test_apply_approvals_zero);
+    g_test_add_func("/tray_helper_protocol/apply_approvals_nonzero",
+                    test_apply_approvals_nonzero);
+    g_test_add_func("/tray_helper_protocol/apply_approvals_rejects_garbage",
+                    test_apply_approvals_rejects_garbage);
+
+    g_test_add_func("/tray_helper_protocol/apply_unrecognised_prefix_returns_false",
+                    test_apply_unrecognised_prefix_returns_false);
+    g_test_add_func("/tray_helper_protocol/apply_with_null_handlers_still_classifies",
+                    test_apply_with_null_handlers_still_classifies);
+
+    g_test_add_func("/tray_helper_protocol/format_approvals_label_zero",
+                    test_format_approvals_label_zero);
+    g_test_add_func("/tray_helper_protocol/format_approvals_label_one",
+                    test_format_approvals_label_one);
+    g_test_add_func("/tray_helper_protocol/format_approvals_label_many",
+                    test_format_approvals_label_many);
+
+    return g_test_run();
+}

--- a/apps/linux/tests/test_tray_protocol.c
+++ b/apps/linux/tests/test_tray_protocol.c
@@ -1,0 +1,153 @@
+/*
+ * test_tray_protocol.c
+ *
+ * Pure-C regression suite for `tray_protocol.{c,h}`. Locks down the
+ * line-format grammar shared between the OpenClaw Linux companion and
+ * its private tray helper:
+ *
+ *   - MENU_VISIBLE formatting (true/false, NULL/empty rejection)
+ *   - RADIO:EXEC_APPROVAL formatting (deny/ask/allow only)
+ *   - APPROVALS formatting (zero, one, large count)
+ *   - EXEC_APPROVAL_SET parsing and validity probes
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include <glib.h>
+#include <string.h>
+
+#include "../src/tray_protocol.h"
+
+static void test_format_menu_visible_true(void) {
+    g_autofree gchar *line = tray_protocol_format_menu_visible("OPEN_DEBUG", TRUE);
+    g_assert_cmpstr(line, ==, "MENU_VISIBLE:OPEN_DEBUG:1\n");
+}
+
+static void test_format_menu_visible_false(void) {
+    g_autofree gchar *line = tray_protocol_format_menu_visible("RESET_REMOTE_TUNNEL", FALSE);
+    g_assert_cmpstr(line, ==, "MENU_VISIBLE:RESET_REMOTE_TUNNEL:0\n");
+}
+
+static void test_format_menu_visible_null_action_returns_null(void) {
+    g_assert_null(tray_protocol_format_menu_visible(NULL, TRUE));
+    g_assert_null(tray_protocol_format_menu_visible("", TRUE));
+}
+
+static void test_format_radio_deny(void) {
+    g_autofree gchar *line = tray_protocol_format_radio_exec_approval("deny");
+    g_assert_cmpstr(line, ==, "RADIO:EXEC_APPROVAL:deny\n");
+}
+
+static void test_format_radio_ask(void) {
+    g_autofree gchar *line = tray_protocol_format_radio_exec_approval("ask");
+    g_assert_cmpstr(line, ==, "RADIO:EXEC_APPROVAL:ask\n");
+}
+
+static void test_format_radio_allow(void) {
+    g_autofree gchar *line = tray_protocol_format_radio_exec_approval("allow");
+    g_assert_cmpstr(line, ==, "RADIO:EXEC_APPROVAL:allow\n");
+}
+
+static void test_format_radio_invalid_mode_returns_null(void) {
+    g_assert_null(tray_protocol_format_radio_exec_approval(NULL));
+    g_assert_null(tray_protocol_format_radio_exec_approval(""));
+    g_assert_null(tray_protocol_format_radio_exec_approval("Deny"));   /* case sensitive */
+    g_assert_null(tray_protocol_format_radio_exec_approval("ALLOW"));
+    g_assert_null(tray_protocol_format_radio_exec_approval("nope"));
+    g_assert_null(tray_protocol_format_radio_exec_approval("ask "));   /* trailing space */
+}
+
+static void test_format_approvals_zero(void) {
+    g_autofree gchar *line = tray_protocol_format_approvals(0);
+    g_assert_cmpstr(line, ==, "APPROVALS:0\n");
+}
+
+static void test_format_approvals_one(void) {
+    g_autofree gchar *line = tray_protocol_format_approvals(1);
+    g_assert_cmpstr(line, ==, "APPROVALS:1\n");
+}
+
+static void test_format_approvals_large(void) {
+    g_autofree gchar *line = tray_protocol_format_approvals(42);
+    g_assert_cmpstr(line, ==, "APPROVALS:42\n");
+}
+
+static void test_mode_is_valid(void) {
+    g_assert_true(tray_protocol_exec_approval_mode_is_valid("deny"));
+    g_assert_true(tray_protocol_exec_approval_mode_is_valid("ask"));
+    g_assert_true(tray_protocol_exec_approval_mode_is_valid("allow"));
+    g_assert_false(tray_protocol_exec_approval_mode_is_valid(NULL));
+    g_assert_false(tray_protocol_exec_approval_mode_is_valid(""));
+    g_assert_false(tray_protocol_exec_approval_mode_is_valid("Ask"));
+    g_assert_false(tray_protocol_exec_approval_mode_is_valid("never"));
+}
+
+static void test_parse_exec_approval_action_deny(void) {
+    char *mode = NULL;
+    g_assert_true(tray_protocol_parse_exec_approval_action("EXEC_APPROVAL_SET:deny", &mode));
+    g_assert_cmpstr(mode, ==, "deny");
+    g_free(mode);
+}
+
+static void test_parse_exec_approval_action_ask(void) {
+    char *mode = NULL;
+    g_assert_true(tray_protocol_parse_exec_approval_action("EXEC_APPROVAL_SET:ask", &mode));
+    g_assert_cmpstr(mode, ==, "ask");
+    g_free(mode);
+}
+
+static void test_parse_exec_approval_action_allow(void) {
+    char *mode = NULL;
+    g_assert_true(tray_protocol_parse_exec_approval_action("EXEC_APPROVAL_SET:allow", &mode));
+    g_assert_cmpstr(mode, ==, "allow");
+    g_free(mode);
+}
+
+static void test_parse_exec_approval_action_accepts_null_out(void) {
+    g_assert_true(tray_protocol_parse_exec_approval_action("EXEC_APPROVAL_SET:ask", NULL));
+}
+
+static void test_parse_exec_approval_action_rejects_invalid(void) {
+    char *mode = NULL;
+    g_assert_false(tray_protocol_parse_exec_approval_action(NULL, &mode));
+    g_assert_false(tray_protocol_parse_exec_approval_action("", &mode));
+    g_assert_false(tray_protocol_parse_exec_approval_action("EXEC_APPROVAL_SET:", &mode));
+    g_assert_false(tray_protocol_parse_exec_approval_action("EXEC_APPROVAL_SET:never", &mode));
+    g_assert_false(tray_protocol_parse_exec_approval_action("EXEC_APPROVAL_SET:Ask", &mode));
+    g_assert_false(tray_protocol_parse_exec_approval_action("EXEC_APPROVAL_SET:ask:extra", &mode));
+    g_assert_false(tray_protocol_parse_exec_approval_action("OPEN_LOGS", &mode));
+    g_assert_false(tray_protocol_parse_exec_approval_action("EXEC_APPROVAL:ask", &mode));
+    g_assert_false(tray_protocol_parse_exec_approval_action("EXEC_APPROVAL_SET:ask\n", &mode));
+    g_assert_false(tray_protocol_parse_exec_approval_action("EXEC_APPROVAL_SET:ask ", &mode));
+    g_assert_null(mode);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/tray_protocol/format_menu_visible_true", test_format_menu_visible_true);
+    g_test_add_func("/tray_protocol/format_menu_visible_false", test_format_menu_visible_false);
+    g_test_add_func("/tray_protocol/format_menu_visible_null_action_returns_null",
+                    test_format_menu_visible_null_action_returns_null);
+    g_test_add_func("/tray_protocol/format_radio_deny", test_format_radio_deny);
+    g_test_add_func("/tray_protocol/format_radio_ask", test_format_radio_ask);
+    g_test_add_func("/tray_protocol/format_radio_allow", test_format_radio_allow);
+    g_test_add_func("/tray_protocol/format_radio_invalid_mode_returns_null",
+                    test_format_radio_invalid_mode_returns_null);
+    g_test_add_func("/tray_protocol/format_approvals_zero", test_format_approvals_zero);
+    g_test_add_func("/tray_protocol/format_approvals_one", test_format_approvals_one);
+    g_test_add_func("/tray_protocol/format_approvals_large", test_format_approvals_large);
+    g_test_add_func("/tray_protocol/mode_is_valid", test_mode_is_valid);
+    g_test_add_func("/tray_protocol/parse_exec_approval_action_deny",
+                    test_parse_exec_approval_action_deny);
+    g_test_add_func("/tray_protocol/parse_exec_approval_action_ask",
+                    test_parse_exec_approval_action_ask);
+    g_test_add_func("/tray_protocol/parse_exec_approval_action_allow",
+                    test_parse_exec_approval_action_allow);
+    g_test_add_func("/tray_protocol/parse_exec_approval_action_accepts_null_out",
+                    test_parse_exec_approval_action_accepts_null_out);
+    g_test_add_func("/tray_protocol/parse_exec_approval_action_rejects_invalid",
+                    test_parse_exec_approval_action_rejects_invalid);
+
+    return g_test_run();
+}


### PR DESCRIPTION
Add a shared Linux debug-action registry and route tray and Debug-section operational actions through one dispatch surface.

Extend the tray helper protocol with pure-C formatters and parsers for dynamic menu visibility, exec approval radio state, and pending approval counts. Add helper-side protocol application so the GTK tray helper can show or hide menu items, update the Exec Approvals submenu, and render pending approval state without duplicating protocol logic.

Add Restart App support, expose test notifications through a public notification helper, add exec approval tray-mode mapping, and expand the tray UI with Logs, Debug, Restart Onboarding, folder reveal actions, Copy Journal Command, Send Test Notification, Restart App, Exec Approvals, and pending approval status.

Keep Reset Remote Tunnel hidden until a real production reset API exists, and add focused tests for registry, protocol, restart, approval-mode mapping, and Debug-section parity.