### PR TITLE
feat(linux): add deep links and behavior toggles (#124)

### DIFF
--- a/apps/linux/ai.openclaw.Companion.desktop
+++ b/apps/linux/ai.openclaw.Companion.desktop
@@ -1,6 +1,8 @@
 [Desktop Entry]
 Type=Application
 Name=OpenClaw Companion
-Exec=openclaw-linux
+Exec=openclaw-linux %U
 Terminal=false
 Categories=Utility;
+MimeType=x-scheme-handler/openclaw;
+StartupNotify=false

--- a/apps/linux/meson.build
+++ b/apps/linux/meson.build
@@ -40,6 +40,10 @@ add_project_arguments('-DOPENCLAW_BUILD_TIMESTAMP="' + build_timestamp + '"', la
 # Main app (GTK4 + Libadwaita + JSON-GLib + libsoup-3.0 + GIO)
 sources = [
   'src/main.c',
+  'src/main_open_dispatch.c',
+  'src/deep_link.c',
+  'src/browser_control_state.c',
+  'src/config_browser_toggle.c',
   'src/tray.c',
   'src/systemd.c',
   'src/systemd_helpers.c',
@@ -301,6 +305,13 @@ test_tray_protocol_exe = executable('test_tray_protocol',
   dependencies : [glib_dep])
 test('tray_protocol', test_tray_protocol_exe)
 
+# Pure-C regression for the openclaw:// deep-link parser. Headless;
+# only glib is needed (uses GUri for RFC-3986 parsing).
+test_deep_link_exe = executable('test_deep_link',
+  ['tests/test_deep_link.c', 'src/deep_link.c'],
+  dependencies : [glib_dep])
+test('deep_link', test_deep_link_exe)
+
 # Pure-C regression for the helper-side parser/applier. Capture
 # callbacks stand in for the GTK widget mutations so the suite stays
 # headless.
@@ -309,6 +320,15 @@ test_tray_helper_protocol_exe = executable('test_tray_helper_protocol',
    'src/tray_helper_protocol.c', 'src/tray_protocol.c'],
   dependencies : [glib_dep])
 test('tray_helper_protocol', test_tray_helper_protocol_exe)
+
+# Pure-C regression for the shared Browser Control state module
+# (Tranche E finalization). The module is GTK-free and exposes a
+# transport seam, so the tests install a stub transport and drive
+# refresh / set callbacks directly without spinning up the gateway.
+test_browser_control_state_exe = executable('test_browser_control_state',
+  ['tests/test_browser_control_state.c', 'src/browser_control_state.c'],
+  dependencies : [glib_dep])
+test('browser_control_state', test_browser_control_state_exe)
 
 # Hermetic regression for the Restart App argv builder. The actual
 # spawn path is intentionally NOT exercised — see test source for the

--- a/apps/linux/src/browser_control_state.c
+++ b/apps/linux/src/browser_control_state.c
@@ -1,0 +1,263 @@
+/*
+ * browser_control_state.c
+ *
+ * See browser_control_state.h for the public contract. The module is
+ * pure-C / GTK-free so it can be unit tested headlessly via the
+ * transport seam.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "browser_control_state.h"
+
+typedef struct {
+    guint id;
+    BrowserControlStateChangedCb cb;
+    gpointer user_data;
+} Subscriber;
+
+typedef struct {
+    /* Cached value + known flag. The `enabled` field is meaningful
+     * only when `known == TRUE`. */
+    gboolean enabled;
+    gboolean known;
+
+    /* TRUE while a refresh is in flight; suppresses a second refresh
+     * being issued in parallel. */
+    gboolean refreshing;
+
+    /* Generation counter that bumps on every state-clearing reset so
+     * stale callbacks from a previous test/init are dropped. */
+    guint generation;
+
+    /* Transport seam — NULL until the host installs one. */
+    BrowserControlStateTransport transport;
+    gboolean transport_installed;
+
+    /* Subscribers. We use a GSList so iteration cost is linear in the
+     * (small) number of UI surfaces; subscriber removal during a
+     * notification is the only tricky case and is handled via a
+     * per-iteration capture. */
+    GSList *subscribers;
+    guint   next_subscription_id;
+} BrowserControlState;
+
+static BrowserControlState g_state;
+
+/* ── lifecycle ─────────────────────────────────────────────────── */
+
+void browser_control_state_init(void) {
+    /* Reset to a deterministic baseline. Idempotent; safe to call
+     * multiple times in the same process. */
+    g_state.enabled = FALSE;
+    g_state.known = FALSE;
+    g_state.refreshing = FALSE;
+    g_state.generation++;
+    g_state.transport.refresh = NULL;
+    g_state.transport.save = NULL;
+    g_state.transport_installed = FALSE;
+    /* Preserve any active subscribers across init() calls so the
+     * General section / tray can subscribe before init runs without
+     * losing their registration. */
+    if (g_state.next_subscription_id == 0) {
+        g_state.next_subscription_id = 1;
+    }
+}
+
+void browser_control_state_test_reset(void) {
+    g_slist_free_full(g_state.subscribers, g_free);
+    g_state.subscribers = NULL;
+    g_state.next_subscription_id = 1;
+    g_state.enabled = FALSE;
+    g_state.known = FALSE;
+    g_state.refreshing = FALSE;
+    g_state.generation++;
+    g_state.transport.refresh = NULL;
+    g_state.transport.save = NULL;
+    g_state.transport_installed = FALSE;
+}
+
+void browser_control_state_set_transport(const BrowserControlStateTransport *transport) {
+    if (!transport) {
+        g_state.transport.refresh = NULL;
+        g_state.transport.save = NULL;
+        g_state.transport_installed = FALSE;
+        return;
+    }
+    g_state.transport = *transport;
+    g_state.transport_installed = TRUE;
+}
+
+/* ── accessors ─────────────────────────────────────────────────── */
+
+void browser_control_state_get(gboolean *out_enabled, gboolean *out_known) {
+    if (out_enabled) *out_enabled = g_state.enabled;
+    if (out_known)   *out_known   = g_state.known;
+}
+
+gboolean browser_control_state_is_refreshing(void) {
+    return g_state.refreshing;
+}
+
+/* ── subscribers ───────────────────────────────────────────────── */
+
+guint browser_control_state_subscribe(BrowserControlStateChangedCb cb, gpointer user_data) {
+    if (!cb) return 0;
+    /* Normalize the counter BEFORE assigning so pre-init subscribers
+     * (who observe a zero-initialized `g_state`) never receive the
+     * invalid id 0. The public API documents 0 as invalid and
+     * `browser_control_state_init` preserves subscribers across init
+     * calls, so this path must stay valid. */
+    if (g_state.next_subscription_id == 0) g_state.next_subscription_id = 1;
+    Subscriber *s = g_new0(Subscriber, 1);
+    s->id = g_state.next_subscription_id++;
+    if (g_state.next_subscription_id == 0) g_state.next_subscription_id = 1; /* wrap guard */
+    s->cb = cb;
+    s->user_data = user_data;
+    g_state.subscribers = g_slist_append(g_state.subscribers, s);
+    return s->id;
+}
+
+void browser_control_state_unsubscribe(guint id) {
+    if (id == 0) return;
+    for (GSList *it = g_state.subscribers; it; it = it->next) {
+        Subscriber *s = it->data;
+        if (s && s->id == id) {
+            g_state.subscribers = g_slist_remove(g_state.subscribers, s);
+            g_free(s);
+            return;
+        }
+    }
+}
+
+static void notify_subscribers(void) {
+    /* Snapshot the list because subscribers may unsubscribe inside
+     * their callback (e.g., during section_general teardown). */
+    GSList *snapshot = g_slist_copy(g_state.subscribers);
+    for (GSList *it = snapshot; it; it = it->next) {
+        Subscriber *s = it->data;
+        /* Ensure the subscriber still exists on the live list before
+         * invoking; another callback in this loop may have removed it. */
+        if (g_slist_find(g_state.subscribers, s) && s && s->cb) {
+            s->cb(s->user_data);
+        }
+    }
+    g_slist_free(snapshot);
+}
+
+/* ── refresh ───────────────────────────────────────────────────── */
+
+typedef struct {
+    guint generation;
+} RefreshCtx;
+
+static void on_refresh_complete(gboolean ok,
+                                gboolean enabled,
+                                const gchar *error_msg,
+                                gpointer ctx) {
+    (void)error_msg;
+    RefreshCtx *rc = ctx;
+    gboolean current = rc && rc->generation == g_state.generation;
+    g_free(rc);
+
+    if (!current) return; /* stale — module was reset since dispatch */
+
+    g_state.refreshing = FALSE;
+    if (ok) {
+        g_state.enabled = enabled ? TRUE : FALSE;
+        g_state.known = TRUE;
+    }
+    /* Failure leaves cache untouched. Subscribers are notified
+     * regardless so a "Loading…" subtitle can clear. */
+    notify_subscribers();
+}
+
+void browser_control_state_refresh(void) {
+    if (g_state.refreshing) return; /* coalesce concurrent refreshes */
+    if (!g_state.transport_installed || !g_state.transport.refresh) {
+        /* No transport yet — silently no-op. The next caller (after
+         * the host wires the transport) will retry. */
+        return;
+    }
+    g_state.refreshing = TRUE;
+    RefreshCtx *ctx = g_new0(RefreshCtx, 1);
+    ctx->generation = g_state.generation;
+    g_state.transport.refresh(on_refresh_complete, ctx);
+}
+
+/* ── request_set ───────────────────────────────────────────────── */
+
+typedef struct {
+    guint generation;
+    gboolean attempted_enabled;
+    BrowserControlStateSetDoneCb user_cb;
+    gpointer user_data;
+} SetCtx;
+
+static void on_save_complete(gboolean ok,
+                             const gchar *error_msg,
+                             gpointer ctx) {
+    SetCtx *sc = ctx;
+    SetCtx local = sc ? *sc : (SetCtx){0};
+    gboolean current = sc && sc->generation == g_state.generation;
+    g_free(sc);
+
+    if (!current) {
+        /* Stale (post-reset) — invoke the user callback with a
+         * "save failed" so they don't hang waiting for a result, but
+         * do not touch cache or subscribers. */
+        if (local.user_cb) {
+            BrowserControlStateSetResult result = {
+                .status = BROWSER_CONTROL_STATE_ERR_SAVE_FAILED,
+                .attempted_enabled = local.attempted_enabled,
+                .error_msg = "STATE_RESET",
+            };
+            local.user_cb(&result, local.user_data);
+        }
+        return;
+    }
+
+    BrowserControlStateSetResult result = {
+        .status = ok ? BROWSER_CONTROL_STATE_OK
+                     : BROWSER_CONTROL_STATE_ERR_SAVE_FAILED,
+        .attempted_enabled = local.attempted_enabled,
+        .error_msg = error_msg,
+    };
+
+    if (ok) {
+        g_state.enabled = local.attempted_enabled ? TRUE : FALSE;
+        g_state.known = TRUE;
+    }
+    /* Notify subscribers BEFORE invoking the per-call user callback
+     * so subscribers (e.g., the section row) can repaint to the new
+     * authoritative state, and the user_cb can rely on `_get`
+     * reflecting that. */
+    notify_subscribers();
+
+    if (local.user_cb) local.user_cb(&result, local.user_data);
+}
+
+void browser_control_state_request_set(gboolean enabled,
+                                       BrowserControlStateSetDoneCb cb,
+                                       gpointer user_data) {
+    if (!g_state.transport_installed || !g_state.transport.save) {
+        /* No transport yet — synthesise a SAVE_FAILED result so the
+         * caller doesn't hang. */
+        if (cb) {
+            BrowserControlStateSetResult result = {
+                .status = BROWSER_CONTROL_STATE_ERR_SAVE_FAILED,
+                .attempted_enabled = enabled ? TRUE : FALSE,
+                .error_msg = "NO_TRANSPORT",
+            };
+            cb(&result, user_data);
+        }
+        return;
+    }
+
+    SetCtx *ctx = g_new0(SetCtx, 1);
+    ctx->generation = g_state.generation;
+    ctx->attempted_enabled = enabled ? TRUE : FALSE;
+    ctx->user_cb = cb;
+    ctx->user_data = user_data;
+    g_state.transport.save(ctx->attempted_enabled, on_save_complete, ctx);
+}

--- a/apps/linux/src/browser_control_state.h
+++ b/apps/linux/src/browser_control_state.h
@@ -1,0 +1,119 @@
+/*
+ * browser_control_state.h
+ *
+ * Shared, async-aware view of the gateway's `browser.enabled` flag.
+ *
+ * Both the General-section row and the system tray subscribe to this
+ * module so the displayed Browser Control state matches the gateway
+ * regardless of which surface is mounted first. The module is GTK-free
+ * — UI surfaces fetch state through `browser_control_state_get` and
+ * repaint when their subscriber callback fires.
+ *
+ * The module dispatches `config.get` and `config.set` through a small
+ * function-pointer transport so production code can wire it to the real
+ * RPC stack and tests can drive it with stubs without spinning up the
+ * gateway.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_BROWSER_CONTROL_STATE_H
+#define OPENCLAW_LINUX_BROWSER_CONTROL_STATE_H
+
+#include <glib.h>
+
+typedef enum {
+    BROWSER_CONTROL_STATE_OK = 0,
+    BROWSER_CONTROL_STATE_ERR_FETCH_FAILED,
+    BROWSER_CONTROL_STATE_ERR_SAVE_FAILED,
+} BrowserControlStateStatus;
+
+typedef struct {
+    BrowserControlStateStatus status;
+    /* The flag the caller attempted to set; on the success path this
+     * matches the new cached value, on the failure path the cached
+     * value is unchanged. */
+    gboolean attempted_enabled;
+    /* Borrowed; only valid for the duration of the callback. */
+    const gchar *error_msg;
+} BrowserControlStateSetResult;
+
+typedef void (*BrowserControlStateChangedCb)(gpointer user_data);
+typedef void (*BrowserControlStateSetDoneCb)(const BrowserControlStateSetResult *result,
+                                             gpointer user_data);
+
+/* ── transport seam ─────────────────────────────────────────────── */
+
+typedef void (*BrowserControlRefreshCb)(gboolean ok,
+                                        gboolean enabled,
+                                        const gchar *error_msg,
+                                        gpointer ctx);
+
+typedef void (*BrowserControlSaveCb)(gboolean ok,
+                                     const gchar *error_msg,
+                                     gpointer ctx);
+
+typedef struct {
+    /* Issue a `config.get`; on completion call `cb(ok, enabled, err, ctx)`. */
+    void (*refresh)(BrowserControlRefreshCb cb, gpointer ctx);
+    /* Issue a transformed `config.set` for `browser.enabled = enabled`;
+     * on completion call `cb(ok, err, ctx)`. */
+    void (*save)(gboolean enabled, BrowserControlSaveCb cb, gpointer ctx);
+} BrowserControlStateTransport;
+
+/* ── public state API ──────────────────────────────────────────── */
+
+void browser_control_state_init(void);
+
+/*
+ * Install the transport that bridges to the real gateway RPC stack.
+ * Pass NULL to detach (e.g., during shutdown). Tests install a stub.
+ */
+void browser_control_state_set_transport(const BrowserControlStateTransport *transport);
+
+/*
+ * Read the cached value. `*out_known` becomes TRUE iff a successful
+ * `refresh` or `request_set` has populated the cache. Either pointer
+ * may be NULL.
+ */
+void browser_control_state_get(gboolean *out_enabled, gboolean *out_known);
+
+/* TRUE while a `config.get` round-trip is in flight. */
+gboolean browser_control_state_is_refreshing(void);
+
+/*
+ * Issue a `config.get` so the cache reflects gateway truth. No-op if
+ * a refresh is already in flight or no transport is installed. Safe
+ * to call when WS is disconnected: the transport will fail fast and
+ * subscribers will fire with `known == FALSE` preserved.
+ */
+void browser_control_state_refresh(void);
+
+/*
+ * Request a Browser Control toggle. The supplied callback (if any)
+ * fires exactly once on completion — success means the cache has been
+ * updated and subscribers have fired; failure leaves the cache
+ * untouched and surfaces the error in the result.
+ */
+void browser_control_state_request_set(gboolean enabled,
+                                       BrowserControlStateSetDoneCb cb,
+                                       gpointer user_data);
+
+/*
+ * Subscribe / unsubscribe to be notified of cache changes. The
+ * callback fires on every refresh and set completion regardless of
+ * outcome — subscribers should re-query via `browser_control_state_get`
+ * to render the latest state. Returns a non-zero subscription id; 0
+ * is returned only for invalid input.
+ */
+guint browser_control_state_subscribe(BrowserControlStateChangedCb cb,
+                                      gpointer user_data);
+void  browser_control_state_unsubscribe(guint id);
+
+/*
+ * Tests-only: drop subscribers, transport, and cache so each test
+ * starts from a deterministic baseline.
+ */
+void browser_control_state_test_reset(void);
+
+#endif /* OPENCLAW_LINUX_BROWSER_CONTROL_STATE_H */

