### PR TITLE
inspector: fix memory leak in channel config merge error path (#130)

### DIFF
--- a/apps/linux/src/section_channels.c
+++ b/apps/linux/src/section_channels.c
@@ -207,7 +207,7 @@ static void on_config_dialog_response(GObject *source, GAsyncResult *result, gpo
     
     /* Get the edited channel subtree */
     /* I1: Properly manage JsonNode ownership - copy root for later transfer */
-    JsonNode *edited_channel_node = json_node_copy(parsed_root);
+    g_autoptr(JsonNode) edited_channel_node = json_node_copy(parsed_root);
     g_object_unref(parser);
 
     if (channels_status_label)
@@ -273,7 +273,7 @@ static void on_config_dialog_response(GObject *source, GAsyncResult *result, gpo
         json_object_remove_member(channels_obj, session->channel_id);
     }
     /* I1: Transfer ownership of edited_channel_node to the channels object */
-    json_object_set_member(channels_obj, session->channel_id, edited_channel_node);
+    json_object_set_member(channels_obj, session->channel_id, g_steal_pointer(&edited_channel_node));
 
     /* Serialize the FULL updated config document */
     g_autofree gchar *full_raw_json = json_to_string(full_config_copy, FALSE);


### PR DESCRIPTION
The `on_config_dialog_response` handler in the Channels section allocates a detached JSON node via `json_node_copy` when parsing user edits. If the subsequent deep-copy parser failed (e.g. invalid base structure), the function returned early, leaking the detached `JsonNode`.

- Replaced manual `JsonNode *` with `g_autoptr(JsonNode)` for automatic cleanup on all execution paths.
- Used `g_steal_pointer` at the final `json_object_set_member` call site to safely transfer ownership into the parent JSON object upon success.
- This adheres to the Error Path Symmetry Law (C-LIFETIME-002) without altering GTK dialog presentation or schema validation mechanics.
