### PR TITLE
security: reject dash-leading SSH destinations (#132)

### DIFF
--- a/apps/linux/src/gateway_remote_config.c
+++ b/apps/linux/src/gateway_remote_config.c
@@ -155,6 +155,20 @@ gboolean gateway_remote_config_parse_ssh_target(const gchar *raw,
         while (*work == ' ' || *work == '\t') work++;
     }
 
+    /*
+     * argv-boundary guard, post-prefix-strip variant.
+     *
+     * The pre-strip check above rejects raw inputs like "-oProxyJump=…",
+     * but an attacker can hide the dash behind the optional "ssh "
+     * prefix (e.g. "ssh -oProxyCommand=evil@host" or
+     * "ssh    -oProxyJump=evil@host"). After we have peeled the prefix
+     * and skipped any leading whitespace, the *functional* head of the
+     * target must not begin with '-' either — otherwise the
+     * subsequently-parsed user/host components could smuggle option
+     * flags through to OpenSSH's argv. Reject such inputs outright.
+     */
+    if (work[0] == '-') return FALSE;
+
     /* No internal whitespace or control characters allowed */
     for (const gchar *p = work; *p; p++) {
         if (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r' || (guchar)*p < 0x20) {

--- a/apps/linux/src/remote_probe.c
+++ b/apps/linux/src/remote_probe.c
@@ -416,11 +416,23 @@ static void spawn_ssh_echo_probe(ProbeCtx *ctx,
         g_ptr_array_add(argv, g_strdup("-i"));
         g_ptr_array_add(argv, g_strdup(ssh_identity));
     }
-    if (ssh_user && ssh_user[0] != '\0') {
-        g_ptr_array_add(argv, g_strdup_printf("%s@%s", ssh_user, ssh_host));
-    } else {
-        g_ptr_array_add(argv, g_strdup(ssh_host));
+    /*
+     * argv-boundary guard, mirroring remote_tunnel_command_build:
+     * render the SSH destination first and reject any leading '-' so
+     * the trailing argv positional cannot smuggle option flags.
+     */
+    g_autofree gchar *destination =
+        (ssh_user && ssh_user[0] != '\0')
+            ? g_strdup_printf("%s@%s", ssh_user, ssh_host)
+            : g_strdup(ssh_host);
+    if (!destination || destination[0] == '\0' || destination[0] == '-') {
+        g_ptr_array_free(argv, TRUE);
+        deliver(ctx, REMOTE_PROBE_FAILED,
+                g_strdup("SSH target invalid"),
+                g_strdup("rendered SSH destination begins with '-'"));
+        return;
     }
+    g_ptr_array_add(argv, g_strdup(destination));
     g_ptr_array_add(argv, g_strdup("echo"));
     g_ptr_array_add(argv, g_strdup("ok"));
     g_ptr_array_add(argv, NULL);
@@ -754,11 +766,23 @@ static void spawn_ssh_forward_probe(ProbeCtx *ctx,
         g_ptr_array_add(argv, g_strdup("-i"));
         g_ptr_array_add(argv, g_strdup(ssh_identity));
     }
-    if (ssh_user && ssh_user[0] != '\0') {
-        g_ptr_array_add(argv, g_strdup_printf("%s@%s", ssh_user, ssh_host));
-    } else {
-        g_ptr_array_add(argv, g_strdup(ssh_host));
+    /*
+     * argv-boundary guard, mirroring remote_tunnel_command_build:
+     * render the SSH destination first and reject any leading '-' so
+     * the trailing argv positional cannot smuggle option flags.
+     */
+    g_autofree gchar *destination =
+        (ssh_user && ssh_user[0] != '\0')
+            ? g_strdup_printf("%s@%s", ssh_user, ssh_host)
+            : g_strdup(ssh_host);
+    if (!destination || destination[0] == '\0' || destination[0] == '-') {
+        g_ptr_array_free(argv, TRUE);
+        deliver(ctx, REMOTE_PROBE_FAILED,
+                g_strdup("SSH target invalid"),
+                g_strdup("rendered SSH destination begins with '-'"));
+        return;
     }
+    g_ptr_array_add(argv, g_strdup(destination));
     g_ptr_array_add(argv, NULL);
     gchar **argv_s = (gchar **)g_ptr_array_free(argv, FALSE);
 
@@ -797,10 +821,18 @@ void remote_probe_ssh_async(const gchar *ssh_user,
     ctx->cancel = cancel ? g_object_ref(cancel) : NULL;
     ctx->gateway_port = gateway_port;
 
-    if (!ssh_host || ssh_host[0] == '\0' || ssh_host[0] == '-') {
+    /*
+     * argv-smuggling entry guard. Both ssh_host and ssh_user feed the
+     * trailing "[user@]host" argv positional in the spawn helpers
+     * below; either leading with '-' would let OpenSSH parse the
+     * destination as another option flag. We re-validate the rendered
+     * destination at each spawn site as well.
+     */
+    if (!ssh_host || ssh_host[0] == '\0' || ssh_host[0] == '-' ||
+        (ssh_user && ssh_user[0] == '-')) {
         deliver(ctx, REMOTE_PROBE_FAILED,
                 g_strdup("SSH target invalid"),
-                g_strdup("SSH target host is empty or begins with '-'"));
+                g_strdup("SSH target host or user is empty or begins with '-'"));
         return;
     }
 

--- a/apps/linux/src/remote_tunnel_command.c
+++ b/apps/linux/src/remote_tunnel_command.c
@@ -15,7 +15,15 @@ static void push(GPtrArray *argv, const gchar *s) {
 gchar** remote_tunnel_command_build(const RemoteTunnelCommandSpec *spec) {
     if (!spec) return NULL;
     if (!spec->ssh_host || spec->ssh_host[0] == '\0') return NULL;
-    if (spec->ssh_host[0] == '-') return NULL;   /* argv-smuggling guard */
+    /*
+     * argv-smuggling guards. The trailing argv positional is rendered
+     * as "[user@]host" and a leading '-' on either component would let
+     * OpenSSH parse the destination as another option flag. We check
+     * each parsed token here and re-validate the final rendered
+     * destination below before pushing it to argv.
+     */
+    if (spec->ssh_host[0] == '-') return NULL;
+    if (spec->ssh_user && spec->ssh_user[0] == '-') return NULL;
     if (spec->local_port <= 0 || spec->local_port > 65535) return NULL;
     if (spec->remote_port <= 0 || spec->remote_port > 65535) return NULL;
 
@@ -48,13 +56,23 @@ gchar** remote_tunnel_command_build(const RemoteTunnelCommandSpec *spec) {
         push(argv, "-i"); push(argv, spec->ssh_identity);
     }
 
-    /* [user@]host — always last to cap the argv. */
-    if (spec->ssh_user && spec->ssh_user[0] != '\0') {
-        g_autofree gchar *target = g_strdup_printf("%s@%s", spec->ssh_user, spec->ssh_host);
-        push(argv, target);
-    } else {
-        push(argv, spec->ssh_host);
+    /*
+     * [user@]host — always last to cap the argv.
+     *
+     * Final argv-boundary invariant: render the destination first, then
+     * verify it does not begin with '-'. This locks the smuggling
+     * invariant even if a future refactor splits the spec differently
+     * or introduces another rendering path.
+     */
+    g_autofree gchar *destination =
+        (spec->ssh_user && spec->ssh_user[0] != '\0')
+            ? g_strdup_printf("%s@%s", spec->ssh_user, spec->ssh_host)
+            : g_strdup(spec->ssh_host);
+    if (!destination || destination[0] == '\0' || destination[0] == '-') {
+        g_ptr_array_free(argv, TRUE);
+        return NULL;
     }
+    push(argv, destination);
 
     g_ptr_array_add(argv, NULL);
     return (gchar**)g_ptr_array_free(argv, FALSE);

--- a/apps/linux/tests/test_gateway_remote_config.c
+++ b/apps/linux/tests/test_gateway_remote_config.c
@@ -124,6 +124,49 @@ static void test_ssh_target_rejects_leading_dash(void) {
     g_assert_null(host);
 }
 
+/*
+ * Regression: the optional "ssh " prefix must not allow an argv-
+ * smuggling payload through. After stripping the prefix the parser
+ * must re-validate that the functional head of the target does not
+ * begin with '-'; otherwise OpenSSH would parse the trailing
+ * "[user@]host" positional as another option flag.
+ */
+static void test_ssh_target_rejects_leading_dash_after_ssh_prefix(void) {
+    gchar *user = NULL, *host = NULL; gint port = 0;
+    g_assert_false(gateway_remote_config_parse_ssh_target(
+        "ssh -oProxyCommand=evil@host", &user, &host, &port));
+    g_assert_null(user);
+    g_assert_null(host);
+}
+
+/*
+ * Same shape as above but with extra whitespace/tabs after the "ssh "
+ * prefix — the parser already skips those, so the argv-smuggling
+ * guard must run on the post-skip head, not the immediate post-prefix
+ * head.
+ */
+static void test_ssh_target_rejects_leading_dash_after_ssh_prefix_with_extra_whitespace(void) {
+    gchar *user = NULL, *host = NULL; gint port = 0;
+    g_assert_false(gateway_remote_config_parse_ssh_target(
+        "ssh    \t-oProxyJump=evil@host", &user, &host, &port));
+    g_assert_null(user);
+    g_assert_null(host);
+}
+
+/*
+ * Regression: dash-leading user with a clean host (no "ssh " prefix)
+ * must also be rejected. The pre-fix parser only checked the host
+ * component, leaving the user free to carry "-oProxyCommand=…" into
+ * argv via the user@host concatenation.
+ */
+static void test_ssh_target_rejects_leading_dash_user(void) {
+    gchar *user = NULL, *host = NULL; gint port = 0;
+    g_assert_false(gateway_remote_config_parse_ssh_target(
+        "-bad@host", &user, &host, &port));
+    g_assert_null(user);
+    g_assert_null(host);
+}
+
 static void test_ssh_target_rejects_whitespace(void) {
     gchar *user = NULL, *host = NULL; gint port = 0;
     g_assert_false(gateway_remote_config_parse_ssh_target(
@@ -359,6 +402,12 @@ int main(int argc, char **argv) {
     g_test_add_func("/remote_cfg/ssh/strips_ssh_prefix", test_ssh_target_strips_ssh_prefix);
     g_test_add_func("/remote_cfg/ssh/rejects_empty_user", test_ssh_target_rejects_empty_user);
     g_test_add_func("/remote_cfg/ssh/rejects_leading_dash", test_ssh_target_rejects_leading_dash);
+    g_test_add_func("/remote_cfg/ssh/rejects_leading_dash_after_ssh_prefix",
+                    test_ssh_target_rejects_leading_dash_after_ssh_prefix);
+    g_test_add_func("/remote_cfg/ssh/rejects_leading_dash_after_ssh_prefix_with_extra_whitespace",
+                    test_ssh_target_rejects_leading_dash_after_ssh_prefix_with_extra_whitespace);
+    g_test_add_func("/remote_cfg/ssh/rejects_leading_dash_user",
+                    test_ssh_target_rejects_leading_dash_user);
     g_test_add_func("/remote_cfg/ssh/rejects_whitespace", test_ssh_target_rejects_whitespace);
     g_test_add_func("/remote_cfg/ssh/rejects_invalid_port", test_ssh_target_rejects_invalid_port);
     g_test_add_func("/remote_cfg/ssh/rejects_empty_port_suffix", test_ssh_target_rejects_empty_port_suffix);

--- a/apps/linux/tests/test_remote_tunnel_command.c
+++ b/apps/linux/tests/test_remote_tunnel_command.c
@@ -111,6 +111,60 @@ static void test_build_rejects_leading_dash_host(void) {
     g_assert_null(remote_tunnel_command_build(&spec));
 }
 
+/*
+ * argv-smuggling regression. A dash-leading user component is just as
+ * dangerous as a dash-leading host: both feed the trailing
+ * "[user@]host" argv positional and either would let OpenSSH parse
+ * the destination as another option flag. The pre-fix builder only
+ * checked the host, so a payload like ssh_user="-oProxyCommand=…",
+ * ssh_host="example.com" rendered to argv as "-oProxyCommand=…@example.com"
+ * and was happily executed.
+ */
+static void test_build_rejects_leading_dash_user(void) {
+    RemoteTunnelCommandSpec spec = {
+        .ssh_user = "-oProxyCommand=evil",
+        .ssh_host = "example.com",
+        .local_port = 18789,
+        .remote_port = 18789,
+    };
+    g_assert_null(remote_tunnel_command_build(&spec));
+}
+
+/*
+ * Same invariant, different payload shape. Locks the rule against
+ * narrow bypasses where only one specific dash-leading prefix is
+ * filtered.
+ */
+static void test_build_rejects_dash_user_when_host_clean(void) {
+    RemoteTunnelCommandSpec spec = {
+        .ssh_user = "-i/tmp/x",
+        .ssh_host = "example.com",
+        .local_port = 18789,
+        .remote_port = 18789,
+    };
+    g_assert_null(remote_tunnel_command_build(&spec));
+}
+
+/*
+ * Positive control: a normal user/host pair must still build, and
+ * the trailing argv positional must be exactly "user@host" so that
+ * the rendered-destination guard cannot regress into rejecting
+ * legitimate inputs.
+ */
+static void test_build_accepts_normal_user_host(void) {
+    RemoteTunnelCommandSpec spec = {
+        .ssh_user = "alice",
+        .ssh_host = "example.com",
+        .local_port = 18789,
+        .remote_port = 18789,
+    };
+    g_auto(GStrv) argv = remote_tunnel_command_build(&spec);
+    g_assert_nonnull(argv);
+    gssize last = 0;
+    while (argv[last + 1]) last++;
+    g_assert_cmpstr(argv[last], ==, "alice@example.com");
+}
+
 static void test_build_rejects_invalid_ports(void) {
     RemoteTunnelCommandSpec spec = {
         .ssh_host = "host.example",
@@ -131,6 +185,9 @@ int main(int argc, char **argv) {
     g_test_add_func("/remote_tunnel_command/build_default_port_omits_p", test_build_default_port_omits_p);
     g_test_add_func("/remote_tunnel_command/rejects_missing_host", test_build_rejects_missing_host);
     g_test_add_func("/remote_tunnel_command/rejects_leading_dash_host", test_build_rejects_leading_dash_host);
+    g_test_add_func("/remote_tunnel_command/rejects_leading_dash_user", test_build_rejects_leading_dash_user);
+    g_test_add_func("/remote_tunnel_command/rejects_dash_user_when_host_clean", test_build_rejects_dash_user_when_host_clean);
+    g_test_add_func("/remote_tunnel_command/accepts_normal_user_host", test_build_accepts_normal_user_host);
     g_test_add_func("/remote_tunnel_command/rejects_invalid_ports", test_build_rejects_invalid_ports);
     return g_test_run();
 }


### PR DESCRIPTION
Harden Linux remote SSH target handling against argv option smuggling.

A malicious `sshTarget` such as
`ssh -oProxyCommand=evil@host` could previously pass parser validation because the leading-dash guard ran before the optional `ssh ` prefix was stripped. After parsing, the dash could survive in the user component and be rendered into the final `[user@]host` positional argument passed to `ssh`, where OpenSSH may treat it as an option.

Enforce the argv-boundary invariant across the remote SSH path by rejecting post-prefix-strip dash-leading targets, dash-leading `ssh_user` values, and fully rendered destinations that begin with `-`. Apply the same boundary check in the tunnel command builder and both remote probe spawn paths.

Add regressions for parser bypasses using `ssh ` plus dash-leading payloads, dash-leading users, and
command-builder rejection of unsafe user components. Include a positive control for normal `user@host` rendering.