--- a/apps/linux/src/config_browser_toggle.c
+++ b/apps/linux/src/config_browser_toggle.c
@@ -1,0 +1,146 @@
+/*
+ * config_browser_toggle.c
+ *
+ * Driver for the Browser Control toggle. See config_browser_toggle.h
+ * for the public contract.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "config_browser_toggle.h"
+
+#include "config_setup_transform.h"
+#include "gateway_data.h"
+#include "gateway_mutations.h"
+#include "log.h"
+
+typedef struct {
+    gboolean enabled;
+    ConfigBrowserToggleCb cb;
+    gpointer user_data;
+} ToggleCtx;
+
+static void notify(ToggleCtx *ctx,
+                   ConfigBrowserToggleStatus status,
+                   const gchar *error_code,
+                   const gchar *error_msg) {
+    if (ctx && ctx->cb) {
+        ConfigBrowserToggleResult result = {
+            .status = status,
+            .error_code = error_code,
+            .error_msg = error_msg,
+        };
+        ctx->cb(&result, ctx->user_data);
+    }
+    g_free(ctx);
+}
+
+static void on_save_done(const GatewayRpcResponse *resp, gpointer user_data) {
+    ToggleCtx *ctx = (ToggleCtx *)user_data;
+    if (!resp || !resp->ok) {
+        OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                    "browser-toggle save failed code=%s msg=%s",
+                    resp && resp->error_code ? resp->error_code : "(none)",
+                    resp && resp->error_msg ? resp->error_msg : "(none)");
+        notify(ctx,
+               CONFIG_BROWSER_TOGGLE_ERR_SAVE_FAILED,
+               resp ? resp->error_code : NULL,
+               resp ? resp->error_msg : NULL);
+        return;
+    }
+
+    OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
+                 "browser-toggle save ok enabled=%d",
+                 ctx ? (int)ctx->enabled : -1);
+    notify(ctx, CONFIG_BROWSER_TOGGLE_OK, NULL, NULL);
+}
+
+static void on_get_done(const GatewayRpcResponse *resp, gpointer user_data) {
+    ToggleCtx *ctx = (ToggleCtx *)user_data;
+    if (!resp || !resp->ok) {
+        OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                    "browser-toggle fetch failed code=%s msg=%s",
+                    resp && resp->error_code ? resp->error_code : "(none)",
+                    resp && resp->error_msg ? resp->error_msg : "(none)");
+        notify(ctx,
+               CONFIG_BROWSER_TOGGLE_ERR_FETCH_FAILED,
+               resp ? resp->error_code : NULL,
+               resp ? resp->error_msg : NULL);
+        return;
+    }
+
+    GatewayConfigSnapshot *snapshot = gateway_data_parse_config_get(resp->payload);
+    if (!snapshot || !snapshot->config || !snapshot->hash) {
+        OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                    "browser-toggle fetch returned malformed snapshot");
+        if (snapshot) gateway_config_snapshot_free(snapshot);
+        notify(ctx,
+               CONFIG_BROWSER_TOGGLE_ERR_FETCH_FAILED,
+               "INVALID_SNAPSHOT",
+               "config.get response missing config or hash");
+        return;
+    }
+
+    /* Reuse the same pretty-printer the section_config baseline does
+     * so the OCC base hash semantics match: we never want to base our
+     * `config.set` on a transform of a *different* serialization than
+     * what the gateway hashed. */
+    JsonNode *node = json_node_new(JSON_NODE_OBJECT);
+    json_node_set_object(node, snapshot->config);
+    g_autofree gchar *raw = json_to_string(node, TRUE);
+    json_node_unref(node);
+
+    g_autoptr(GError) terr = NULL;
+    g_autofree gchar *updated =
+        config_setup_apply_browser_enabled(raw, ctx->enabled, &terr);
+
+    if (!updated) {
+        OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                    "browser-toggle transform failed: %s",
+                    terr && terr->message ? terr->message : "(unknown)");
+        gateway_config_snapshot_free(snapshot);
+        notify(ctx,
+               CONFIG_BROWSER_TOGGLE_ERR_TRANSFORM_FAILED,
+               "TRANSFORM_FAILED",
+               terr ? terr->message : NULL);
+        return;
+    }
+
+    g_autofree gchar *base_hash = g_strdup(snapshot->hash);
+    gateway_config_snapshot_free(snapshot);
+
+    g_autofree gchar *rid =
+        mutation_config_set(updated, base_hash, on_save_done, ctx);
+    if (!rid) {
+        OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                    "browser-toggle config.set dispatch returned NULL");
+        notify(ctx,
+               CONFIG_BROWSER_TOGGLE_ERR_SAVE_FAILED,
+               "DISPATCH_FAILED",
+               "config.set could not be dispatched");
+        return;
+    }
+    /* `on_save_done` owns ctx from here. */
+}
+
+void config_browser_toggle_request(gboolean enabled,
+                                   ConfigBrowserToggleCb cb,
+                                   gpointer user_data) {
+    ToggleCtx *ctx = g_new0(ToggleCtx, 1);
+    ctx->enabled = enabled ? TRUE : FALSE;
+    ctx->cb = cb;
+    ctx->user_data = user_data;
+
+    g_autofree gchar *rid =
+        mutation_config_get(NULL, on_get_done, ctx);
+    if (!rid) {
+        OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                    "browser-toggle config.get dispatch returned NULL");
+        notify(ctx,
+               CONFIG_BROWSER_TOGGLE_ERR_FETCH_FAILED,
+               "DISPATCH_FAILED",
+               "config.get could not be dispatched");
+        return;
+    }
+    /* `on_get_done` owns ctx from here. */
+}

--- a/apps/linux/src/config_browser_toggle.h
+++ b/apps/linux/src/config_browser_toggle.h
@@ -1,0 +1,55 @@
+/*
+ * config_browser_toggle.h
+ *
+ * Orchestrates the Browser Control on/off toggle by chaining a fresh
+ * `config.get` (when no recent baseline is cached), the
+ * `config_setup_apply_browser_enabled` transform, and a `config.set`
+ * RPC dispatch with the matching OCC base hash.
+ *
+ * The General section row and the tray helper share this entry point
+ * so the in-app and tray surfaces resolve to the same mutation funnel.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_CONFIG_BROWSER_TOGGLE_H
+#define OPENCLAW_LINUX_CONFIG_BROWSER_TOGGLE_H
+
+#include <glib.h>
+
+typedef enum {
+    CONFIG_BROWSER_TOGGLE_OK = 0,
+    /* `config.get` round-trip failed. */
+    CONFIG_BROWSER_TOGGLE_ERR_FETCH_FAILED,
+    /* The transform helper rejected the cached config. */
+    CONFIG_BROWSER_TOGGLE_ERR_TRANSFORM_FAILED,
+    /* `config.set` returned a non-OK response. The driver does NOT
+     * retry — callers wishing to recover should refresh and re-issue. */
+    CONFIG_BROWSER_TOGGLE_ERR_SAVE_FAILED,
+} ConfigBrowserToggleStatus;
+
+typedef struct {
+    ConfigBrowserToggleStatus status;
+    /* Borrowed; valid only for the duration of the callback. */
+    const gchar *error_code;
+    const gchar *error_msg;
+} ConfigBrowserToggleResult;
+
+typedef void (*ConfigBrowserToggleCb)(const ConfigBrowserToggleResult *result,
+                                      gpointer user_data);
+
+/*
+ * Request a Browser Control toggle. Always reads the freshest config
+ * from the gateway via `config.get` first so the OCC base hash matches
+ * the gateway's snapshot at the time of `config.set`. The supplied
+ * callback (if any) fires exactly once on completion (success or
+ * failure).
+ *
+ * Safe to call when WS is disconnected: dispatch will fail fast and
+ * the callback will fire with `CONFIG_BROWSER_TOGGLE_ERR_FETCH_FAILED`.
+ */
+void config_browser_toggle_request(gboolean enabled,
+                                   ConfigBrowserToggleCb cb,
+                                   gpointer user_data);
+
+#endif /* OPENCLAW_LINUX_CONFIG_BROWSER_TOGGLE_H */

--- a/apps/linux/src/config_setup_transform.c
+++ b/apps/linux/src/config_setup_transform.c
@@ -195,3 +195,21 @@ gchar* config_setup_apply_default_model(const gchar *raw_json,
     g_object_unref(parser);
     return updated;
 }
+
+gchar* config_setup_apply_browser_enabled(const gchar *raw_json,
+                                          gboolean enabled,
+                                          GError **error) {
+    JsonParser *parser = NULL;
+    JsonObject *root_obj = parse_root_object(raw_json, error, &parser);
+    if (!root_obj) return NULL;
+
+    /* `ensure_object_member` already replaces non-object values with a
+     * fresh empty object, which is the deterministic recovery path
+     * documented in the public contract. */
+    JsonObject *browser_obj = ensure_object_member(root_obj, "browser");
+    json_object_set_boolean_member(browser_obj, "enabled", enabled ? TRUE : FALSE);
+
+    gchar *updated = transform_to_pretty_json(root_obj);
+    g_object_unref(parser);
+    return updated;
+}

--- a/apps/linux/src/config_setup_transform.h
+++ b/apps/linux/src/config_setup_transform.h
@@ -13,4 +13,17 @@ gchar* config_setup_apply_default_model(const gchar *raw_json,
                                         const gchar *model_id,
                                         GError **error);
 
+/*
+ * Toggle the top-level `browser.enabled` flag in `raw_json`. When the
+ * `browser` member is missing or holds a non-object value, it is
+ * created/replaced with a fresh `{ "enabled": <bool> }` object so the
+ * outcome is deterministic. Other members of `browser` are preserved.
+ *
+ * Returns a newly-allocated pretty-printed JSON string on success
+ * (caller frees with g_free) or NULL on parse failure.
+ */
+gchar* config_setup_apply_browser_enabled(const gchar *raw_json,
+                                          gboolean enabled,
+                                          GError **error);
+
 #endif

--- a/apps/linux/src/deep_link.c
+++ b/apps/linux/src/deep_link.c
@@ -1,0 +1,93 @@
+/*
+ * deep_link.c
+ *
+ * Pure-C parser for the Linux companion's `openclaw://` URL scheme.
+ * See deep_link.h for the recognised routes.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "deep_link.h"
+
+#include <string.h>
+
+void deep_link_route_clear(DeepLinkRoute *route) {
+    if (!route) return;
+    g_clear_pointer(&route->section_id, g_free);
+    route->kind = DEEP_LINK_ROUTE_NONE;
+}
+
+/* Validate that a section id is a reasonable lowercase token (letters,
+ * digits, hyphens). We deliberately keep this conservative: the final
+ * allowlist is the shell-section registry, but rejecting obviously
+ * malformed tokens here avoids passing junk into the dispatcher. */
+static gboolean section_id_looks_valid(const char *s) {
+    if (!s || s[0] == '\0') return FALSE;
+    for (const char *p = s; *p; p++) {
+        unsigned char ch = (unsigned char)*p;
+        gboolean ok = (ch >= 'a' && ch <= 'z')
+                   || (ch >= '0' && ch <= '9')
+                   || ch == '-';
+        if (!ok) return FALSE;
+    }
+    return TRUE;
+}
+
+gboolean deep_link_parse(const char *uri, DeepLinkRoute *out_route) {
+    if (out_route) memset(out_route, 0, sizeof(*out_route));
+    if (!uri || !out_route) return FALSE;
+
+    g_autoptr(GError) error = NULL;
+    g_autoptr(GUri) parsed = g_uri_parse(uri, G_URI_FLAGS_NONE, &error);
+    if (!parsed) return FALSE;
+
+    const char *scheme = g_uri_get_scheme(parsed);
+    if (!scheme || g_ascii_strcasecmp(scheme, "openclaw") != 0) return FALSE;
+
+    const char *host = g_uri_get_host(parsed);
+    if (!host || host[0] == '\0') return FALSE;
+
+    g_autofree gchar *host_lower = g_ascii_strdown(host, -1);
+
+    const char *path = g_uri_get_path(parsed);
+    /* GUri yields "" (not NULL) for authority-only URIs. Treat NULL
+     * defensively to the same effect. */
+    const char *effective_path = path ? path : "";
+
+    if (g_strcmp0(host_lower, "dashboard") == 0) {
+        if (effective_path[0] != '\0' && g_strcmp0(effective_path, "/") != 0) return FALSE;
+        out_route->kind = DEEP_LINK_ROUTE_DASHBOARD;
+        return TRUE;
+    }
+
+    if (g_strcmp0(host_lower, "chat") == 0) {
+        if (effective_path[0] != '\0' && g_strcmp0(effective_path, "/") != 0) return FALSE;
+        out_route->kind = DEEP_LINK_ROUTE_CHAT;
+        return TRUE;
+    }
+
+    if (g_strcmp0(host_lower, "onboarding") == 0) {
+        if (effective_path[0] != '\0' && g_strcmp0(effective_path, "/") != 0) return FALSE;
+        out_route->kind = DEEP_LINK_ROUTE_ONBOARDING;
+        return TRUE;
+    }
+
+    if (g_strcmp0(host_lower, "settings") == 0) {
+        if (effective_path[0] == '\0' || g_strcmp0(effective_path, "/") == 0) {
+            out_route->kind = DEEP_LINK_ROUTE_SETTINGS;
+            return TRUE;
+        }
+        /* Expect exactly one segment after the leading slash. */
+        if (effective_path[0] != '/') return FALSE;
+        const char *segment = effective_path + 1;
+        if (strchr(segment, '/')) return FALSE;
+        g_autofree gchar *lower = g_ascii_strdown(segment, -1);
+        if (!section_id_looks_valid(lower)) return FALSE;
+
+        out_route->kind = DEEP_LINK_ROUTE_SETTINGS;
+        out_route->section_id = g_steal_pointer(&lower);
+        return TRUE;
+    }
+
+    return FALSE;
+}

--- a/apps/linux/src/deep_link.h
+++ b/apps/linux/src/deep_link.h
@@ -1,0 +1,63 @@
+/*
+ * deep_link.h
+ *
+ * Pure-C / GLib parser for the Linux companion's `openclaw://` URL
+ * scheme. Keeps navigation URL handling isolated from GTK so it can be
+ * unit tested headlessly.
+ *
+ * Recognised routes in this tranche (navigation-only — macOS-style
+ * agent/gateway deep links are intentionally NOT handled here):
+ *
+ *   openclaw://dashboard
+ *   openclaw://chat
+ *   openclaw://settings                 → General section
+ *   openclaw://settings/<section-id>    → named shell section
+ *   openclaw://onboarding               → re-run onboarding
+ *
+ * Section id validation is left to the caller (the main-window shell
+ * registry); this parser preserves the raw id string.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_DEEP_LINK_H
+#define OPENCLAW_LINUX_DEEP_LINK_H
+
+#include <glib.h>
+
+typedef enum {
+    DEEP_LINK_ROUTE_NONE = 0,
+    DEEP_LINK_ROUTE_DASHBOARD,
+    DEEP_LINK_ROUTE_CHAT,
+    DEEP_LINK_ROUTE_SETTINGS,
+    DEEP_LINK_ROUTE_ONBOARDING,
+} DeepLinkRouteKind;
+
+typedef struct {
+    DeepLinkRouteKind kind;
+    /*
+     * Optional shell-section id for DEEP_LINK_ROUTE_SETTINGS when a
+     * path segment was supplied (e.g. `openclaw://settings/channels`).
+     * NULL for the bare `openclaw://settings` route and for every other
+     * kind. Owned by the route; free with `deep_link_route_clear`.
+     */
+    gchar *section_id;
+} DeepLinkRoute;
+
+/*
+ * Parse `uri` into a deep-link route. Returns TRUE on a recognised
+ * shape and writes the result to `*out_route`; returns FALSE and
+ * leaves `*out_route` zero-initialised otherwise.
+ *
+ * Scheme/host matching is case-insensitive per RFC 3986. Query
+ * strings and fragments are ignored. Unknown hosts (including
+ * macOS-specific `agent` / `gateway`) return FALSE. Extra path
+ * segments beyond the single optional `<section-id>` on `settings`
+ * are rejected.
+ */
+gboolean deep_link_parse(const char *uri, DeepLinkRoute *out_route);
+
+/* Release any heap-owned fields inside `*route` (currently section_id). */
+void deep_link_route_clear(DeepLinkRoute *route);
+
+#endif /* OPENCLAW_LINUX_DEEP_LINK_H */

--- a/apps/linux/src/gateway_client.c
+++ b/apps/linux/src/gateway_client.c
@@ -14,9 +14,12 @@
  */
 
 #include "gateway_client.h"
+#include "browser_control_state.h"
+#include "config_browser_toggle.h"
 #include "gateway_config.h"
 #include "gateway_http.h"
 #include "gateway_rpc.h"
+#include "gateway_mutations.h"
 #include "gateway_ws.h"
 #include "gateway_data.h"
 #include "json_access.h"
@@ -543,6 +546,27 @@ static void on_ws_status(const GatewayWsStatus *status, gpointer user_data) {
      */
     if (ws_connected) {
         device_pair_prompter_notify_transport_authenticated();
+        /*
+         * Reassert the locally-persisted Heartbeats intent each time
+         * the transport flips to connected so gateway restarts and
+         * fresh auth scopes honor the operator's last UI choice. This
+         * is a one-shot per transition and is best-effort: an RPC
+         * failure here is non-fatal.
+         */
+        gateway_client_resync_heartbeats_intent();
+
+        /*
+         * Pull a fresh Browser Control snapshot if the shared cache is
+         * still unknown (typical after a cold start, where the kick in
+         * `gateway_client_init` saw WS disconnected). The state module
+         * coalesces concurrent refreshes, so we won't double-fire if
+         * another caller is already mid-refresh.
+         */
+        gboolean bc_known = FALSE;
+        browser_control_state_get(NULL, &bc_known);
+        if (!bc_known) {
+            browser_control_state_refresh();
+        }
     }
 }
 
@@ -1056,12 +1080,113 @@ static void gateway_client_apply_mode(void) {
     connection_mode_coordinator_apply(current_config, gateway_client_effective_mode());
 }
 
+/* ── Browser Control state production transport ──────────────────
+ *
+ * Bridges the GTK-free `browser_control_state` module to the real
+ * `mutation_config_get` / `config_browser_toggle_request` RPC stack
+ * so the General section and the tray see the same authoritative
+ * Browser Control flag regardless of which UI surface mounts first.
+ *
+ * Each bridge struct carries the state-module callback pointer and
+ * its opaque ctx so we don't capture them in static globals. The
+ * bridge is freed after the state module's callback fires.
+ */
+
+typedef struct {
+    BrowserControlRefreshCb cb;
+    gpointer ctx;
+} BrowserControlRefreshBridge;
+
+typedef struct {
+    BrowserControlSaveCb cb;
+    gpointer ctx;
+} BrowserControlSaveBridge;
+
+static void on_browser_control_refresh_rpc_done(const GatewayRpcResponse *resp, gpointer user_data) {
+    BrowserControlRefreshBridge *bridge = user_data;
+    if (!bridge) return;
+    BrowserControlRefreshCb cb = bridge->cb;
+    gpointer ctx = bridge->ctx;
+    g_free(bridge);
+
+    if (!resp || !resp->ok) {
+        const gchar *err = resp && resp->error_msg ? resp->error_msg : "FETCH_FAILED";
+        if (cb) cb(FALSE, FALSE, err, ctx);
+        return;
+    }
+
+    GatewayConfigSnapshot *snap = gateway_data_parse_config_get(resp->payload);
+    if (!snap || !snap->config) {
+        if (snap) gateway_config_snapshot_free(snap);
+        if (cb) cb(FALSE, FALSE, "INVALID_SNAPSHOT", ctx);
+        return;
+    }
+
+    gboolean enabled = FALSE;
+    if (json_object_has_member(snap->config, "browser")) {
+        JsonNode *node = json_object_get_member(snap->config, "browser");
+        if (node && JSON_NODE_HOLDS_OBJECT(node)) {
+            JsonObject *browser = json_node_get_object(node);
+            if (json_object_has_member(browser, "enabled")) {
+                enabled = json_object_get_boolean_member(browser, "enabled");
+            }
+        }
+    }
+    gateway_config_snapshot_free(snap);
+    if (cb) cb(TRUE, enabled, NULL, ctx);
+}
+
+static void browser_control_prod_refresh(BrowserControlRefreshCb cb, gpointer ctx) {
+    BrowserControlRefreshBridge *bridge = g_new0(BrowserControlRefreshBridge, 1);
+    bridge->cb = cb;
+    bridge->ctx = ctx;
+    g_autofree gchar *rid =
+        mutation_config_get(NULL, on_browser_control_refresh_rpc_done, bridge);
+    if (!rid) {
+        g_free(bridge);
+        if (cb) cb(FALSE, FALSE, "DISPATCH_FAILED", ctx);
+    }
+}
+
+static void on_browser_control_save_done(const ConfigBrowserToggleResult *result,
+                                         gpointer user_data) {
+    BrowserControlSaveBridge *bridge = user_data;
+    if (!bridge) return;
+    BrowserControlSaveCb cb = bridge->cb;
+    gpointer ctx = bridge->ctx;
+    g_free(bridge);
+
+    gboolean ok = result && result->status == CONFIG_BROWSER_TOGGLE_OK;
+    const gchar *err = result ? result->error_msg : NULL;
+    if (cb) cb(ok, err, ctx);
+}
+
+static void browser_control_prod_save(gboolean enabled, BrowserControlSaveCb cb, gpointer ctx) {
+    BrowserControlSaveBridge *bridge = g_new0(BrowserControlSaveBridge, 1);
+    bridge->cb = cb;
+    bridge->ctx = ctx;
+    config_browser_toggle_request(enabled, on_browser_control_save_done, bridge);
+}
+
+static const BrowserControlStateTransport k_browser_control_prod_transport = {
+    .refresh = browser_control_prod_refresh,
+    .save    = browser_control_prod_save,
+};
+
 void gateway_client_init(void) {
     if (initialized) return;
     initialized = TRUE;
 
     gateway_http_init();
     gateway_ws_init();
+
+    /* Bring up the shared Browser Control cache and wire the
+     * production transport. The cold-start refresh below is
+     * best-effort: if WS isn't connected yet the dispatch fails fast
+     * and the WS-connected hook will retry. */
+    browser_control_state_init();
+    browser_control_state_set_transport(&k_browser_control_prod_transport);
+    browser_control_state_refresh();
 
     /* Init remote-mode subsystems and subscribe to endpoint changes so
      * tunnel readiness drives transport rebuild. Idempotent. */
@@ -1180,6 +1305,41 @@ void gateway_client_shutdown(void) {
 
 gboolean gateway_client_is_connected(void) {
     return gateway_ws_get_state() == GATEWAY_WS_CONNECTED;
+}
+
+static void on_set_heartbeats_response(const GatewayRpcResponse *resp, gpointer user_data) {
+    (void)user_data;
+    if (!resp) return;
+    if (resp->ok) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
+                     "set-heartbeats RPC ok");
+        return;
+    }
+    /*
+     * Non-fatal: keep the persisted intent and let the next WS-ready
+     * transition re-issue. We log at INFO so operators can see the
+     * mismatch in `journalctl --user -u openclaw-companion` without
+     * promoting it to a tray notification.
+     */
+    OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                "set-heartbeats RPC failed code=%s msg=%s",
+                resp->error_code ? resp->error_code : "(none)",
+                resp->error_msg ? resp->error_msg : "(none)");
+}
+
+void gateway_client_resync_heartbeats_intent(void) {
+    if (gateway_ws_get_state() != GATEWAY_WS_CONNECTED) {
+        OC_LOG_DEBUG(OPENCLAW_LOG_CAT_GATEWAY,
+                     "skipping heartbeats resync: ws not connected");
+        return;
+    }
+    gboolean enabled = product_state_get_heartbeats_enabled();
+    g_autofree gchar *rid =
+        mutation_system_set_heartbeats(enabled, on_set_heartbeats_response, NULL);
+    if (!rid) {
+        OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                    "set-heartbeats dispatch returned NULL");
+    }
 }
 
 GatewayConfig* gateway_client_get_config(void) {

--- a/apps/linux/src/gateway_client.h
+++ b/apps/linux/src/gateway_client.h
@@ -26,6 +26,18 @@ void gateway_client_invalidate_dependencies(gboolean invalidate_models,
                                             gboolean invalidate_agents,
                                             gboolean invalidate_config_audit);
 
+/*
+ * Push the locally-persisted Heartbeats intent (`product_state`) to
+ * the gateway via the `set-heartbeats` RPC. Safe to call repeatedly;
+ * a no-op when WS is not connected.
+ *
+ * The gateway client invokes this automatically on every WS-connected
+ * transition so that operator intent survives gateway restarts and
+ * scope upgrades. Other modules may call it after a UI mutation has
+ * already updated `product_state`.
+ */
+void gateway_client_resync_heartbeats_intent(void);
+
 #include "gateway_config.h"
 GatewayConfig* gateway_client_get_config(void);
 

--- a/apps/linux/src/gateway_mutations.c
+++ b/apps/linux/src/gateway_mutations.c
@@ -409,3 +409,20 @@ gchar* mutation_node_pair_list(GatewayRpcCallback cb, gpointer data) {
     json_node_unref(params);
     return rid;
 }
+
+/* ── System mutations ────────────────────────────────────────────── */
+
+gchar* mutation_system_set_heartbeats(gboolean enabled,
+                                      GatewayRpcCallback cb, gpointer data) {
+    JsonBuilder *b = json_builder_new();
+    json_builder_begin_object(b);
+    json_builder_set_member_name(b, "enabled");
+    json_builder_add_boolean_value(b, enabled);
+    json_builder_end_object(b);
+    JsonNode *params = json_builder_get_root(b);
+    g_object_unref(b);
+
+    gchar *rid = gateway_rpc_request("set-heartbeats", params, 0, cb, data);
+    json_node_unref(params);
+    return rid;
+}

--- a/apps/linux/src/gateway_mutations.h
+++ b/apps/linux/src/gateway_mutations.h
@@ -123,4 +123,14 @@ gchar* mutation_node_list(GatewayRpcCallback cb, gpointer data);
 
 gchar* mutation_node_pair_list(GatewayRpcCallback cb, gpointer data);
 
+/* ── System mutations ────────────────────────────────────────────── */
+
+/*
+ * Set the persistent heartbeats-enabled flag on the gateway. Maps to
+ * the macOS `set-heartbeats` RPC (see `src/gateway/server-methods/
+ * system.ts`). Params: { "enabled": <bool> }.
+ */
+gchar* mutation_system_set_heartbeats(gboolean enabled,
+                                      GatewayRpcCallback cb, gpointer data);
+
 #endif /* OPENCLAW_LINUX_GATEWAY_MUTATIONS_H */

--- a/apps/linux/src/main.c
+++ b/apps/linux/src/main.c
@@ -9,6 +9,11 @@
  *   Lane 1: Systemd D-Bus event subscription (service lifecycle context)
  *   Lane 2: Native gateway client (HTTP health + WebSocket connectivity)
  *
+ * Also registers as the `openclaw://` URL-scheme handler: URIs passed
+ * from the desktop dispatcher are routed through the deep-link
+ * dispatcher into the product coordinator / chat window without
+ * duplicating navigation state.
+ *
  * Author: Thiago Camargo <thiagocmc@proton.me>
  */
 
@@ -16,13 +21,46 @@
 #include <adwaita.h>
 #include <glib.h>
 
-#include "log.h"
+#include "chat_window.h"
 #include "gateway_client.h"
+#include "log.h"
+#include "main_open_dispatch.h"
 #include "product_coordinator.h"
+#include "shell_sections.h"
 
 void state_on_gateway_refresh_requested(void) {
     gateway_client_refresh();
 }
+
+static void deep_link_show_section(AppSection section, gpointer user_data) {
+    (void)user_data;
+    product_coordinator_request_show_section(section);
+}
+
+static void deep_link_show_chat(gpointer user_data) {
+    (void)user_data;
+    chat_window_show();
+}
+
+static void deep_link_rerun_onboarding(gpointer user_data) {
+    (void)user_data;
+    product_coordinator_request_rerun_onboarding();
+}
+
+static gboolean deep_link_resolve_section_id(const char *section_id,
+                                             AppSection *out_section,
+                                             gpointer user_data) {
+    (void)user_data;
+    return shell_sections_section_for_id(section_id, out_section);
+}
+
+static const DeepLinkDispatcher g_deep_link_dispatcher = {
+    .show_section       = deep_link_show_section,
+    .show_chat          = deep_link_show_chat,
+    .rerun_onboarding   = deep_link_rerun_onboarding,
+    .resolve_section_id = deep_link_resolve_section_id,
+    .user_data          = NULL,
+};
 
 static void on_activate(GtkApplication *app, gpointer user_data) {
     (void)app;
@@ -31,11 +69,47 @@ static void on_activate(GtkApplication *app, gpointer user_data) {
     product_coordinator_activate();
 }
 
+static void on_open(GApplication *app,
+                    GFile **files,
+                    gint n_files,
+                    const gchar *hint,
+                    gpointer user_data) {
+    (void)hint;
+    (void)user_data;
+
+    /*
+     * Deliver the primary `activate` signal before routing the URI so
+     * that shell-coordinator state is fully bootstrapped when the
+     * dispatcher asks to show a section. With single-instance
+     * GApplication semantics this is a no-op on the primary (activate
+     * already fired); it defensively covers the URL-first cold start.
+     */
+    g_application_activate(app);
+
+    for (gint i = 0; i < n_files; i++) {
+        if (!files[i]) continue;
+        g_autofree gchar *uri = g_file_get_uri(files[i]);
+        if (!uri) continue;
+
+        DeepLinkDispatchKind kind =
+            deep_link_dispatcher_dispatch(&g_deep_link_dispatcher, uri);
+        if (kind == DEEP_LINK_DISPATCH_NONE) {
+            OC_LOG_DEBUG(OPENCLAW_LOG_CAT_STATE, "ignored deep link uri=%s", uri);
+        } else {
+            OC_LOG_INFO(OPENCLAW_LOG_CAT_STATE,
+                        "deep link dispatched uri=%s kind=%d",
+                        uri, (int)kind);
+        }
+    }
+}
+
 int main(int argc, char **argv) {
     openclaw_log_init();
-    
-    g_autoptr(AdwApplication) app = adw_application_new("ai.openclaw.Companion", G_APPLICATION_DEFAULT_FLAGS);
+
+    g_autoptr(AdwApplication) app =
+        adw_application_new("ai.openclaw.Companion", G_APPLICATION_HANDLES_OPEN);
     g_signal_connect(app, "activate", G_CALLBACK(on_activate), NULL);
+    g_signal_connect(app, "open", G_CALLBACK(on_open), NULL);
 
     g_application_hold(G_APPLICATION(app));
 

--- a/apps/linux/src/main_open_dispatch.c
+++ b/apps/linux/src/main_open_dispatch.c
@@ -1,0 +1,79 @@
+/*
+ * main_open_dispatch.c
+ *
+ * Dispatcher for `openclaw://` deep links. See main_open_dispatch.h.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "main_open_dispatch.h"
+
+#include "deep_link.h"
+
+DeepLinkDispatchKind deep_link_dispatcher_dispatch(const DeepLinkDispatcher *dispatcher,
+                                                   const char *uri) {
+    DeepLinkRoute route = {0};
+    if (!deep_link_parse(uri, &route)) return DEEP_LINK_DISPATCH_NONE;
+
+    DeepLinkDispatchKind kind = DEEP_LINK_DISPATCH_NONE;
+
+    switch (route.kind) {
+    case DEEP_LINK_ROUTE_DASHBOARD:
+        if (dispatcher && dispatcher->show_section) {
+            dispatcher->show_section(SECTION_DASHBOARD, dispatcher->user_data);
+        }
+        kind = DEEP_LINK_DISPATCH_DASHBOARD;
+        break;
+
+    case DEEP_LINK_ROUTE_CHAT:
+        if (dispatcher && dispatcher->show_chat) {
+            dispatcher->show_chat(dispatcher->user_data);
+        }
+        kind = DEEP_LINK_DISPATCH_CHAT;
+        break;
+
+    case DEEP_LINK_ROUTE_SETTINGS: {
+        AppSection target = SECTION_GENERAL;
+        if (route.section_id) {
+            if (dispatcher && dispatcher->resolve_section_id) {
+                gboolean resolved = dispatcher->resolve_section_id(
+                    route.section_id, &target, dispatcher->user_data);
+                if (!resolved) {
+                    /* Hidden / unknown sections fall through without
+                     * navigating — see deep_link_dispatcher_dispatch
+                     * contract in main_open_dispatch.h. */
+                    kind = DEEP_LINK_DISPATCH_NONE;
+                    break;
+                }
+            } else {
+                /* No resolver installed — be strict and ignore named
+                 * sections rather than silently defaulting to General,
+                 * which would make typos indistinguishable from the
+                 * intentional root route. */
+                kind = DEEP_LINK_DISPATCH_NONE;
+                break;
+            }
+        }
+        if (dispatcher && dispatcher->show_section) {
+            dispatcher->show_section(target, dispatcher->user_data);
+        }
+        kind = DEEP_LINK_DISPATCH_SETTINGS;
+        break;
+    }
+
+    case DEEP_LINK_ROUTE_ONBOARDING:
+        if (dispatcher && dispatcher->rerun_onboarding) {
+            dispatcher->rerun_onboarding(dispatcher->user_data);
+        }
+        kind = DEEP_LINK_DISPATCH_ONBOARDING;
+        break;
+
+    case DEEP_LINK_ROUTE_NONE:
+    default:
+        kind = DEEP_LINK_DISPATCH_NONE;
+        break;
+    }
+
+    deep_link_route_clear(&route);
+    return kind;
+}

--- a/apps/linux/src/main_open_dispatch.h
+++ b/apps/linux/src/main_open_dispatch.h
@@ -1,0 +1,70 @@
+/*
+ * main_open_dispatch.h
+ *
+ * Headless dispatch helper for `openclaw://` deep links. Extracted from
+ * main.c so the `open`-signal wiring can be unit tested without GTK.
+ *
+ * The dispatcher is plumbed through a small host-supplied callback
+ * table so production code can route to the real product coordinator
+ * / chat window, and tests can install capture callbacks.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#ifndef OPENCLAW_LINUX_MAIN_OPEN_DISPATCH_H
+#define OPENCLAW_LINUX_MAIN_OPEN_DISPATCH_H
+
+#include <glib.h>
+
+#include "app_window.h"
+
+typedef enum {
+    DEEP_LINK_DISPATCH_NONE = 0,      /* URI unrecognised; no host action taken */
+    DEEP_LINK_DISPATCH_DASHBOARD,
+    DEEP_LINK_DISPATCH_CHAT,
+    DEEP_LINK_DISPATCH_SETTINGS,      /* resolved to section via the registry */
+    DEEP_LINK_DISPATCH_ONBOARDING,
+} DeepLinkDispatchKind;
+
+typedef struct {
+    /* Fires for ROUTE_DASHBOARD and ROUTE_SETTINGS (root or resolved
+     * section). Host wires this to
+     * `product_coordinator_request_show_section`. */
+    void (*show_section)(AppSection section, gpointer user_data);
+
+    /* Fires for ROUTE_CHAT. Host wires this to `chat_window_show`. */
+    void (*show_chat)(gpointer user_data);
+
+    /* Fires for ROUTE_ONBOARDING. Host wires this to
+     * `product_coordinator_request_rerun_onboarding`. */
+    void (*rerun_onboarding)(gpointer user_data);
+
+    /* Resolve a section id to AppSection. Host typically delegates to
+     * `shell_sections_section_for_id`. For a named settings route
+     * (`openclaw://settings/<id>`), if this is NULL or returns FALSE
+     * the dispatcher returns DEEP_LINK_DISPATCH_NONE without calling
+     * `show_section`. Only the bare `openclaw://settings` root route
+     * defaults to SECTION_GENERAL. */
+    gboolean (*resolve_section_id)(const char *section_id,
+                                   AppSection *out_section,
+                                   gpointer user_data);
+
+    gpointer user_data;
+} DeepLinkDispatcher;
+
+/*
+ * Parse `uri` as a deep link and invoke the matching handler in
+ * `dispatcher`. Returns the kind of dispatch that was performed;
+ * DEEP_LINK_DISPATCH_NONE signals an ignored/unknown URI (no host
+ * call was made).
+ *
+ * When `resolve_section_id` is provided but returns FALSE for a
+ * named section (e.g. `openclaw://settings/debug` while the debug
+ * pane is hidden), the dispatcher silently falls back to
+ * DEEP_LINK_DISPATCH_NONE and does NOT invoke `show_section`, per
+ * the tranche spec.
+ */
+DeepLinkDispatchKind deep_link_dispatcher_dispatch(const DeepLinkDispatcher *dispatcher,
+                                                   const char *uri);
+
+#endif /* OPENCLAW_LINUX_MAIN_OPEN_DISPATCH_H */

--- a/apps/linux/src/product_state.c
+++ b/apps/linux/src/product_state.c
@@ -19,6 +19,7 @@
 #define PRODUCT_STATE_GROUP "product"
 #define PRODUCT_STATE_KEY_CONNECTION_MODE "connection_mode"
 #define PRODUCT_STATE_KEY_ONBOARDING_SEEN_VERSION "onboarding_seen_version"
+#define PRODUCT_STATE_KEY_HEARTBEATS_ENABLED "heartbeats_enabled"
 
 typedef struct {
     ProductStateSnapshot snapshot;
@@ -43,6 +44,7 @@ static void product_state_apply_defaults(ProductStateSnapshot *state) {
     if (!state) return;
     state->connection_mode = PRODUCT_CONNECTION_MODE_LOCAL;
     state->onboarding_seen_version = 0;
+    state->heartbeats_enabled = TRUE;
 }
 
 static ProductConnectionMode product_state_normalize_connection_mode(ProductConnectionMode mode) {
@@ -133,6 +135,10 @@ static gboolean product_state_flush_to_disk(const ProductStateSnapshot *state) {
                           PRODUCT_STATE_GROUP,
                           PRODUCT_STATE_KEY_ONBOARDING_SEEN_VERSION,
                           state->onboarding_seen_version);
+    g_key_file_set_boolean(key_file,
+                           PRODUCT_STATE_GROUP,
+                           PRODUCT_STATE_KEY_HEARTBEATS_ENABLED,
+                           state->heartbeats_enabled);
 
     data = g_key_file_to_data(key_file, &data_len, NULL);
     if (!data) return FALSE;
@@ -185,6 +191,24 @@ static gboolean product_state_load_from_disk(ProductStateSnapshot *state,
                     g_clear_error(&error);
                     needs_flush = TRUE;
                 }
+            }
+
+            if (g_key_file_has_key(key_file, PRODUCT_STATE_GROUP, PRODUCT_STATE_KEY_HEARTBEATS_ENABLED, NULL)) {
+                gboolean hb = g_key_file_get_boolean(key_file,
+                                                     PRODUCT_STATE_GROUP,
+                                                     PRODUCT_STATE_KEY_HEARTBEATS_ENABLED,
+                                                     &error);
+                if (!error) {
+                    state->heartbeats_enabled = hb;
+                } else {
+                    g_clear_error(&error);
+                    needs_flush = TRUE;
+                }
+            } else {
+                /* First-run upgrade: explicit default lives on disk so
+                 * the GKeyFile we re-read on next launch is faithful to
+                 * the operator's effective intent. */
+                needs_flush = TRUE;
             }
         }
     }
@@ -265,6 +289,21 @@ gboolean product_state_set_onboarding_seen_version(guint version) {
     return product_state_flush_to_disk(&g_store.snapshot);
 }
 
+gboolean product_state_get_heartbeats_enabled(void) {
+    product_state_ensure_initialized();
+    return g_store.snapshot.heartbeats_enabled;
+}
+
+gboolean product_state_set_heartbeats_enabled(gboolean enabled) {
+    gboolean normalized = enabled ? TRUE : FALSE;
+
+    product_state_ensure_initialized();
+    if (g_store.snapshot.heartbeats_enabled == normalized) return TRUE;
+
+    g_store.snapshot.heartbeats_enabled = normalized;
+    return product_state_flush_to_disk(&g_store.snapshot);
+}
+
 gboolean product_state_reset_onboarding_seen_version(void) {
     g_autofree gchar *legacy_path = NULL;
 
@@ -290,5 +329,6 @@ void product_state_test_set_legacy_marker_path(const gchar *path) {
 void product_state_test_reset(void) {
     g_store.snapshot.connection_mode = PRODUCT_CONNECTION_MODE_UNSPECIFIED;
     g_store.snapshot.onboarding_seen_version = 0;
+    g_store.snapshot.heartbeats_enabled = FALSE;
     g_store.initialized = FALSE;
 }

--- a/apps/linux/src/product_state.h
+++ b/apps/linux/src/product_state.h
@@ -11,6 +11,7 @@ typedef enum {
 typedef struct {
     ProductConnectionMode connection_mode;
     guint onboarding_seen_version;
+    gboolean heartbeats_enabled;
 } ProductStateSnapshot;
 
 void product_state_init(void);
@@ -21,6 +22,14 @@ gboolean product_state_set_connection_mode(ProductConnectionMode mode);
 guint product_state_get_onboarding_seen_version(void);
 gboolean product_state_set_onboarding_seen_version(guint version);
 gboolean product_state_reset_onboarding_seen_version(void);
+
+/*
+ * Persisted operator intent for whether the Linux companion asks the
+ * gateway to emit heartbeats. Default on fresh installs is TRUE,
+ * mirroring the macOS default (`heartbeatsEnabled` in AppState.swift).
+ */
+gboolean product_state_get_heartbeats_enabled(void);
+gboolean product_state_set_heartbeats_enabled(gboolean enabled);
 
 void product_state_test_set_storage_path(const gchar *path);
 void product_state_test_set_legacy_marker_path(const gchar *path);

--- a/apps/linux/src/section_config.h
+++ b/apps/linux/src/section_config.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <glib.h>
+
 #include "section_controller.h"
 
 const SectionController* section_config_get(void);

--- a/apps/linux/src/section_general.c
+++ b/apps/linux/src/section_general.c
@@ -13,12 +13,15 @@
 
 #include <adwaita.h>
 
+#include "browser_control_state.h"
 #include "connection_mode_resolver.h"
 #include "display_model.h"
 #include "exec_approval_store.h"
 #include "gateway_client.h"
 #include "gateway_config.h"
 #include "gateway_remote_config.h"
+#include "log.h"
+#include "onboarding_cli_detect.h"
 #include "product_coordinator.h"
 #include "product_state.h"
 #include "readiness.h"
@@ -59,6 +62,22 @@ static GtkWidget *gen_btn_start = NULL;
 static GtkWidget *gen_btn_stop = NULL;
 static GtkWidget *gen_btn_restart = NULL;
 static GtkWidget *gen_btn_open_dashboard = NULL;
+
+/* ── Behavior toggles (Heartbeats + Browser Control) ── */
+static GtkWidget *gen_heartbeats_row = NULL;
+static gboolean gen_heartbeats_programmatic_change = FALSE;
+static GtkWidget *gen_browser_row = NULL;
+static gboolean gen_browser_programmatic_change = FALSE;
+/*
+ * Subscription id into `browser_control_state`. Non-zero while the
+ * row is mounted; zero after `general_destroy` unsubscribes. The
+ * shared module owns the cached enabled/known values so we never
+ * mirror them locally.
+ */
+static guint gen_browser_state_sub = 0;
+
+/* ── Companion CLI status row ── */
+static GtkWidget *gen_cli_status_row = NULL;
 
 /* ── Remote-mode settings group ── */
 static GtkWidget *gen_remote_group = NULL;
@@ -723,6 +742,162 @@ static void on_gen_remote_apply_clicked(GtkButton *button, gpointer user_data) {
     gen_remote_set_test_status("✅ Remote settings saved and applied");
 }
 
+/* ── Behavior toggle helpers (Heartbeats + Browser Control) ── */
+
+static void gen_heartbeats_set_row_active(gboolean active) {
+    if (!gen_heartbeats_row || !ADW_IS_SWITCH_ROW(gen_heartbeats_row)) return;
+    gen_heartbeats_programmatic_change = TRUE;
+    adw_switch_row_set_active(ADW_SWITCH_ROW(gen_heartbeats_row), active);
+    gen_heartbeats_programmatic_change = FALSE;
+}
+
+static void gen_browser_set_row_active(gboolean active) {
+    if (!gen_browser_row || !ADW_IS_SWITCH_ROW(gen_browser_row)) return;
+    gen_browser_programmatic_change = TRUE;
+    adw_switch_row_set_active(ADW_SWITCH_ROW(gen_browser_row), active);
+    gen_browser_programmatic_change = FALSE;
+}
+
+static void gen_browser_set_subtitle(const char *subtitle) {
+    if (!gen_browser_row || !ADW_IS_ACTION_ROW(gen_browser_row)) return;
+    adw_action_row_set_subtitle(ADW_ACTION_ROW(gen_browser_row),
+                                subtitle ? subtitle : "");
+}
+
+static void gen_browser_set_sensitive(gboolean sensitive) {
+    if (!gen_browser_row) return;
+    gtk_widget_set_sensitive(gen_browser_row, sensitive);
+}
+
+/*
+ * Repaint the row from the shared `browser_control_state` cache.
+ * Called both from the subscriber callback (when the cache changes)
+ * and during section build to seed the initial state.
+ */
+static void gen_browser_render_from_state(void) {
+    if (!gen_browser_row) return;
+
+    gboolean enabled = FALSE;
+    gboolean known = FALSE;
+    browser_control_state_get(&enabled, &known);
+
+    if (known) {
+        gen_browser_set_row_active(enabled);
+        gen_browser_set_subtitle(
+            "Allow agents to drive a managed browser session.");
+        gen_browser_set_sensitive(TRUE);
+        return;
+    }
+
+    if (browser_control_state_is_refreshing()) {
+        gen_browser_set_subtitle("Loading current setting…");
+        gen_browser_set_sensitive(FALSE);
+        return;
+    }
+
+    gen_browser_set_subtitle(
+        "Browser Control state unavailable — gateway not ready yet.");
+    gen_browser_set_sensitive(TRUE);
+}
+
+static void on_gen_browser_state_changed(gpointer user_data) {
+    (void)user_data;
+    /* Cache changed (refresh or set completed). Re-render — this also
+     * clears the optimistic "Saving…" subtitle on save success. */
+    gen_browser_render_from_state();
+}
+
+static void on_gen_browser_save_done(const BrowserControlStateSetResult *result,
+                                     gpointer user_data) {
+    (void)user_data;
+    if (!gen_browser_row) return;
+
+    if (result && result->status == BROWSER_CONTROL_STATE_OK) {
+        /* Subscribers fired before this callback so the row already
+         * reflects the new authoritative state. Nothing else to do. */
+        return;
+    }
+
+    OC_LOG_INFO(OPENCLAW_LOG_CAT_GATEWAY,
+                "Browser Control toggle failed: status=%d msg=%s",
+                result ? (int)result->status : -1,
+                result && result->error_msg ? result->error_msg : "(none)");
+
+    /* On failure the shared cache is unchanged. Re-render from cache
+     * to revert the optimistic switch position, then overlay an
+     * actionable subtitle so the operator sees what happened. */
+    gen_browser_render_from_state();
+    gen_browser_set_subtitle("Browser Control change failed — please try again.");
+}
+
+void section_general_request_heartbeats(gboolean enabled) {
+    (void)product_state_set_heartbeats_enabled(enabled);
+    gen_heartbeats_set_row_active(enabled);
+    /*
+     * Best-effort RPC push. When WS isn't yet connected the local
+     * persistence above will be replayed by the WS-ready hook in
+     * gateway_client.c, so this is safe to skip silently.
+     */
+    if (gateway_client_is_connected()) {
+        gateway_client_resync_heartbeats_intent();
+    }
+}
+
+void section_general_request_browser_control(gboolean enabled) {
+    /*
+     * Section-side compatibility wrapper around the shared mutator.
+     * Adds optimistic UI: paint the desired position, lock the row,
+     * and surface "Saving…" until the subscriber-driven repaint or
+     * the failure callback runs. The optimistic helpers are NULL-safe
+     * so calling this when the row isn't mounted is harmless.
+     */
+    if (gen_browser_row) {
+        gen_browser_set_row_active(enabled);
+        gen_browser_set_sensitive(FALSE);
+        gen_browser_set_subtitle("Saving…");
+    }
+    browser_control_state_request_set(enabled, on_gen_browser_save_done, NULL);
+}
+
+gboolean section_general_heartbeats_enabled(void) {
+    return product_state_get_heartbeats_enabled();
+}
+
+static void on_gen_heartbeats_active_notify(GObject *object,
+                                            GParamSpec *pspec,
+                                            gpointer user_data) {
+    (void)pspec;
+    (void)user_data;
+    if (gen_heartbeats_programmatic_change) return;
+    if (!ADW_IS_SWITCH_ROW(object)) return;
+
+    gboolean enabled = adw_switch_row_get_active(ADW_SWITCH_ROW(object));
+    section_general_request_heartbeats(enabled);
+}
+
+static void on_gen_browser_active_notify(GObject *object,
+                                         GParamSpec *pspec,
+                                         gpointer user_data) {
+    (void)pspec;
+    (void)user_data;
+    if (gen_browser_programmatic_change) return;
+    if (!ADW_IS_SWITCH_ROW(object)) return;
+
+    gboolean enabled = adw_switch_row_get_active(ADW_SWITCH_ROW(object));
+    section_general_request_browser_control(enabled);
+}
+
+/* ── Companion CLI status helpers ── */
+
+static void gen_cli_refresh_status_row(void) {
+    if (!gen_cli_status_row || !ADW_IS_ACTION_ROW(gen_cli_status_row)) return;
+    gboolean present = onboarding_cli_is_present();
+    adw_action_row_set_subtitle(ADW_ACTION_ROW(gen_cli_status_row),
+        present
+            ? "Detected on PATH."
+            : "Not detected — open onboarding to install the openclaw CLI.");
+}
+
 static GtkWidget* general_build(void) {
     GtkWidget *scrolled = gtk_scrolled_window_new();
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled),
@@ -773,6 +948,53 @@ static GtkWidget* general_build(void) {
     gen_connection_mode_detail_row = general_note_row("Availability");
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(connection_group), gen_connection_mode_detail_row);
     refresh_general_connection_mode_controls();
+
+    /* ── Behavior toggles (Heartbeats + Browser Control) ── */
+    GtkWidget *behavior_group = adw_preferences_group_new();
+    adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(behavior_group), "Behavior");
+    adw_preferences_group_set_description(ADW_PREFERENCES_GROUP(behavior_group),
+        "Everyday on/off toggles shared with the tray menu.");
+    adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(behavior_group));
+
+    gen_heartbeats_row = adw_switch_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(gen_heartbeats_row),
+                                  "Send Heartbeats");
+    adw_action_row_set_subtitle(ADW_ACTION_ROW(gen_heartbeats_row),
+        "Periodically nudge the gateway so it can drive scheduled work and presence.");
+    gen_heartbeats_set_row_active(product_state_get_heartbeats_enabled());
+    g_signal_connect(gen_heartbeats_row, "notify::active",
+                     G_CALLBACK(on_gen_heartbeats_active_notify), NULL);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(behavior_group), gen_heartbeats_row);
+
+    gen_browser_row = adw_switch_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(gen_browser_row),
+                                  "Browser Control");
+    g_signal_connect(gen_browser_row, "notify::active",
+                     G_CALLBACK(on_gen_browser_active_notify), NULL);
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(behavior_group), gen_browser_row);
+
+    /* Subscribe to the shared cache and paint the current state. The
+     * subscription stays active until `general_destroy` unhooks it,
+     * so any cache change triggered by the tray (or by a parallel
+     * refresh) repaints the row in place. */
+    gen_browser_render_from_state();
+    if (gen_browser_state_sub == 0) {
+        gen_browser_state_sub =
+            browser_control_state_subscribe(on_gen_browser_state_changed, NULL);
+    }
+    {
+        gboolean bc_known = FALSE;
+        browser_control_state_get(NULL, &bc_known);
+        if (!bc_known) {
+            /* Best-effort kick. If WS isn't yet connected the cache
+             * stays unknown and the WS-connected hook in
+             * gateway_client.c will retry; in either case the
+             * subscriber callback will paint the row when the value
+             * lands. */
+            browser_control_state_refresh();
+            gen_browser_render_from_state();
+        }
+    }
 
     /* ── Exec approvals quick-mode picker ── */
     GtkWidget *approvals_group = adw_preferences_group_new();
@@ -964,6 +1186,19 @@ static GtkWidget* general_build(void) {
     adw_preferences_group_set_title(ADW_PREFERENCES_GROUP(companion_group), "Companion");
     adw_preferences_page_add(ADW_PREFERENCES_PAGE(page), ADW_PREFERENCES_GROUP(companion_group));
 
+    /*
+     * Passive read-only OpenClaw CLI presence indicator. Onboarding
+     * remains the single owner of CLI install guidance — we surface
+     * the same `onboarding_cli_is_present()` truth here without
+     * duplicating the install copy or auto-running install scripts.
+     * Operators recover by clicking Re-run Onboarding below.
+     */
+    gen_cli_status_row = adw_action_row_new();
+    adw_preferences_row_set_title(ADW_PREFERENCES_ROW(gen_cli_status_row),
+                                  "OpenClaw CLI");
+    adw_preferences_group_add(ADW_PREFERENCES_GROUP(companion_group), gen_cli_status_row);
+    gen_cli_refresh_status_row();
+
     GtkWidget *onboard_btn = gtk_button_new_with_label("Re-run Onboarding");
     g_signal_connect(onboard_btn, "clicked", G_CALLBACK(on_gen_rerun_onboarding), NULL);
     adw_preferences_group_add(ADW_PREFERENCES_GROUP(companion_group),
@@ -1059,6 +1294,9 @@ static void general_refresh(void) {
     refresh_general_approval_mode_controls();
     gen_remote_refresh_group_visibility();
     gen_remote_refresh_status_row();
+    gen_heartbeats_set_row_active(product_state_get_heartbeats_enabled());
+    gen_browser_render_from_state();
+    gen_cli_refresh_status_row();
 
     gtk_widget_set_sensitive(gen_btn_start, dm.can_start);
     gtk_widget_set_sensitive(gen_btn_stop, dm.can_stop);
@@ -1118,6 +1356,20 @@ static void general_destroy(void) {
     gen_remote_status_row = NULL;
     gen_remote_test_btn = NULL;
     gen_remote_apply_btn = NULL;
+
+    /* Behavior toggles + CLI status row cleanup. The shared
+     * `browser_control_state` cache is process-scoped and survives
+     * section rebuilds — we just unsubscribe so the destroyed row
+     * can't be repainted from a delayed transport callback. */
+    if (gen_browser_state_sub) {
+        browser_control_state_unsubscribe(gen_browser_state_sub);
+        gen_browser_state_sub = 0;
+    }
+    gen_heartbeats_row = NULL;
+    gen_heartbeats_programmatic_change = FALSE;
+    gen_browser_row = NULL;
+    gen_browser_programmatic_change = FALSE;
+    gen_cli_status_row = NULL;
     gen_remote_test_status_label = NULL;
 }
 

--- a/apps/linux/src/section_general.h
+++ b/apps/linux/src/section_general.h
@@ -1,5 +1,32 @@
 #pragma once
 
+#include <glib.h>
+
 #include "section_controller.h"
 
 const SectionController* section_general_get(void);
+
+/*
+ * Public funnels for the two everyday toggles introduced in Tranche E.
+ *
+ * Heartbeats: persists the choice via product_state and pushes the
+ * `set-heartbeats` RPC. Safe to call when WS is disconnected — the
+ * persisted value will be re-asserted on the next WS-ready transition.
+ *
+ * Browser Control: thin section-side compatibility wrapper around
+ * `browser_control_state_request_set` that adds optimistic UI on top
+ * of the shared mutator. Tray-driven toggles bypass this wrapper and
+ * call `browser_control_state_request_set` directly so the tray does
+ * not depend on the General section being mounted.
+ */
+void section_general_request_heartbeats(gboolean enabled);
+void section_general_request_browser_control(gboolean enabled);
+
+/*
+ * Best-effort heartbeats probe used by the tray host so it can emit
+ * `CHECK:HEARTBEATS:0|1` lines that match what the General section
+ * would render. Browser Control state is read directly from
+ * `browser_control_state_get` instead — there is no
+ * section-mediated accessor for it.
+ */
+gboolean section_general_heartbeats_enabled(void);

--- a/apps/linux/src/shell_sections.c
+++ b/apps/linux/src/shell_sections.c
@@ -99,6 +99,25 @@ const ShellSectionMeta* shell_sections_meta(AppSection section) {
     return &section_meta[section];
 }
 
+gboolean shell_sections_section_for_id(const char *section_id,
+                                       AppSection *out_section) {
+    if (!section_id || section_id[0] == '\0') return FALSE;
+
+    for (int i = 0; i < SECTION_COUNT; i++) {
+        const ShellSectionMeta *meta = &section_meta[i];
+        if (!meta->id) continue;
+        if (g_ascii_strcasecmp(meta->id, section_id) != 0) continue;
+
+        AppSection candidate = (AppSection)i;
+        if (!shell_sections_is_visible(candidate)) {
+            return FALSE;
+        }
+        if (out_section) *out_section = candidate;
+        return TRUE;
+    }
+    return FALSE;
+}
+
 const char* shell_sections_group_heading(ShellSectionGroup group) {
     switch (group) {
     case SHELL_SECTION_GROUP_PARITY:

--- a/apps/linux/src/shell_sections.h
+++ b/apps/linux/src/shell_sections.h
@@ -26,6 +26,17 @@ typedef struct {
 gboolean shell_sections_is_embedded(AppSection section);
 gboolean shell_sections_is_visible(AppSection section);
 const ShellSectionMeta* shell_sections_meta(AppSection section);
+
+/*
+ * Resolve a shell-section id string (e.g. "channels") to its
+ * AppSection enum. Returns TRUE on a known, embedded, currently-visible
+ * section and writes the match into *out_section; returns FALSE
+ * otherwise (unknown id, not embedded, or gated out by the host's
+ * visibility rules — notably SECTION_DEBUG hidden without
+ * OPENCLAW_DEBUG_PANE). `out_section` may be NULL for a pure probe.
+ */
+gboolean shell_sections_section_for_id(const char *section_id,
+                                       AppSection *out_section);
 const char* shell_sections_group_heading(ShellSectionGroup group);
 const SectionController* shell_sections_controller(AppSection section);
 gsize shell_sections_display_count(void);

--- a/apps/linux/src/tray.c
+++ b/apps/linux/src/tray.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include "state.h"
 #include "log.h"
+#include "browser_control_state.h"
 #include "chat_window.h"
 #include "debug_actions.h"
 #include "exec_approval_prompter.h"
@@ -29,6 +30,7 @@
 #include "onboarding.h"
 #include "product_coordinator.h"
 #include "product_state.h"
+#include "section_general.h"
 #include "shell_sections.h"
 #include "test_seams.h"
 #include "tray_protocol.h"
@@ -37,6 +39,14 @@ static GSubprocess *helper_process = NULL;
 static GOutputStream *helper_stdin = NULL;
 static GDataInputStream *helper_stdout_stream = NULL;
 static guint helper_seq = 0;
+/*
+ * Subscription id into `browser_control_state`. When the shared
+ * cache changes asynchronously (e.g., a WS-connected refresh lands
+ * while the user is on a non-General section, or another surface
+ * toggles Browser Control) we push a full tray update so the tray
+ * helper re-receives MENU_VISIBLE:BROWSER_CONTROL + CHECK:BROWSER_CONTROL.
+ */
+static guint tray_browser_control_sub = 0;
 
 static void on_helper_process_weak_notify(gpointer data, GObject *where_the_object_was) {
     (void)data;
@@ -179,6 +189,25 @@ static void handle_helper_action(const gchar *action) {
             }
         }
         g_free(mode_str);
+    } else if (g_str_has_prefix(action, "HEARTBEATS_SET:") ||
+               g_str_has_prefix(action, "BROWSER_CONTROL_SET:")) {
+        /* Tranche E binary check toggles. Heartbeats routes through
+         * the section funnel (local persistence + RPC push). Browser
+         * Control routes through the shared `browser_control_state`
+         * mutator so tray-driven toggles do not depend on the General
+         * section being mounted; subscribers (including the tray's
+         * own `on_browser_control_state_changed` below) repaint the
+         * CHECK line when the save lands. */
+        char *key = NULL;
+        gboolean enabled = FALSE;
+        if (tray_protocol_parse_check_action(action, &key, &enabled)) {
+            if (g_strcmp0(key, "HEARTBEATS") == 0) {
+                section_general_request_heartbeats(enabled);
+            } else if (g_strcmp0(key, "BROWSER_CONTROL") == 0) {
+                browser_control_state_request_set(enabled, NULL, NULL);
+            }
+        }
+        g_free(key);
     } else {
         /* All remaining tray actions belong to the shared debug-action
          * registry. Unknown actions are silently ignored — the helper
@@ -272,6 +301,17 @@ static void on_helper_exited(GObject *source_object, GAsyncResult *res, gpointer
     }
 }
 
+static void on_tray_browser_control_state_changed(gpointer user_data) {
+    (void)user_data;
+    /* The cache flipped (refresh landed, or a save completed). Push a
+     * full tray update so MENU_VISIBLE:BROWSER_CONTROL and
+     * CHECK:BROWSER_CONTROL reflect the new truth. Using the full
+     * update path avoids duplicating line-formatting logic and keeps
+     * all other tray fields in sync. */
+    if (!helper_stdin) return;
+    tray_update_from_state(state_get_current());
+}
+
 void tray_init(void) {
     g_autoptr(GError) error = NULL;
     g_autofree gchar *helper_path = NULL;
@@ -283,6 +323,14 @@ void tray_init(void) {
     oc_debug_actions_set_uri_launcher(tray_debug_uri_launcher, NULL);
     oc_debug_actions_set_clipboard_writer(tray_debug_clipboard_writer, NULL);
     oc_debug_actions_set_show_section_handler(tray_debug_show_section, NULL);
+
+    /* Subscribe once (idempotent) to the shared Browser Control cache
+     * so async refreshes / out-of-band saves reach the tray without
+     * requiring the General section to be mounted. */
+    if (tray_browser_control_sub == 0) {
+        tray_browser_control_sub =
+            browser_control_state_subscribe(on_tray_browser_control_state_changed, NULL);
+    }
     
     // 1. Try build-tree sibling path first
     g_autofree gchar *exe_path = g_file_read_link("/proc/self/exe", NULL);
@@ -520,11 +568,39 @@ void tray_update_from_state(const AppState state) {
     g_autofree gchar *menu_restart_app =
         tray_protocol_format_menu_visible("RESTART_APP", TRUE);
 
+    /*
+     * Tranche E binary toggles. Heartbeats is always visible because
+     * its source-of-truth (product_state) is local and always
+     * populated; Browser Control is only revealed once the shared
+     * `browser_control_state` cache has landed a successful
+     * `config.get` so the displayed state matches the gateway's
+     * current value. The cache lives independently of the General
+     * section, so tray visibility no longer requires the General row
+     * to have ever been mounted. */
+    gboolean browser_known = FALSE;
+    gboolean browser_enabled = FALSE;
+    browser_control_state_get(&browser_enabled, &browser_known);
+
+    g_autofree gchar *menu_heartbeats =
+        tray_protocol_format_menu_visible("HEARTBEATS", TRUE);
+    g_autofree gchar *menu_browser_control =
+        tray_protocol_format_menu_visible("BROWSER_CONTROL", browser_known);
+    g_autofree gchar *check_heartbeats =
+        tray_protocol_format_check("HEARTBEATS",
+                                   section_general_heartbeats_enabled());
+    g_autofree gchar *check_browser_control = browser_known
+        ? tray_protocol_format_check("BROWSER_CONTROL", browser_enabled)
+        : NULL;
+
     if (menu_open_debug)        send_line_to_helper(menu_open_debug, NULL);
     if (menu_exec_approval)     send_line_to_helper(menu_exec_approval, NULL);
     if (menu_approvals_pending) send_line_to_helper(menu_approvals_pending, NULL);
     if (menu_reset_tunnel)      send_line_to_helper(menu_reset_tunnel, NULL);
     if (menu_restart_app)       send_line_to_helper(menu_restart_app, NULL);
+    if (menu_heartbeats)        send_line_to_helper(menu_heartbeats, NULL);
+    if (menu_browser_control)   send_line_to_helper(menu_browser_control, NULL);
+    if (check_heartbeats)       send_line_to_helper(check_heartbeats, NULL);
+    if (check_browser_control)  send_line_to_helper(check_browser_control, NULL);
 
     if (mode_token) {
         g_autofree gchar *radio_line =

--- a/apps/linux/src/tray_helper.c
+++ b/apps/linux/src/tray_helper.c
@@ -66,6 +66,13 @@ static GtkWidget *approvals_pending_item = NULL;
 static GtkWidget *reset_remote_tunnel_item = NULL;
 static GtkWidget *restart_app_item = NULL;
 
+/* Tranche E binary toggles. Hidden by default — the host's first
+ * `MENU_VISIBLE:HEARTBEATS:1` / `MENU_VISIBLE:BROWSER_CONTROL:1`
+ * line reveals each item once it has the source-of-truth value to
+ * paint. */
+static GtkWidget *heartbeats_check_item = NULL;
+static GtkWidget *browser_control_check_item = NULL;
+
 /* Navigation actions */
 static GtkWidget *open_main_item = NULL;
 static GtkWidget *open_dashboard_item = NULL;
@@ -137,6 +144,23 @@ static void on_exec_approval_radio_activate(GtkRadioMenuItem *item, gpointer dat
     send_action(line);
 }
 
+/*
+ * Tranche E check-toggle handlers. Each item carries its KEY token
+ * via `g_object_set_data(item, "tray-check-key", "HEARTBEATS"|...)`
+ * so a single callback can serve every binary toggle. The
+ * `updating_from_host` guard prevents a host-driven CHECK update
+ * from echoing back as ACTION:<KEY>_SET.
+ */
+static void on_check_item_toggled(GtkCheckMenuItem *item, gpointer data) {
+    (void)data;
+    if (updating_from_host) return;
+    const char *key = g_object_get_data(G_OBJECT(item), "tray-check-key");
+    if (!key) return;
+    gboolean active = gtk_check_menu_item_get_active(item);
+    g_autofree gchar *line = g_strdup_printf("%s_SET:%d", key, active ? 1 : 0);
+    send_action(line);
+}
+
 static void on_quit_clicked(GtkMenuItem *item, gpointer data) { 
     (void)item; (void)data;
     send_action("QUIT"); 
@@ -156,6 +180,8 @@ static GtkWidget* widget_for_menu_key(TrayHelperMenuKey key) {
     case TRAY_HELPER_MENU_KEY_APPROVALS_PENDING:   return approvals_pending_item;
     case TRAY_HELPER_MENU_KEY_RESET_REMOTE_TUNNEL: return reset_remote_tunnel_item;
     case TRAY_HELPER_MENU_KEY_RESTART_APP:         return restart_app_item;
+    case TRAY_HELPER_MENU_KEY_HEARTBEATS:          return heartbeats_check_item;
+    case TRAY_HELPER_MENU_KEY_BROWSER_CONTROL:     return browser_control_check_item;
     case TRAY_HELPER_MENU_KEY_UNKNOWN:
     default:                                       return NULL;
     }
@@ -208,10 +234,22 @@ static void helper_set_approvals_count(guint count, gpointer ud) {
     else         gtk_widget_hide(approvals_pending_item);
 }
 
+static void helper_set_check_state(TrayHelperMenuKey key, gboolean checked, gpointer ud) {
+    (void)ud;
+    GtkWidget *w = widget_for_menu_key(key);
+    if (!w || !GTK_IS_CHECK_MENU_ITEM(w)) return;
+    /* Apply under the host-update guard so the resulting `toggled`
+     * signal does not echo a `<KEY>_SET:<flag>` ACTION back. */
+    updating_from_host = TRUE;
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(w), checked);
+    updating_from_host = FALSE;
+}
+
 static const TrayHelperProtocolHandlers helper_protocol_handlers = {
     .set_menu_visible        = helper_set_menu_visible,
     .set_radio_exec_approval = helper_set_radio_exec_approval,
     .set_approvals_count     = helper_set_approvals_count,
+    .set_check_state         = helper_set_check_state,
     .user_data               = NULL,
 };
 
@@ -345,6 +383,35 @@ int main(int argc, char **argv) {
     refresh_item = gtk_menu_item_new_with_label("Refresh Status");
     g_signal_connect(refresh_item, "activate", G_CALLBACK(on_refresh_clicked), NULL);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), refresh_item);
+
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+
+    /* ── Behavior toggles (Tranche E) ──
+     *
+     * Hidden by default. The host emits a MENU_VISIBLE:<KEY>:1 line
+     * once it has the source-of-truth value to render, paired with a
+     * CHECK:<KEY>:0|1 line that paints the initial state under the
+     * `updating_from_host` guard. Operator clicks emit
+     * `ACTION:<KEY>_SET:<0|1>`; on the host side HEARTBEATS routes
+     * through the General-section / product_state funnel
+     * (`section_general_request_heartbeats`), while BROWSER_CONTROL
+     * routes through the shared `browser_control_state` cache
+     * (`browser_control_state_request_set`) so the tray does not
+     * depend on the General section being mounted.
+     */
+    heartbeats_check_item = gtk_check_menu_item_new_with_label("Send Heartbeats");
+    g_object_set_data(G_OBJECT(heartbeats_check_item), "tray-check-key", "HEARTBEATS");
+    g_signal_connect(heartbeats_check_item, "toggled",
+                     G_CALLBACK(on_check_item_toggled), NULL);
+    gtk_widget_set_no_show_all(heartbeats_check_item, TRUE);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), heartbeats_check_item);
+
+    browser_control_check_item = gtk_check_menu_item_new_with_label("Browser Control");
+    g_object_set_data(G_OBJECT(browser_control_check_item), "tray-check-key", "BROWSER_CONTROL");
+    g_signal_connect(browser_control_check_item, "toggled",
+                     G_CALLBACK(on_check_item_toggled), NULL);
+    gtk_widget_set_no_show_all(browser_control_check_item, TRUE);
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), browser_control_check_item);
 
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 

--- a/apps/linux/src/tray_helper_protocol.c
+++ b/apps/linux/src/tray_helper_protocol.c
@@ -21,6 +21,8 @@ TrayHelperMenuKey tray_helper_protocol_menu_key_from_string(const char *s) {
     if (g_strcmp0(s, "APPROVALS_PENDING")   == 0) return TRAY_HELPER_MENU_KEY_APPROVALS_PENDING;
     if (g_strcmp0(s, "RESET_REMOTE_TUNNEL") == 0) return TRAY_HELPER_MENU_KEY_RESET_REMOTE_TUNNEL;
     if (g_strcmp0(s, "RESTART_APP")         == 0) return TRAY_HELPER_MENU_KEY_RESTART_APP;
+    if (g_strcmp0(s, "HEARTBEATS")          == 0) return TRAY_HELPER_MENU_KEY_HEARTBEATS;
+    if (g_strcmp0(s, "BROWSER_CONTROL")     == 0) return TRAY_HELPER_MENU_KEY_BROWSER_CONTROL;
     return TRAY_HELPER_MENU_KEY_UNKNOWN;
 }
 
@@ -86,6 +88,29 @@ static gboolean apply_approvals(const TrayHelperProtocolHandlers *handlers,
     return TRUE;
 }
 
+static gboolean apply_check(const TrayHelperProtocolHandlers *handlers,
+                             const char *body) {
+    /* body shape: "<KEY>:0|1" — same flag grammar as MENU_VISIBLE. */
+    if (!body) return FALSE;
+    const char *colon = strchr(body, ':');
+    if (!colon || colon == body) return FALSE;
+
+    g_autofree gchar *action = g_strndup(body, (gsize)(colon - body));
+    const char *flag = colon + 1;
+    if (flag[0] == '\0' || flag[1] != '\0') return FALSE;
+    if (flag[0] != '0' && flag[0] != '1') return FALSE;
+
+    TrayHelperMenuKey key = tray_helper_protocol_menu_key_from_string(action);
+    if (key == TRAY_HELPER_MENU_KEY_UNKNOWN) {
+        return FALSE;
+    }
+
+    if (handlers && handlers->set_check_state) {
+        handlers->set_check_state(key, flag[0] == '1', handlers->user_data);
+    }
+    return TRUE;
+}
+
 gboolean tray_helper_protocol_apply_line(const TrayHelperProtocolHandlers *handlers,
                                           const char *line) {
     if (!line) return FALSE;
@@ -98,6 +123,9 @@ gboolean tray_helper_protocol_apply_line(const TrayHelperProtocolHandlers *handl
     }
     if (g_str_has_prefix(line, "APPROVALS:")) {
         return apply_approvals(handlers, line + sizeof("APPROVALS:") - 1);
+    }
+    if (g_str_has_prefix(line, "CHECK:")) {
+        return apply_check(handlers, line + sizeof("CHECK:") - 1);
     }
 
     return FALSE;

--- a/apps/linux/src/tray_helper_protocol.h
+++ b/apps/linux/src/tray_helper_protocol.h
@@ -40,6 +40,11 @@ typedef enum {
     TRAY_HELPER_MENU_KEY_APPROVALS_PENDING,
     TRAY_HELPER_MENU_KEY_RESET_REMOTE_TUNNEL,
     TRAY_HELPER_MENU_KEY_RESTART_APP,
+    /* Tranche E binary check toggles. When extending TrayHelperMenuKey,
+     * remember to extend the helper's `widget_for_menu_key` switch and
+     * the `tray_helper_protocol_menu_key_from_string` parser as well. */
+    TRAY_HELPER_MENU_KEY_HEARTBEATS,
+    TRAY_HELPER_MENU_KEY_BROWSER_CONTROL,
 } TrayHelperMenuKey;
 
 typedef struct {
@@ -55,6 +60,12 @@ typedef struct {
     /* Update the pending-approvals counter. Helper computes the
      * displayed label and visibility from the count. */
     void (*set_approvals_count)(guint count, gpointer user_data);
+
+    /* Set the checked state of a binary toggle item (Tranche E). The
+     * helper must use its `updating_from_host` guard so the resulting
+     * GtkCheckMenuItem::toggled does not re-emit an ACTION line. Keys
+     * that don't map to a check item are silently ignored. */
+    void (*set_check_state)(TrayHelperMenuKey key, gboolean checked, gpointer user_data);
 
     gpointer user_data;
 } TrayHelperProtocolHandlers;

--- a/apps/linux/src/tray_protocol.c
+++ b/apps/linux/src/tray_protocol.c
@@ -55,3 +55,63 @@ gboolean tray_protocol_parse_exec_approval_action(const char *action, char **out
     if (out_mode) *out_mode = g_strdup(mode);
     return TRUE;
 }
+
+static gboolean check_key_is_valid(const char *key) {
+    if (!key || key[0] == '\0') return FALSE;
+    for (const char *p = key; *p; p++) {
+        if (*p == ':' || *p == '\n' || *p == ' ' || *p == '\r') {
+            return FALSE;
+        }
+    }
+    return TRUE;
+}
+
+gchar* tray_protocol_format_check(const char *key, gboolean checked) {
+    if (!check_key_is_valid(key)) return NULL;
+    return g_strdup_printf("CHECK:%s:%d\n", key, checked ? 1 : 0);
+}
+
+gboolean tray_protocol_parse_check_action(const char *action,
+                                          char **out_key,
+                                          gboolean *out_value) {
+    if (!action) return FALSE;
+
+    /* Action body shape: "<KEY>_SET:<0|1>". The KEY token must end
+     * with the literal "_SET" infix immediately before the colon, and
+     * the trailing flag must be exactly one of '0' or '1' with no
+     * extra characters. The host strips the `ACTION:` prefix before
+     * reaching this parser. */
+    const char *colon = strchr(action, ':');
+    if (!colon) return FALSE;
+
+    /* Reject extra colons. */
+    if (strchr(colon + 1, ':') != NULL) return FALSE;
+
+    /* Validate the flag suffix. */
+    const char *flag = colon + 1;
+    if (flag[0] == '\0' || flag[1] != '\0') return FALSE;
+    if (flag[0] != '0' && flag[0] != '1') return FALSE;
+
+    gsize head_len = (gsize)(colon - action);
+    static const char suffix[] = "_SET";
+    const gsize suffix_len = sizeof(suffix) - 1;
+    if (head_len <= suffix_len) return FALSE;
+
+    /* The head before the colon must end with `_SET`. */
+    if (memcmp(action + head_len - suffix_len, suffix, suffix_len) != 0) {
+        return FALSE;
+    }
+
+    /* The KEY token is the substring before `_SET`. Reject empty
+     * keys, whitespace, and embedded newlines. */
+    gsize key_len = head_len - suffix_len;
+    if (key_len == 0) return FALSE;
+    for (gsize i = 0; i < key_len; i++) {
+        char c = action[i];
+        if (c == ' ' || c == '\n' || c == '\r' || c == '\t') return FALSE;
+    }
+
+    if (out_key) *out_key = g_strndup(action, key_len);
+    if (out_value) *out_value = (flag[0] == '1');
+    return TRUE;
+}

--- a/apps/linux/src/tray_protocol.h
+++ b/apps/linux/src/tray_protocol.h
@@ -69,4 +69,30 @@ gboolean tray_protocol_parse_exec_approval_action(const char *action, char **out
  */
 gboolean tray_protocol_exec_approval_mode_is_valid(const char *mode);
 
+/*
+ * Format a CHECK line for a binary toggle menu item. Tranche E adds
+ * two such items: HEARTBEATS and BROWSER_CONTROL.
+ *
+ *   CHECK:<KEY>:0|1\n
+ *
+ * `key` must be a non-empty bare token without colons, spaces, or
+ * newlines. Returns NULL for any malformed key. Caller frees with
+ * g_free().
+ */
+gchar* tray_protocol_format_check(const char *key, gboolean checked);
+
+/*
+ * Parse the body of a `<KEY>_SET:0|1` action line (i.e. the substring
+ * AFTER `ACTION:`). On success writes a newly-allocated copy of the
+ * KEY token (without the trailing `_SET:<flag>`) into `*out_key` and
+ * the parsed boolean into `*out_value`. Either out-pointer may be
+ * NULL — the function still returns the validity verdict.
+ *
+ * Rejects any input with extra colons, whitespace, non-binary flags,
+ * empty keys, missing `_SET` infix, or trailing characters.
+ */
+gboolean tray_protocol_parse_check_action(const char *action,
+                                          char **out_key,
+                                          gboolean *out_value);
+
 #endif /* OPENCLAW_LINUX_TRAY_PROTOCOL_H */

--- a/apps/linux/tests/test_browser_control_state.c
+++ b/apps/linux/tests/test_browser_control_state.c
@@ -1,0 +1,321 @@
+/*
+ * test_browser_control_state.c
+ *
+ * Headless regression for the shared Browser Control state module.
+ *
+ * The module is GTK-free and dispatches RPC through a transport
+ * struct, so each test installs a small stub transport that captures
+ * the pending callback. The test then drives the callback directly to
+ * exercise refresh and set completion paths without standing up the
+ * gateway.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include <glib.h>
+#include <string.h>
+
+#include "../src/browser_control_state.h"
+
+/* ── stub transport ───────────────────────────────────────────── */
+
+typedef struct {
+    /* Captured refresh callback (set when the module calls
+     * `transport.refresh`). The test invokes it to "complete" the
+     * pending fetch. */
+    BrowserControlRefreshCb refresh_cb;
+    gpointer refresh_ctx;
+    int refresh_calls;
+
+    /* Captured save callback. */
+    BrowserControlSaveCb save_cb;
+    gpointer save_ctx;
+    gboolean save_arg_enabled;
+    int save_calls;
+} StubTransport;
+
+static StubTransport stub;
+
+static void stub_refresh(BrowserControlRefreshCb cb, gpointer ctx) {
+    stub.refresh_cb = cb;
+    stub.refresh_ctx = ctx;
+    stub.refresh_calls++;
+}
+
+static void stub_save(gboolean enabled, BrowserControlSaveCb cb, gpointer ctx) {
+    stub.save_cb = cb;
+    stub.save_ctx = ctx;
+    stub.save_arg_enabled = enabled;
+    stub.save_calls++;
+}
+
+static const BrowserControlStateTransport stub_transport_template = {
+    .refresh = stub_refresh,
+    .save = stub_save,
+};
+
+static void install_stub(void) {
+    memset(&stub, 0, sizeof(stub));
+    browser_control_state_test_reset();
+    browser_control_state_init();
+    browser_control_state_set_transport(&stub_transport_template);
+}
+
+/* ── subscriber recorder ──────────────────────────────────────── */
+
+typedef struct {
+    int calls;
+    /* The state observed at the time of each callback. */
+    gboolean last_known;
+    gboolean last_enabled;
+} SubscriberRecorder;
+
+static void on_state_changed(gpointer user_data) {
+    SubscriberRecorder *rec = user_data;
+    rec->calls++;
+    browser_control_state_get(&rec->last_enabled, &rec->last_known);
+}
+
+/* ── set-completion recorder ──────────────────────────────────── */
+
+typedef struct {
+    int calls;
+    BrowserControlStateStatus last_status;
+    gboolean last_attempted;
+} SetRecorder;
+
+static void on_set_done(const BrowserControlStateSetResult *result, gpointer user_data) {
+    SetRecorder *rec = user_data;
+    rec->calls++;
+    if (result) {
+        rec->last_status = result->status;
+        rec->last_attempted = result->attempted_enabled;
+    }
+}
+
+/* ── tests ────────────────────────────────────────────────────── */
+
+static void test_initial_state_is_unknown(void) {
+    install_stub();
+
+    gboolean enabled = TRUE; /* sentinel — should be cleared to FALSE */
+    gboolean known = TRUE;
+    browser_control_state_get(&enabled, &known);
+    g_assert_false(known);
+    g_assert_false(enabled);
+    g_assert_false(browser_control_state_is_refreshing());
+}
+
+static void test_refresh_success_populates_known_value(void) {
+    install_stub();
+
+    SubscriberRecorder rec = {0};
+    guint sub = browser_control_state_subscribe(on_state_changed, &rec);
+    g_assert_cmpuint(sub, !=, 0);
+
+    browser_control_state_refresh();
+    g_assert_cmpint(stub.refresh_calls, ==, 1);
+    g_assert_true(browser_control_state_is_refreshing());
+
+    /* Complete the fetch with enabled=TRUE. */
+    g_assert_nonnull(stub.refresh_cb);
+    stub.refresh_cb(TRUE, TRUE, NULL, stub.refresh_ctx);
+
+    gboolean enabled = FALSE, known = FALSE;
+    browser_control_state_get(&enabled, &known);
+    g_assert_true(known);
+    g_assert_true(enabled);
+    g_assert_false(browser_control_state_is_refreshing());
+
+    /* Subscriber fires exactly once on the refresh completion. */
+    g_assert_cmpint(rec.calls, ==, 1);
+    g_assert_true(rec.last_known);
+    g_assert_true(rec.last_enabled);
+
+    browser_control_state_unsubscribe(sub);
+}
+
+static void test_refresh_failure_keeps_unknown(void) {
+    install_stub();
+
+    SubscriberRecorder rec = {0};
+    browser_control_state_subscribe(on_state_changed, &rec);
+
+    browser_control_state_refresh();
+    stub.refresh_cb(FALSE, FALSE, "FETCH_FAILED", stub.refresh_ctx);
+
+    gboolean known = TRUE;
+    browser_control_state_get(NULL, &known);
+    g_assert_false(known);
+    g_assert_false(browser_control_state_is_refreshing());
+
+    /* Subscriber still fires so a "Loading…" subtitle can clear. */
+    g_assert_cmpint(rec.calls, ==, 1);
+}
+
+static void test_refresh_failure_after_known_preserves_value(void) {
+    install_stub();
+
+    /* First refresh — success with enabled=TRUE. */
+    browser_control_state_refresh();
+    stub.refresh_cb(TRUE, TRUE, NULL, stub.refresh_ctx);
+
+    /* Second refresh — failure. Cached value should remain TRUE. */
+    browser_control_state_refresh();
+    g_assert_cmpint(stub.refresh_calls, ==, 2);
+    stub.refresh_cb(FALSE, FALSE, "STALE", stub.refresh_ctx);
+
+    gboolean enabled = FALSE, known = FALSE;
+    browser_control_state_get(&enabled, &known);
+    g_assert_true(known);
+    g_assert_true(enabled);
+}
+
+static void test_concurrent_refresh_is_coalesced(void) {
+    install_stub();
+
+    browser_control_state_refresh();
+    browser_control_state_refresh(); /* should be a no-op while in flight */
+
+    g_assert_cmpint(stub.refresh_calls, ==, 1);
+}
+
+static void test_request_set_success_updates_cache(void) {
+    install_stub();
+
+    SubscriberRecorder rec = {0};
+    browser_control_state_subscribe(on_state_changed, &rec);
+
+    SetRecorder srec = {0};
+    browser_control_state_request_set(TRUE, on_set_done, &srec);
+    g_assert_cmpint(stub.save_calls, ==, 1);
+    g_assert_true(stub.save_arg_enabled);
+
+    /* Complete the save successfully. */
+    stub.save_cb(TRUE, NULL, stub.save_ctx);
+
+    gboolean enabled = FALSE, known = FALSE;
+    browser_control_state_get(&enabled, &known);
+    g_assert_true(known);
+    g_assert_true(enabled);
+
+    /* Subscriber + per-call callback both fire exactly once. */
+    g_assert_cmpint(rec.calls, ==, 1);
+    g_assert_cmpint(srec.calls, ==, 1);
+    g_assert_cmpint((int)srec.last_status, ==, (int)BROWSER_CONTROL_STATE_OK);
+    g_assert_true(srec.last_attempted);
+}
+
+static void test_request_set_failure_preserves_previous_known(void) {
+    install_stub();
+
+    /* Seed a known FALSE via refresh first. */
+    browser_control_state_refresh();
+    stub.refresh_cb(TRUE, FALSE, NULL, stub.refresh_ctx);
+
+    SubscriberRecorder rec = {0};
+    browser_control_state_subscribe(on_state_changed, &rec);
+
+    SetRecorder srec = {0};
+    browser_control_state_request_set(TRUE, on_set_done, &srec);
+    /* Now fail the save. The cached value MUST stay at known=TRUE,
+     * enabled=FALSE so the UI reverts to the last gateway truth. */
+    stub.save_cb(FALSE, "SAVE_FAILED", stub.save_ctx);
+
+    gboolean enabled = TRUE, known = FALSE;
+    browser_control_state_get(&enabled, &known);
+    g_assert_true(known);
+    g_assert_false(enabled);
+
+    /* Subscriber fires on save completion regardless of outcome. */
+    g_assert_cmpint(rec.calls, ==, 1);
+    g_assert_cmpint((int)srec.last_status, ==, (int)BROWSER_CONTROL_STATE_ERR_SAVE_FAILED);
+    g_assert_true(srec.last_attempted);
+}
+
+static void test_subscriber_unsubscribe_stops_callbacks(void) {
+    install_stub();
+
+    SubscriberRecorder rec = {0};
+    guint sub = browser_control_state_subscribe(on_state_changed, &rec);
+
+    browser_control_state_refresh();
+    stub.refresh_cb(TRUE, TRUE, NULL, stub.refresh_ctx);
+    g_assert_cmpint(rec.calls, ==, 1);
+
+    browser_control_state_unsubscribe(sub);
+
+    /* Drive another refresh; the unsubscribed callback must NOT fire. */
+    browser_control_state_refresh();
+    stub.refresh_cb(TRUE, FALSE, NULL, stub.refresh_ctx);
+    g_assert_cmpint(rec.calls, ==, 1);
+}
+
+static void test_subscribe_before_init_returns_valid_id(void) {
+    /* Reset to fresh state without calling init(). A caller that
+     * subscribes before init() — the tray today, in principle —
+     * must still receive a non-zero id, and its callback must fire
+     * normally once init/transport are wired and a refresh lands. */
+    memset(&stub, 0, sizeof(stub));
+    browser_control_state_test_reset();
+
+    SubscriberRecorder rec = {0};
+    guint sub = browser_control_state_subscribe(on_state_changed, &rec);
+    g_assert_cmpuint(sub, !=, 0);
+
+    browser_control_state_init();
+    browser_control_state_set_transport(&stub_transport_template);
+
+    browser_control_state_refresh();
+    g_assert_nonnull(stub.refresh_cb);
+    stub.refresh_cb(TRUE, TRUE, NULL, stub.refresh_ctx);
+
+    g_assert_cmpint(rec.calls, ==, 1);
+    g_assert_true(rec.last_known);
+    g_assert_true(rec.last_enabled);
+
+    browser_control_state_unsubscribe(sub);
+}
+
+static void test_request_set_without_transport_synthesises_failure(void) {
+    /* Reset and intentionally leave the transport detached. */
+    browser_control_state_test_reset();
+    browser_control_state_init();
+
+    SetRecorder srec = {0};
+    browser_control_state_request_set(TRUE, on_set_done, &srec);
+
+    g_assert_cmpint(srec.calls, ==, 1);
+    g_assert_cmpint((int)srec.last_status, ==, (int)BROWSER_CONTROL_STATE_ERR_SAVE_FAILED);
+
+    gboolean known = TRUE;
+    browser_control_state_get(NULL, &known);
+    g_assert_false(known);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/browser_control_state/initial_state_is_unknown",
+                    test_initial_state_is_unknown);
+    g_test_add_func("/browser_control_state/refresh_success_populates_known",
+                    test_refresh_success_populates_known_value);
+    g_test_add_func("/browser_control_state/refresh_failure_keeps_unknown",
+                    test_refresh_failure_keeps_unknown);
+    g_test_add_func("/browser_control_state/refresh_failure_after_known_preserves",
+                    test_refresh_failure_after_known_preserves_value);
+    g_test_add_func("/browser_control_state/concurrent_refresh_coalesced",
+                    test_concurrent_refresh_is_coalesced);
+    g_test_add_func("/browser_control_state/request_set_success_updates_cache",
+                    test_request_set_success_updates_cache);
+    g_test_add_func("/browser_control_state/request_set_failure_preserves_previous",
+                    test_request_set_failure_preserves_previous_known);
+    g_test_add_func("/browser_control_state/subscriber_unsubscribe_stops",
+                    test_subscriber_unsubscribe_stops_callbacks);
+    g_test_add_func("/browser_control_state/subscribe_before_init_returns_valid_id",
+                    test_subscribe_before_init_returns_valid_id);
+    g_test_add_func("/browser_control_state/request_set_no_transport",
+                    test_request_set_without_transport_synthesises_failure);
+
+    return g_test_run();
+}

--- a/apps/linux/tests/test_config.c
+++ b/apps/linux/tests/test_config.c
@@ -317,6 +317,94 @@ static void test_wizard_empty_last_run_at(void) {
     gateway_config_free(cfg);
 }
 
+/* ── browser.enabled transform (Tranche E) ─────────────────────── */
+
+static gboolean parse_browser_enabled(const gchar *raw, gboolean *out_value) {
+    g_autoptr(GError) err = NULL;
+    g_autoptr(JsonParser) parser = json_parser_new();
+    if (!json_parser_load_from_data(parser, raw, -1, &err)) return FALSE;
+    JsonNode *root = json_parser_get_root(parser);
+    if (!root || !JSON_NODE_HOLDS_OBJECT(root)) return FALSE;
+    JsonObject *obj = json_node_get_object(root);
+    if (!json_object_has_member(obj, "browser")) return FALSE;
+    JsonNode *node = json_object_get_member(obj, "browser");
+    if (!node || !JSON_NODE_HOLDS_OBJECT(node)) return FALSE;
+    JsonObject *browser = json_node_get_object(node);
+    if (!json_object_has_member(browser, "enabled")) return FALSE;
+    if (out_value) *out_value = json_object_get_boolean_member(browser, "enabled");
+    return TRUE;
+}
+
+static void test_setup_apply_browser_enabled_creates_object_when_missing(void) {
+    const gchar *raw = "{\"gateway\":{\"port\":18789}}";
+    g_autoptr(GError) err = NULL;
+    g_autofree gchar *updated = config_setup_apply_browser_enabled(raw, TRUE, &err);
+    g_assert_no_error(err);
+    g_assert_nonnull(updated);
+
+    gboolean parsed = FALSE;
+    g_assert_true(parse_browser_enabled(updated, &parsed));
+    g_assert_true(parsed);
+}
+
+static void test_setup_apply_browser_enabled_overwrites_existing(void) {
+    const gchar *raw = "{\"gateway\":{\"port\":18789},\"browser\":{\"enabled\":false,\"foo\":\"bar\"}}";
+    g_autoptr(GError) err = NULL;
+    g_autofree gchar *updated = config_setup_apply_browser_enabled(raw, TRUE, &err);
+    g_assert_no_error(err);
+    g_assert_nonnull(updated);
+
+    gboolean parsed = FALSE;
+    g_assert_true(parse_browser_enabled(updated, &parsed));
+    g_assert_true(parsed);
+
+    /* Other browser members must survive the toggle. */
+    g_autoptr(JsonParser) parser = json_parser_new();
+    g_assert_true(json_parser_load_from_data(parser, updated, -1, &err));
+    JsonObject *root = json_node_get_object(json_parser_get_root(parser));
+    JsonObject *browser = json_node_get_object(json_object_get_member(root, "browser"));
+    g_assert_cmpstr(json_object_get_string_member(browser, "foo"), ==, "bar");
+}
+
+static void test_setup_apply_browser_enabled_preserves_unrelated_keys(void) {
+    const gchar *raw =
+        "{\"gateway\":{\"port\":18789,\"auth\":{\"mode\":\"none\"}},"
+        "\"models\":{\"providers\":{\"openai\":{\"baseUrl\":\"https://api.openai.com\"}}}}";
+    g_autoptr(GError) err = NULL;
+    g_autofree gchar *updated = config_setup_apply_browser_enabled(raw, FALSE, &err);
+    g_assert_no_error(err);
+    g_assert_nonnull(updated);
+
+    gboolean parsed = TRUE;
+    g_assert_true(parse_browser_enabled(updated, &parsed));
+    g_assert_false(parsed);
+
+    g_autoptr(JsonParser) parser = json_parser_new();
+    g_assert_true(json_parser_load_from_data(parser, updated, -1, &err));
+    JsonObject *root = json_node_get_object(json_parser_get_root(parser));
+    JsonObject *gateway = json_node_get_object(json_object_get_member(root, "gateway"));
+    g_assert_cmpint(json_object_get_int_member(gateway, "port"), ==, 18789);
+    JsonObject *models = json_node_get_object(json_object_get_member(root, "models"));
+    JsonObject *providers = json_node_get_object(json_object_get_member(models, "providers"));
+    JsonObject *openai = json_node_get_object(json_object_get_member(providers, "openai"));
+    g_assert_cmpstr(json_object_get_string_member(openai, "baseUrl"), ==, "https://api.openai.com");
+}
+
+static void test_setup_apply_browser_enabled_handles_non_object_browser(void) {
+    /* If `browser` is something stupid like a string, the transform
+     * still recovers by replacing it with a fresh `{ "enabled": ... }`
+     * object — same recovery path documented for `apply_provider`. */
+    const gchar *raw = "{\"browser\":\"oops\"}";
+    g_autoptr(GError) err = NULL;
+    g_autofree gchar *updated = config_setup_apply_browser_enabled(raw, TRUE, &err);
+    g_assert_no_error(err);
+    g_assert_nonnull(updated);
+
+    gboolean parsed = FALSE;
+    g_assert_true(parse_browser_enabled(updated, &parsed));
+    g_assert_true(parsed);
+}
+
 int main(int argc, char **argv) {
     g_test_init(&argc, &argv, NULL);
 
@@ -343,6 +431,15 @@ int main(int argc, char **argv) {
     g_test_add_func("/config/model/root_providers_empty_false", test_model_config_root_providers_empty_false);
     g_test_add_func("/config/model/agents_defaults_model_malformed_false", test_model_config_agents_defaults_model_malformed_false);
     g_test_add_func("/config/model/minimal_onboard_false", test_model_config_minimal_onboard_false);
+
+    g_test_add_func("/config/setup/apply_browser_enabled_creates_object_when_missing",
+                    test_setup_apply_browser_enabled_creates_object_when_missing);
+    g_test_add_func("/config/setup/apply_browser_enabled_overwrites_existing",
+                    test_setup_apply_browser_enabled_overwrites_existing);
+    g_test_add_func("/config/setup/apply_browser_enabled_preserves_unrelated_keys",
+                    test_setup_apply_browser_enabled_preserves_unrelated_keys);
+    g_test_add_func("/config/setup/apply_browser_enabled_handles_non_object_browser",
+                    test_setup_apply_browser_enabled_handles_non_object_browser);
 
     return g_test_run();
 }

--- a/apps/linux/tests/test_deep_link.c
+++ b/apps/linux/tests/test_deep_link.c
@@ -1,0 +1,182 @@
+/*
+ * test_deep_link.c
+ *
+ * Hermetic regression for the Linux companion's `openclaw://` URL
+ * scheme parser. No GTK, no shell: the parser produces a pure-C
+ * DeepLinkRoute value and the suite walks the recognised grammar.
+ *
+ * Author: Thiago Camargo <thiagocmc@proton.me>
+ */
+
+#include "../src/deep_link.h"
+
+#include <glib.h>
+
+static void assert_parses(const char *uri, DeepLinkRouteKind expected_kind) {
+    DeepLinkRoute route = {0};
+    g_assert_true(deep_link_parse(uri, &route));
+    g_assert_cmpint(route.kind, ==, expected_kind);
+    deep_link_route_clear(&route);
+}
+
+static void assert_rejects(const char *uri) {
+    DeepLinkRoute route = {0};
+    g_assert_false(deep_link_parse(uri, &route));
+    g_assert_cmpint(route.kind, ==, DEEP_LINK_ROUTE_NONE);
+    g_assert_null(route.section_id);
+    deep_link_route_clear(&route);
+}
+
+static void test_rejects_null_and_empty(void) {
+    DeepLinkRoute route = {0};
+    g_assert_false(deep_link_parse(NULL, &route));
+    g_assert_false(deep_link_parse("", &route));
+    /* Missing `out_route` must not crash. */
+    g_assert_false(deep_link_parse("openclaw://dashboard", NULL));
+}
+
+static void test_rejects_non_openclaw_scheme(void) {
+    assert_rejects("https://dashboard");
+    assert_rejects("http://openclaw.ai/dashboard");
+    assert_rejects("file:///openclaw/dashboard");
+}
+
+static void test_dashboard_route(void) {
+    assert_parses("openclaw://dashboard", DEEP_LINK_ROUTE_DASHBOARD);
+}
+
+static void test_dashboard_route_case_insensitive_host(void) {
+    assert_parses("openclaw://Dashboard", DEEP_LINK_ROUTE_DASHBOARD);
+    assert_parses("OPENCLAW://DASHBOARD", DEEP_LINK_ROUTE_DASHBOARD);
+}
+
+static void test_chat_route(void) {
+    assert_parses("openclaw://chat", DEEP_LINK_ROUTE_CHAT);
+    assert_parses("openclaw://chat/", DEEP_LINK_ROUTE_CHAT);
+}
+
+static void test_settings_root_route(void) {
+    DeepLinkRoute route = {0};
+    g_assert_true(deep_link_parse("openclaw://settings", &route));
+    g_assert_cmpint(route.kind, ==, DEEP_LINK_ROUTE_SETTINGS);
+    g_assert_null(route.section_id);
+    deep_link_route_clear(&route);
+}
+
+static void test_settings_with_known_section_id(void) {
+    DeepLinkRoute route = {0};
+    g_assert_true(deep_link_parse("openclaw://settings/channels", &route));
+    g_assert_cmpint(route.kind, ==, DEEP_LINK_ROUTE_SETTINGS);
+    g_assert_cmpstr(route.section_id, ==, "channels");
+    deep_link_route_clear(&route);
+}
+
+static void test_settings_with_hyphenated_section_id(void) {
+    DeepLinkRoute route = {0};
+    g_assert_true(deep_link_parse("openclaw://settings/control-room", &route));
+    g_assert_cmpstr(route.section_id, ==, "control-room");
+    deep_link_route_clear(&route);
+}
+
+static void test_settings_lowercases_section_id(void) {
+    DeepLinkRoute route = {0};
+    /* Upper-case is normalized by the parser so the dispatcher only
+     * has to compare against lowercased shell-section ids. */
+    g_assert_true(deep_link_parse("openclaw://settings/CHANNELS", &route));
+    g_assert_cmpstr(route.section_id, ==, "channels");
+    deep_link_route_clear(&route);
+}
+
+static void test_settings_rejects_extra_path_segments(void) {
+    assert_rejects("openclaw://settings/channels/extra");
+    assert_rejects("openclaw://settings//");
+}
+
+static void test_onboarding_route(void) {
+    assert_parses("openclaw://onboarding", DEEP_LINK_ROUTE_ONBOARDING);
+    assert_parses("openclaw://onboarding/", DEEP_LINK_ROUTE_ONBOARDING);
+}
+
+static void test_ignores_query_and_fragment(void) {
+    assert_parses("openclaw://dashboard?foo=bar", DEEP_LINK_ROUTE_DASHBOARD);
+    assert_parses("openclaw://dashboard#frag", DEEP_LINK_ROUTE_DASHBOARD);
+    assert_parses("openclaw://dashboard?foo=bar#frag", DEEP_LINK_ROUTE_DASHBOARD);
+
+    DeepLinkRoute route = {0};
+    g_assert_true(deep_link_parse("openclaw://settings/channels?tab=1#x", &route));
+    g_assert_cmpstr(route.section_id, ==, "channels");
+    deep_link_route_clear(&route);
+}
+
+static void test_rejects_unknown_host(void) {
+    /* macOS uses `agent` and `gateway` hosts for deep-link features
+     * that are intentionally out of scope for Linux in this tranche. */
+    assert_rejects("openclaw://agent?key=abc&message=hi");
+    assert_rejects("openclaw://gateway?target=lan");
+    assert_rejects("openclaw://something-else");
+}
+
+static void test_rejects_extra_path_segments_on_non_settings_hosts(void) {
+    assert_rejects("openclaw://dashboard/extra");
+    assert_rejects("openclaw://chat/session/abc");
+    assert_rejects("openclaw://onboarding/step-one");
+}
+
+static void test_rejects_settings_with_invalid_section_token(void) {
+    /* Reject tokens that cannot be valid shell-section ids — spaces,
+     * punctuation, etc. A bare trailing slash on `settings/` is a
+     * recognised synonym for the root route, so it is intentionally
+     * NOT covered here. */
+    assert_rejects("openclaw://settings/chan.nels");
+    assert_rejects("openclaw://settings/_");
+    assert_rejects("openclaw://settings/foo!bar");
+}
+
+static void test_settings_root_with_trailing_slash(void) {
+    /* `openclaw://settings/` is the same recognised route as
+     * `openclaw://settings`, mirroring the chat/dashboard handling. */
+    DeepLinkRoute route = {0};
+    g_assert_true(deep_link_parse("openclaw://settings/", &route));
+    g_assert_cmpint(route.kind, ==, DEEP_LINK_ROUTE_SETTINGS);
+    g_assert_null(route.section_id);
+    deep_link_route_clear(&route);
+}
+
+static void test_route_clear_frees_section_id(void) {
+    DeepLinkRoute route = {0};
+    g_assert_true(deep_link_parse("openclaw://settings/channels", &route));
+    g_assert_nonnull(route.section_id);
+    deep_link_route_clear(&route);
+    g_assert_null(route.section_id);
+    g_assert_cmpint(route.kind, ==, DEEP_LINK_ROUTE_NONE);
+    /* Clearing an already-cleared route must be safe. */
+    deep_link_route_clear(&route);
+    deep_link_route_clear(NULL);
+}
+
+int main(int argc, char **argv) {
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/deep_link/rejects_null_and_empty", test_rejects_null_and_empty);
+    g_test_add_func("/deep_link/rejects_non_openclaw_scheme", test_rejects_non_openclaw_scheme);
+    g_test_add_func("/deep_link/dashboard_route", test_dashboard_route);
+    g_test_add_func("/deep_link/dashboard_route_case_insensitive_host", test_dashboard_route_case_insensitive_host);
+    g_test_add_func("/deep_link/chat_route", test_chat_route);
+    g_test_add_func("/deep_link/settings_root_route", test_settings_root_route);
+    g_test_add_func("/deep_link/settings_with_known_section_id", test_settings_with_known_section_id);
+    g_test_add_func("/deep_link/settings_with_hyphenated_section_id", test_settings_with_hyphenated_section_id);
+    g_test_add_func("/deep_link/settings_lowercases_section_id", test_settings_lowercases_section_id);
+    g_test_add_func("/deep_link/settings_rejects_extra_path_segments", test_settings_rejects_extra_path_segments);
+    g_test_add_func("/deep_link/onboarding_route", test_onboarding_route);
+    g_test_add_func("/deep_link/ignores_query_and_fragment", test_ignores_query_and_fragment);
+    g_test_add_func("/deep_link/rejects_unknown_host", test_rejects_unknown_host);
+    g_test_add_func("/deep_link/rejects_extra_path_segments_on_non_settings_hosts",
+                    test_rejects_extra_path_segments_on_non_settings_hosts);
+    g_test_add_func("/deep_link/rejects_settings_with_invalid_section_token",
+                    test_rejects_settings_with_invalid_section_token);
+    g_test_add_func("/deep_link/settings_root_with_trailing_slash",
+                    test_settings_root_with_trailing_slash);
+    g_test_add_func("/deep_link/route_clear_frees_section_id", test_route_clear_frees_section_id);
+
+    return g_test_run();
+}

--- a/apps/linux/tests/test_product_state.c
+++ b/apps/linux/tests/test_product_state.c
@@ -238,6 +238,79 @@ static void test_reset_onboarding_seen_version_persists_zero(void) {
     cleanup_tmp_dir(dir);
 }
 
+/* ── Heartbeats persistence (Tranche E) ──────────────────────── */
+
+static void test_heartbeats_default_is_true(void) {
+    g_autofree gchar *dir = make_tmp_dir();
+    g_autofree gchar *storage_path = g_build_filename(dir, "product-state.ini", NULL);
+    g_autofree gchar *legacy_path = g_build_filename(dir, "onboarding_version", NULL);
+
+    reset_product_state_for_paths(storage_path, legacy_path);
+    product_state_init();
+    g_assert_true(product_state_get_heartbeats_enabled());
+
+    /* The first flush after a default-init must persist the explicit
+     * value so that future loads can read a deterministic answer. */
+    g_autofree gchar *contents = read_file_or_null(storage_path);
+    g_assert_nonnull(contents);
+    g_assert_nonnull(g_strstr_len(contents, -1, "heartbeats_enabled=true"));
+
+    clear_product_state_test_overrides();
+    remove_if_exists(storage_path);
+    remove_if_exists(legacy_path);
+    cleanup_tmp_dir(dir);
+}
+
+static void test_heartbeats_persist_across_reload(void) {
+    g_autofree gchar *dir = make_tmp_dir();
+    g_autofree gchar *storage_path = g_build_filename(dir, "product-state.ini", NULL);
+    g_autofree gchar *legacy_path = g_build_filename(dir, "onboarding_version", NULL);
+
+    reset_product_state_for_paths(storage_path, legacy_path);
+    product_state_init();
+    g_assert_true(product_state_set_heartbeats_enabled(FALSE));
+
+    /* Reload from disk. */
+    product_state_test_reset();
+    product_state_init();
+    g_assert_false(product_state_get_heartbeats_enabled());
+
+    g_assert_true(product_state_set_heartbeats_enabled(TRUE));
+    product_state_test_reset();
+    product_state_init();
+    g_assert_true(product_state_get_heartbeats_enabled());
+
+    clear_product_state_test_overrides();
+    remove_if_exists(storage_path);
+    remove_if_exists(legacy_path);
+    cleanup_tmp_dir(dir);
+}
+
+static void test_heartbeats_legacy_storage_upgrades_to_default(void) {
+    g_autofree gchar *dir = make_tmp_dir();
+    g_autofree gchar *storage_path = g_build_filename(dir, "product-state.ini", NULL);
+    g_autofree gchar *legacy_path = g_build_filename(dir, "onboarding_version", NULL);
+
+    /* Storage that predates Tranche E omits `heartbeats_enabled`.
+     * The loader must pick up the TRUE default and rewrite the file
+     * so the next launch has an explicit value. */
+    const gchar *legacy_data = "[product]\nconnection_mode=local\nonboarding_seen_version=2\n";
+    g_assert_true(g_file_set_contents(storage_path, legacy_data, -1, NULL));
+
+    reset_product_state_for_paths(storage_path, legacy_path);
+    product_state_init();
+    g_assert_true(product_state_get_heartbeats_enabled());
+
+    g_autofree gchar *contents = read_file_or_null(storage_path);
+    g_assert_nonnull(contents);
+    g_assert_nonnull(g_strstr_len(contents, -1, "heartbeats_enabled=true"));
+
+    clear_product_state_test_overrides();
+    remove_if_exists(storage_path);
+    remove_if_exists(legacy_path);
+    cleanup_tmp_dir(dir);
+}
+
 int main(int argc, char **argv) {
     g_test_init(&argc, &argv, NULL);
     g_test_add_func("/product_state/defaults_create_local_state", test_defaults_create_local_state);
@@ -248,5 +321,9 @@ int main(int argc, char **argv) {
     g_test_add_func("/product_state/invalid_seen_version_falls_back_to_zero", test_invalid_seen_version_falls_back_to_zero);
     g_test_add_func("/product_state/legacy_marker_migrates", test_legacy_marker_migrates_to_product_state);
     g_test_add_func("/product_state/reset_onboarding_seen_version_persists_zero", test_reset_onboarding_seen_version_persists_zero);
+    g_test_add_func("/product_state/heartbeats_default_is_true", test_heartbeats_default_is_true);
+    g_test_add_func("/product_state/heartbeats_persist_across_reload", test_heartbeats_persist_across_reload);
+    g_test_add_func("/product_state/heartbeats_legacy_storage_upgrades_to_default",
+                    test_heartbeats_legacy_storage_upgrades_to_default);
     return g_test_run();
 }

--- a/apps/linux/tests/test_rpc_mutations.c
+++ b/apps/linux/tests/test_rpc_mutations.c
@@ -369,6 +369,30 @@ static void test_channels_logout_no_acct(void) {
     g_free(rid);
 }
 
+/* ── System mutation tests (Tranche E) ──────────────────────────── */
+
+static void test_system_set_heartbeats_enabled(void) {
+    stub_reset();
+    gchar *rid = mutation_system_set_heartbeats(TRUE, noop_cb, NULL);
+    ASSERT(rid != NULL, "set_heartbeats: rid");
+    ASSERT(g_strcmp0(stub_last_method, "set-heartbeats") == 0, "set_heartbeats: method");
+    JsonObject *p = get_stub_params_obj();
+    ASSERT(p != NULL, "set_heartbeats: params obj");
+    ASSERT(json_object_has_member(p, "enabled"), "set_heartbeats: enabled present");
+    ASSERT(obj_get_bool(p, "enabled") == TRUE, "set_heartbeats: enabled=true");
+    g_free(rid);
+}
+
+static void test_system_set_heartbeats_disabled(void) {
+    stub_reset();
+    gchar *rid = mutation_system_set_heartbeats(FALSE, noop_cb, NULL);
+    ASSERT(rid != NULL, "set_heartbeats_off: rid");
+    ASSERT(g_strcmp0(stub_last_method, "set-heartbeats") == 0, "set_heartbeats_off: method");
+    JsonObject *p = get_stub_params_obj();
+    ASSERT(obj_get_bool(p, "enabled") == FALSE, "set_heartbeats_off: enabled=false");
+    g_free(rid);
+}
+
 /* ── Config mutation tests ───────────────────────────────────────── */
 
 static void test_config_get(void) {
@@ -1324,6 +1348,9 @@ int main(int argc, char **argv) {
     g_test_add_func("/rpc_mutations/web_login/wait", test_web_login_wait);
     g_test_add_func("/rpc_mutations/web_login/wait_null_account", test_web_login_wait_null_account);
     g_test_add_func("/rpc_mutations/web_login/qr_login_start_without_qrdataurl", test_qr_login_start_without_qrdataurl);
+
+    g_test_add_func("/rpc_mutations/system/set_heartbeats_enabled", test_system_set_heartbeats_enabled);
+    g_test_add_func("/rpc_mutations/system/set_heartbeats_disabled", test_system_set_heartbeats_disabled);
 
     int status = g_test_run();
     stub_reset();

--- a/apps/linux/tests/test_tray_helper_protocol.c
+++ b/apps/linux/tests/test_tray_helper_protocol.c
@@ -24,6 +24,10 @@ typedef struct {
 
     guint              approvals_calls;
     guint              last_approvals_count;
+
+    guint              check_calls;
+    TrayHelperMenuKey  last_check_key;
+    gboolean           last_check_value;
 } CaptureState;
 
 static void capture_menu_visible(TrayHelperMenuKey key, gboolean visible, gpointer ud) {
@@ -46,11 +50,19 @@ static void capture_approvals(guint count, gpointer ud) {
     s->last_approvals_count = count;
 }
 
+static void capture_check(TrayHelperMenuKey key, gboolean value, gpointer ud) {
+    CaptureState *s = ud;
+    s->check_calls++;
+    s->last_check_key = key;
+    s->last_check_value = value;
+}
+
 static TrayHelperProtocolHandlers make_handlers(CaptureState *s) {
     return (TrayHelperProtocolHandlers){
         .set_menu_visible          = capture_menu_visible,
         .set_radio_exec_approval   = capture_radio,
         .set_approvals_count       = capture_approvals,
+        .set_check_state           = capture_check,
         .user_data                 = s,
     };
 }
@@ -68,6 +80,8 @@ static void test_menu_key_from_string_known(void) {
     g_assert_cmpint(tray_helper_protocol_menu_key_from_string("APPROVALS_PENDING"),   ==, TRAY_HELPER_MENU_KEY_APPROVALS_PENDING);
     g_assert_cmpint(tray_helper_protocol_menu_key_from_string("RESET_REMOTE_TUNNEL"), ==, TRAY_HELPER_MENU_KEY_RESET_REMOTE_TUNNEL);
     g_assert_cmpint(tray_helper_protocol_menu_key_from_string("RESTART_APP"),         ==, TRAY_HELPER_MENU_KEY_RESTART_APP);
+    g_assert_cmpint(tray_helper_protocol_menu_key_from_string("HEARTBEATS"),          ==, TRAY_HELPER_MENU_KEY_HEARTBEATS);
+    g_assert_cmpint(tray_helper_protocol_menu_key_from_string("BROWSER_CONTROL"),     ==, TRAY_HELPER_MENU_KEY_BROWSER_CONTROL);
 }
 
 static void test_menu_key_from_string_unknown(void) {
@@ -195,7 +209,49 @@ static void test_apply_with_null_handlers_still_classifies(void) {
     g_assert_true (tray_helper_protocol_apply_line(NULL, "MENU_VISIBLE:OPEN_DEBUG:1"));
     g_assert_true (tray_helper_protocol_apply_line(NULL, "RADIO:EXEC_APPROVAL:ask"));
     g_assert_true (tray_helper_protocol_apply_line(NULL, "APPROVALS:3"));
+    g_assert_true (tray_helper_protocol_apply_line(NULL, "CHECK:HEARTBEATS:1"));
     g_assert_false(tray_helper_protocol_apply_line(NULL, "STATE:foo"));
+}
+
+/* ── apply_line: CHECK (Tranche E) ────────────────────── */
+
+static void test_apply_check_heartbeats_on(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+    g_assert_true(tray_helper_protocol_apply_line(&h, "CHECK:HEARTBEATS:1"));
+    g_assert_cmpuint(s.check_calls, ==, 1);
+    g_assert_cmpint(s.last_check_key, ==, TRAY_HELPER_MENU_KEY_HEARTBEATS);
+    g_assert_true(s.last_check_value);
+    capture_state_clear(&s);
+}
+
+static void test_apply_check_browser_off(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+    g_assert_true(tray_helper_protocol_apply_line(&h, "CHECK:BROWSER_CONTROL:0"));
+    g_assert_cmpuint(s.check_calls, ==, 1);
+    g_assert_cmpint(s.last_check_key, ==, TRAY_HELPER_MENU_KEY_BROWSER_CONTROL);
+    g_assert_false(s.last_check_value);
+    capture_state_clear(&s);
+}
+
+static void test_apply_check_unknown_key_ignored(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+    g_assert_false(tray_helper_protocol_apply_line(&h, "CHECK:NOPE:1"));
+    g_assert_cmpuint(s.check_calls, ==, 0);
+    capture_state_clear(&s);
+}
+
+static void test_apply_check_invalid_flag_rejected(void) {
+    CaptureState s = {0};
+    TrayHelperProtocolHandlers h = make_handlers(&s);
+    g_assert_false(tray_helper_protocol_apply_line(&h, "CHECK:HEARTBEATS:2"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, "CHECK:HEARTBEATS:"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, "CHECK:HEARTBEATS:11"));
+    g_assert_false(tray_helper_protocol_apply_line(&h, "CHECK::1"));
+    g_assert_cmpuint(s.check_calls, ==, 0);
+    capture_state_clear(&s);
 }
 
 /* ── pending-approvals label formatter ───────────────── */
@@ -255,6 +311,15 @@ int main(int argc, char **argv) {
                     test_format_approvals_label_one);
     g_test_add_func("/tray_helper_protocol/format_approvals_label_many",
                     test_format_approvals_label_many);
+
+    g_test_add_func("/tray_helper_protocol/apply_check_heartbeats_on",
+                    test_apply_check_heartbeats_on);
+    g_test_add_func("/tray_helper_protocol/apply_check_browser_off",
+                    test_apply_check_browser_off);
+    g_test_add_func("/tray_helper_protocol/apply_check_unknown_key_ignored",
+                    test_apply_check_unknown_key_ignored);
+    g_test_add_func("/tray_helper_protocol/apply_check_invalid_flag_rejected",
+                    test_apply_check_invalid_flag_rejected);
 
     return g_test_run();
 }

--- a/apps/linux/tests/test_tray_protocol.c
+++ b/apps/linux/tests/test_tray_protocol.c
@@ -122,6 +122,71 @@ static void test_parse_exec_approval_action_rejects_invalid(void) {
     g_assert_null(mode);
 }
 
+/* ── CHECK formatter (Tranche E) ─────────────────────────── */
+
+static void test_format_check_true(void) {
+    g_autofree gchar *line = tray_protocol_format_check("HEARTBEATS", TRUE);
+    g_assert_cmpstr(line, ==, "CHECK:HEARTBEATS:1\n");
+}
+
+static void test_format_check_false(void) {
+    g_autofree gchar *line = tray_protocol_format_check("BROWSER_CONTROL", FALSE);
+    g_assert_cmpstr(line, ==, "CHECK:BROWSER_CONTROL:0\n");
+}
+
+static void test_format_check_rejects_invalid_keys(void) {
+    g_assert_null(tray_protocol_format_check(NULL, TRUE));
+    g_assert_null(tray_protocol_format_check("", TRUE));
+    g_assert_null(tray_protocol_format_check("HAS:COLON", TRUE));
+    g_assert_null(tray_protocol_format_check("HAS SPACE", TRUE));
+    g_assert_null(tray_protocol_format_check("HAS\nNEWLINE", TRUE));
+}
+
+/* ── <KEY>_SET parser (Tranche E) ────────────────────────── */
+
+static void test_parse_check_action_zero(void) {
+    char *key = NULL;
+    gboolean value = TRUE;
+    g_assert_true(tray_protocol_parse_check_action("HEARTBEATS_SET:0", &key, &value));
+    g_assert_cmpstr(key, ==, "HEARTBEATS");
+    g_assert_false(value);
+    g_free(key);
+}
+
+static void test_parse_check_action_one(void) {
+    char *key = NULL;
+    gboolean value = FALSE;
+    g_assert_true(tray_protocol_parse_check_action("BROWSER_CONTROL_SET:1", &key, &value));
+    g_assert_cmpstr(key, ==, "BROWSER_CONTROL");
+    g_assert_true(value);
+    g_free(key);
+}
+
+static void test_parse_check_action_accepts_null_outs(void) {
+    g_assert_true(tray_protocol_parse_check_action("HEARTBEATS_SET:1", NULL, NULL));
+}
+
+static void test_parse_check_action_rejects_invalid(void) {
+    char *key = NULL;
+    gboolean value = FALSE;
+    g_assert_false(tray_protocol_parse_check_action(NULL, &key, &value));
+    g_assert_false(tray_protocol_parse_check_action("", &key, &value));
+    g_assert_false(tray_protocol_parse_check_action("HEARTBEATS_SET:", &key, &value));
+    g_assert_false(tray_protocol_parse_check_action("HEARTBEATS_SET:yes", &key, &value));
+    g_assert_false(tray_protocol_parse_check_action("HEARTBEATS_SET:2", &key, &value));
+    g_assert_false(tray_protocol_parse_check_action("HEARTBEATS_SET:11", &key, &value));
+    g_assert_false(tray_protocol_parse_check_action("HEARTBEATS_SET:1:0", &key, &value));
+    g_assert_false(tray_protocol_parse_check_action("HEARTBEATS_SET: 1", &key, &value));
+    g_assert_false(tray_protocol_parse_check_action("HEARTBEATS_SET:1\n", &key, &value));
+    /* No trailing `_SET` on the key. */
+    g_assert_false(tray_protocol_parse_check_action("HEARTBEATS:1", &key, &value));
+    /* Empty key — colon at offset 0 means head_len == 0. */
+    g_assert_false(tray_protocol_parse_check_action(":1", &key, &value));
+    /* Bare `_SET:1` → empty key. */
+    g_assert_false(tray_protocol_parse_check_action("_SET:1", &key, &value));
+    g_assert_null(key);
+}
+
 int main(int argc, char **argv) {
     g_test_init(&argc, &argv, NULL);
 
@@ -148,6 +213,17 @@ int main(int argc, char **argv) {
                     test_parse_exec_approval_action_accepts_null_out);
     g_test_add_func("/tray_protocol/parse_exec_approval_action_rejects_invalid",
                     test_parse_exec_approval_action_rejects_invalid);
+
+    g_test_add_func("/tray_protocol/format_check_true", test_format_check_true);
+    g_test_add_func("/tray_protocol/format_check_false", test_format_check_false);
+    g_test_add_func("/tray_protocol/format_check_rejects_invalid_keys",
+                    test_format_check_rejects_invalid_keys);
+    g_test_add_func("/tray_protocol/parse_check_action_zero", test_parse_check_action_zero);
+    g_test_add_func("/tray_protocol/parse_check_action_one", test_parse_check_action_one);
+    g_test_add_func("/tray_protocol/parse_check_action_accepts_null_outs",
+                    test_parse_check_action_accepts_null_outs);
+    g_test_add_func("/tray_protocol/parse_check_action_rejects_invalid",
+                    test_parse_check_action_rejects_invalid);
 
     return g_test_run();
 }


### PR DESCRIPTION
Register the Linux companion as an `openclaw://` URL handler and route navigation deep links through a GTK-free parser and dispatch layer. Support dashboard, chat, settings, named settings sections, and onboarding routes while ignoring unsupported hosts.

Add Heartbeats and Browser Control controls to the General page and tray. Persist Heartbeats intent locally, expose a typed `set-heartbeats` RPC mutation, and reassert the saved intent whenever the gateway WebSocket reconnects.

Add Browser Control support backed by `browser.enabled` in gateway config. Read a fresh config snapshot, apply a focused transform, and write through `config.set` with the matching base hash. Use a shared GTK-free
`browser_control_state` cache so General and tray stay in sync even when mounted independently.

Extend the tray protocol with `CHECK:<KEY>:0|1` state lines and `<KEY>_SET:0|1` action parsing, and add checked tray items for Send Heartbeats and Browser Control.

Add a passive OpenClaw CLI status row in General and headless regression coverage for deep-link parsing, Browser Control shared state, config transforms, Heartbeats persistence, RPC construction, and tray CHECK protocol handling.
